### PR TITLE
fix: handle when current release is None

### DIFF
--- a/smithd/src/magic/structure.rs
+++ b/smithd/src/magic/structure.rs
@@ -11,8 +11,6 @@ pub struct MagicFile {
     pub tunnel: Option<ConfigTunnel>,
     #[serde(rename = "metric")]
     pub metrics: Option<Vec<ConfigMetric>>,
-    #[serde(rename = "package")]
-    pub packages: Option<Vec<ConfigPackage>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -102,7 +100,6 @@ impl MagicFile {
                     secret: "".to_string(),
                 }),
                 metrics: None,
-                packages: None,
             })?;
             std::fs::write(magic_in_cwd, string)?;
             Self::load_from_path(magic_in_cwd.to_str().unwrap())

--- a/smithd/src/updater/actor.rs
+++ b/smithd/src/updater/actor.rs
@@ -425,21 +425,19 @@ impl Actor {
             }
         }
 
-        let current_release_id = self
-            .magic
-            .get_release_id()
-            .await
-            .with_context(|| "Failed to get Current Release ID")?;
+        if let Some(current_release_id) = self.magic.get_release_id().await {
+            self.ensure_release_cache(current_release_id)
+                .await
+                .with_context(|| "Failed to ensure current release cache")?;
+        } else {
+            error!("No current release ID, skipping current release cache check");
+        }
 
         let target_release_id = self
             .magic
             .get_target_release_id()
             .await
             .with_context(|| "Failed to get Target Release ID")?;
-
-        self.ensure_release_cache(current_release_id)
-            .await
-            .with_context(|| "Failed to ensure current release cache")?;
 
         self.ensure_release_cache(target_release_id)
             .await


### PR DESCRIPTION
- skip when there's no current release
- stop parsing packages from magic.toml