### PR TITLE
feat: run dev device containers under systemd to enable system service testing

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -73,10 +73,13 @@ services:
     volumes:
       - ./scripts/network-throttle.sh:/app/network-throttle.sh:ro
     environment:
-      - RUST_LOG=INFO
+      - RUST_LOG=${RUST_LOG:-INFO}
       - NETWORK_THROTTLE=${NETWORK_THROTTLE:-random}
-    entrypoint: ["/bin/bash", "-c", "/app/network-throttle.sh && cd /etc/smith && exec /usr/bin/smithd"]
-    init: true
+    entrypoint: ["/bin/bash", "-c", "printenv > /etc/smith/environment && /app/network-throttle.sh && exec /lib/systemd/systemd"]
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
     deploy:
       replicas: ${DEVICE_REPLICAS:-1}
     networks:

--- a/smithd/debian/smithd.service
+++ b/smithd/debian/smithd.service
@@ -11,6 +11,7 @@ User=root
 ExecStart=/usr/bin/smithd
 WorkingDirectory=/etc/smith
 Environment="RUST_LOG=INFO"
+EnvironmentFile=-/etc/smith/environment
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Replace direct `smithd` invocation in the Docker dev device container with a full systemd boot, so systemd-dependent commands work in the local dev/test setup
- Dump container env vars to `/etc/smith/environment` before handing off to systemd, so `RUST_LOG` and `NETWORK_THROTTLE` overrides survive the `exec systemd` handoff
- Add `tmpfs` mounts on `/run`, `/run/lock`, and `/tmp` (required by systemd inside a container); remove `init: true` since systemd is now PID 1
- Load `/etc/smith/environment` in the smithd unit via `EnvironmentFile` (with `-` prefix to ignore if missing)

## Test plan

- [x] Start the dev stack; confirm `smithd` comes up as a systemd service inside the container
- [x] Confirm `journalctl -u smithd` works inside the container
- [x] Confirm `RUST_LOG` and `NETWORK_THROTTLE` overrides from the host are respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)