### PR TITLE
fix: weird coauthoer thing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,8 @@ jobs:
           base: main
           labels: automated,release
           delete-branch: true
+          author: 'teton-bot <bot@teton.ai>'
+          committer: 'teton-bot <bot@teton.ai>'
 
   create-release:
     runs-on: ubuntu-latest

--- a/api/src/handlers/download.rs
+++ b/api/src/handlers/download.rs
@@ -43,4 +43,3 @@ pub async fn download_file(
 
     Ok(response)
 }
-z

--- a/api/src/handlers/download.rs
+++ b/api/src/handlers/download.rs
@@ -43,3 +43,4 @@ pub async fn download_file(
 
     Ok(response)
 }
+z


### PR DESCRIPTION
Now the custom release please PR is using the workflow person's email who triggers it as commiter and author, that's annoyting because then does this Co-Author weird thing from last person who trigger the pipeline,
this makes the bot the author