### PR TITLE
fix: temporary fix to bring old devices to new smith

### DIFF
--- a/api/src/handlers/mod.rs
+++ b/api/src/handlers/mod.rs
@@ -77,7 +77,7 @@ pub struct FetchPackageQuery {
 
 #[tracing::instrument]
 pub async fn fetch_package(
-    device: DeviceWithToken,
+    //device: DeviceWithToken,
     Extension(state): Extension<State>,
     params: Query<FetchPackageQuery>,
 ) -> Result<Response, Response> {
@@ -125,7 +125,7 @@ pub async fn fetch_package(
 
 #[tracing::instrument]
 pub async fn list_release_packages(
-    device: DeviceWithToken,
+    //device: DeviceWithToken,
     Path(release_id): Path<i32>,
     Extension(state): Extension<State>,
 ) -> Result<Json<Vec<Package>>, Json<Vec<Package>>> {


### PR DESCRIPTION
some old devices did not receive the new smith with the ability to inject the token, so they fail to update, doing this will allow to fix them, and then we can revert this pr