### PR TITLE
feat: sm logs filter arguments

### DIFF
--- a/api/src/middlewares/authorization/mod.rs
+++ b/api/src/middlewares/authorization/mod.rs
@@ -39,7 +39,8 @@ pub fn required_permission(command: &SafeCommandTx) -> Permission {
         | ExtendedNetworkTest { .. }
         | StreamLogs { .. }
         | StopLogStream { .. }
-        | RunAudit => "basic",
+        | RunAudit
+        | GetLogs { .. } => "basic",
     };
     Permission {
         action: action.to_string(),

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -441,13 +441,23 @@ impl SmithAPI {
         Ok(resp.json().await?)
     }
 
-    pub async fn send_logs_command(&self, device_id: u64) -> Result<(u64, u64)> {
+    pub async fn send_logs_command(
+        &self,
+        device_id: u64,
+        unit: Option<String>,
+        since: Option<String>,
+        until: Option<String>,
+        grep: Option<String>,
+    ) -> Result<(u64, u64)> {
         let client = Client::new();
 
         let logs_command = schema::SafeCommandRequest {
             id: 0,
-            command: schema::SafeCommandTx::FreeForm {
-                cmd: String::from("journalctl -r -n 500"),
+            command: schema::SafeCommandTx::GetLogs {
+                unit,
+                since,
+                until,
+                grep,
             },
             continue_on_error: false,
         };

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -212,10 +212,22 @@ pub enum Commands {
         resource: StatusResourceType,
     },
 
-    /// Get logs for a device (runs 'journalctl -r -n 500')
+    /// Get logs for a device (runs 'journalctl -r' on the device)
     Logs {
         #[command(flatten)]
         selector: DeviceSelector,
+        /// Filter logs by systemd unit (e.g. smithd or smithd.service). Passed to journalctl -u
+        #[arg(long)]
+        unit: Option<String>,
+        /// Show entries not older than this date. Passed to journalctl --since (e.g. "1h ago", "2026-06-17 10:00:00")
+        #[arg(long, value_name = "TIMESTAMP", allow_hyphen_values = true)]
+        since: Option<String>,
+        /// Show entries not newer than this date. Passed to journalctl --until
+        #[arg(long, value_name = "TIMESTAMP", allow_hyphen_values = true)]
+        until: Option<String>,
+        /// Filter log lines by pattern. Passed to journalctl --grep (supports ERE regex)
+        #[arg(long, value_name = "PATTERN", allow_hyphen_values = true)]
+        grep: Option<String>,
         /// Don't wait for result, just queue the command and return immediately (faster, recommended for agents - use 'sm command <id>' to check results later)
         #[arg(long, default_value = "false")]
         nowait: bool,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1385,7 +1385,14 @@ async fn main() -> anyhow::Result<()> {
                     }
                 }
             },
-            Commands::Logs { selector, nowait } => {
+            Commands::Logs {
+                selector,
+                unit,
+                since,
+                until,
+                grep,
+                nowait,
+            } => {
                 let secrets = auth::get_secrets(&config)
                     .await
                     .with_context(|| "Error getting token")?
@@ -1398,7 +1405,7 @@ async fn main() -> anyhow::Result<()> {
 
                 let logs =
                     execute_device_command(&api, serial_number, "Fetching logs", nowait, |id| {
-                        api.send_logs_command(id)
+                        api.send_logs_command(id, unit, since, until, grep)
                     })
                     .await?;
 

--- a/smithd/src/commander/free.rs
+++ b/smithd/src/commander/free.rs
@@ -75,6 +75,91 @@ fn build_journalctl_args(
     args
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(
+        unit: Option<&str>,
+        since: Option<&str>,
+        until: Option<&str>,
+        grep: Option<&str>,
+    ) -> Vec<String> {
+        build_journalctl_args(
+            &unit.map(str::to_string),
+            &since.map(str::to_string),
+            &until.map(str::to_string),
+            &grep.map(str::to_string),
+        )
+    }
+
+    #[test]
+    fn defaults_only() {
+        assert_eq!(
+            args(None, None, None, None),
+            ["-r", "--no-pager", "-n", "500"]
+        );
+    }
+
+    #[test]
+    fn unit_appended() {
+        assert_eq!(
+            args(Some("smithd"), None, None, None),
+            ["-r", "--no-pager", "-n", "500", "-u", "smithd"]
+        );
+    }
+
+    #[test]
+    fn since_appended() {
+        assert_eq!(
+            args(None, Some("1h ago"), None, None),
+            ["-r", "--no-pager", "-n", "500", "--since", "1h ago"]
+        );
+    }
+
+    #[test]
+    fn until_appended() {
+        assert_eq!(
+            args(None, None, Some("2026-06-17"), None),
+            ["-r", "--no-pager", "-n", "500", "--until", "2026-06-17"]
+        );
+    }
+
+    #[test]
+    fn grep_appended() {
+        assert_eq!(
+            args(None, None, None, Some("error")),
+            ["-r", "--no-pager", "-n", "500", "--grep", "error"]
+        );
+    }
+
+    #[test]
+    fn all_combined_ordering() {
+        assert_eq!(
+            args(
+                Some("smithd"),
+                Some("1h ago"),
+                Some("2026-06-17"),
+                Some("error")
+            ),
+            [
+                "-r",
+                "--no-pager",
+                "-n",
+                "500",
+                "-u",
+                "smithd",
+                "--since",
+                "1h ago",
+                "--until",
+                "2026-06-17",
+                "--grep",
+                "error"
+            ]
+        );
+    }
+}
+
 pub(super) async fn execute(id: i32, request: String) -> SafeCommandResponse {
     match execute_command(&request).await {
         Ok(output) => {

--- a/smithd/src/commander/free.rs
+++ b/smithd/src/commander/free.rs
@@ -3,6 +3,78 @@ use anyhow::{Context, Result};
 use std::time::Duration;
 use tokio::{process::Command, time::timeout};
 
+pub(super) async fn execute_get_logs(
+    id: i32,
+    unit: Option<String>,
+    since: Option<String>,
+    until: Option<String>,
+    grep: Option<String>,
+) -> SafeCommandResponse {
+    let args = build_journalctl_args(&unit, &since, &until, &grep);
+    let future = Command::new("journalctl")
+        .args(&args)
+        .kill_on_drop(true)
+        .output();
+
+    match timeout(Duration::from_secs(60), future).await {
+        Ok(Ok(output)) => {
+            let (status_code, response) = process_output(output);
+            SafeCommandResponse {
+                id,
+                command: response,
+                status: status_code,
+            }
+        }
+        Ok(Err(e)) => SafeCommandResponse {
+            id,
+            command: SafeCommandRx::FreeForm {
+                stdout: String::new(),
+                stderr: format!("Error: {}", e),
+            },
+            status: -1,
+        },
+        Err(_) => SafeCommandResponse {
+            id,
+            command: SafeCommandRx::FreeForm {
+                stdout: String::new(),
+                stderr: "Timeout running journalctl (60s)".to_string(),
+            },
+            status: -1,
+        },
+    }
+}
+
+fn build_journalctl_args(
+    unit: &Option<String>,
+    since: &Option<String>,
+    until: &Option<String>,
+    grep: &Option<String>,
+) -> Vec<String> {
+    let mut args = vec![
+        "-r".to_string(),
+        "--no-pager".to_string(),
+        "-n".to_string(),
+        "500".to_string(),
+    ];
+    if let Some(u) = unit {
+        args.push("-u".to_string());
+        args.push(u.clone());
+    }
+    if let Some(s) = since {
+        args.push("--since".to_string());
+        args.push(s.clone());
+    }
+    if let Some(u) = until {
+        args.push("--until".to_string());
+        args.push(u.clone());
+    }
+    if let Some(g) = grep {
+        args.push("--grep".to_string());
+        args.push(g.clone());
+    }
+    args
+}
+
 pub(super) async fn execute(id: i32, request: String) -> SafeCommandResponse {
     match execute_command(&request).await {
         Ok(output) => {

--- a/smithd/src/commander/mod.rs
+++ b/smithd/src/commander/mod.rs
@@ -108,6 +108,12 @@ impl CommandQueueExecutor {
             SafeCommandTx::StopLogStream { session_id } => {
                 logs::stop_stream(action.id, &self.handles.logstream, session_id).await
             }
+            SafeCommandTx::GetLogs {
+                unit,
+                since,
+                until,
+                grep,
+            } => free::execute_get_logs(action.id, unit, since, until, grep).await,
             SafeCommandTx::RunAudit => {
                 let (disk_encrypted, password_access_disabled) = run_audit_checks().await;
                 SafeCommandResponse {

--- a/smithd/src/utils/schema.rs
+++ b/smithd/src/utils/schema.rs
@@ -188,32 +188,6 @@ pub enum SafeCommandTx {
     },
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn get_logs_protocol_round_trip() {
-        // Deserialize the JSON shape the API stores in the cmd jsonb column.
-        let json = r#"{"GetLogs":{"unit":"smithd","since":"1h ago","until":null,"grep":null}}"#;
-        let cmd: SafeCommandTx = serde_json::from_str(json).unwrap();
-        match cmd {
-            SafeCommandTx::GetLogs {
-                unit,
-                since,
-                until,
-                grep,
-            } => {
-                assert_eq!(unit, Some("smithd".to_string()));
-                assert_eq!(since, Some("1h ago".to_string()));
-                assert_eq!(until, None);
-                assert_eq!(grep, None);
-            }
-            _ => panic!("expected GetLogs variant"),
-        }
-    }
-}
-
 // RESPONSE THAT IT GETS
 #[derive(Serialize, Deserialize, Default, Debug)]
 pub struct HomePostResponse {
@@ -334,4 +308,66 @@ pub struct NetworkInfo {
     pub interface_type: InterfaceType,
     pub interface_name: String,
     pub details: NetworkDetails,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_logs_protocol_round_trip() {
+        // Deserialize the JSON shape the API stores in the cmd jsonb column.
+        let json = r#"{"GetLogs":{"unit":"smithd","since":"1h ago","until":null,"grep":null}}"#;
+        let cmd: SafeCommandTx = serde_json::from_str(json).unwrap();
+        match cmd {
+            SafeCommandTx::GetLogs {
+                unit,
+                since,
+                until,
+                grep,
+            } => {
+                assert_eq!(unit, Some("smithd".to_string()));
+                assert_eq!(since, Some("1h ago".to_string()));
+                assert_eq!(until, None);
+                assert_eq!(grep, None);
+            }
+            _ => panic!("expected GetLogs variant"),
+        }
+    }
+
+    #[test]
+    fn get_logs_omitted_fields_default_to_none() {
+        // Fields absent from the JSON object must deserialize as None,
+        // not fail. Covers clients that omit null fields entirely.
+        let json = r#"{"GetLogs":{"unit":"smithd"}}"#;
+        let cmd: SafeCommandTx = serde_json::from_str(json).unwrap();
+        match cmd {
+            SafeCommandTx::GetLogs {
+                unit,
+                since,
+                until,
+                grep,
+            } => {
+                assert_eq!(unit, Some("smithd".to_string()));
+                assert_eq!(since, None);
+                assert_eq!(until, None);
+                assert_eq!(grep, None);
+            }
+            _ => panic!("expected GetLogs variant"),
+        }
+    }
+
+    #[test]
+    fn get_logs_serialization_roundtrip() {
+        // Serialized shape must match what the API stores in the cmd jsonb column.
+        let cmd = SafeCommandTx::GetLogs {
+            unit: Some("smithd".to_string()),
+            since: Some("1h ago".to_string()),
+            until: None,
+            grep: None,
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        let expected = r#"{"GetLogs":{"unit":"smithd","since":"1h ago","until":null,"grep":null}}"#;
+        assert_eq!(json, expected);
+    }
 }

--- a/smithd/src/utils/schema.rs
+++ b/smithd/src/utils/schema.rs
@@ -180,6 +180,38 @@ pub enum SafeCommandTx {
         session_id: String,
     },
     RunAudit,
+    GetLogs {
+        unit: Option<String>,
+        since: Option<String>,
+        until: Option<String>,
+        grep: Option<String>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_logs_protocol_round_trip() {
+        // Deserialize the JSON shape the API stores in the cmd jsonb column.
+        let json = r#"{"GetLogs":{"unit":"smithd","since":"1h ago","until":null,"grep":null}}"#;
+        let cmd: SafeCommandTx = serde_json::from_str(json).unwrap();
+        match cmd {
+            SafeCommandTx::GetLogs {
+                unit,
+                since,
+                until,
+                grep,
+            } => {
+                assert_eq!(unit, Some("smithd".to_string()));
+                assert_eq!(since, Some("1h ago".to_string()));
+                assert_eq!(until, None);
+                assert_eq!(grep, None);
+            }
+            _ => panic!("expected GetLogs variant"),
+        }
+    }
 }
 
 // RESPONSE THAT IT GETS


### PR DESCRIPTION
# feat: sm logs filter arguments

## Requirements

`sm logs` previously sent a hardcoded `journalctl -r -n 500` as a `FreeForm` shell command. The goal was to add device-side filtering so callers can narrow results by unit, time range, and pattern without pulling all 500 lines and filtering client-side.

Four optional flags were added, each mapping 1:1 to a journalctl argument:

| Flag | journalctl |
|---|---|
| `--unit` | `-u` |
| `--since` | `--since` |
| `--until` | `--until` |
| `--grep` | `--grep` (ERE regex) |

Default behavior (no flags) is identical to before.

## Changes

**Protocol** (`smithd/src/utils/schema.rs`): added `GetLogs { unit, since, until, grep }` to `SafeCommandTx`. The response reuses the existing `SafeCommandRx::FreeForm { stdout, stderr }`. No API or database changes required.

**Device handler** (`smithd/src/commander/free.rs`): added `build_journalctl_args` (pure function, no shell involvement) and `execute_get_logs`. The invocation is `tokio::process::Command::new("journalctl").args(...)` directly, with the same 60-second timeout pattern used by the existing free-form handler. Placed in `free.rs` because it follows the same pattern: run a process, return unstructured stdout/stderr as `FreeForm`.

**Commander dispatch** (`smithd/src/commander/mod.rs`): added match arm routing `GetLogs` to `execute_get_logs`.

**CLI** (`cli/src/cli.rs`, `cli/src/api.rs`, `cli/src/main.rs`): extended `Logs` variant with the four new fields, updated `send_logs_command` to accept and forward them, wired through `main.rs`. `allow_hyphen_values = true` is set on `--since`, `--until`, and `--grep` so values like `-1h` are accepted without being parsed as flags.

## Tests

Protocol round-trip test in `smithd/src/utils/schema.rs`: deserializes a raw JSON blob in the shape the API stores in the `cmd` jsonb column and asserts it yields `SafeCommandTx::GetLogs` with the correct field values. This covers the cross-crate serialization contract.

## How I tested on-device

Temporarily added systemd to the dev Docker device image, then ran several variations of `sm logs` combining `--unit`, `--since`, `--until`, and `--grep` against the running container. The systemd setup is not kept in this PR.