### PR TITLE
Fix SSH auth failure after bore goes down and back up

### DIFF
--- a/smithd/src/tunnel/actor.rs
+++ b/smithd/src/tunnel/actor.rs
@@ -97,16 +97,6 @@ impl Actor {
                         return;
                     }
                     info!("SSH directory ensured for user: {}", remote_login.user);
-                    let res = add_key(&remote_login.user, &remote_login.pub_key, tag.clone()).await;
-                    if let Err(err) = res {
-                        error!(
-                            "Failed to add key for user '{}': {}",
-                            remote_login.user, err
-                        );
-                        _ = remote.send(0);
-                        return;
-                    }
-                    info!("SSH key added successfully for user: {}", remote_login.user);
                 }
 
                 let server = server.to_owned();
@@ -135,11 +125,27 @@ impl Actor {
                 });
 
                 let port = rx.await.unwrap_or_default();
-                _ = remote.send(port);
 
                 if port == 0 {
+                    _ = remote.send(port);
                     return;
                 }
+
+                if let Some(ref remote_login) = remote_login {
+                    let res = add_key(&remote_login.user, &remote_login.pub_key, tag.clone()).await;
+                    if let Err(err) = res {
+                        error!(
+                            "Failed to add key for user '{}': {}",
+                            remote_login.user, err
+                        );
+                        handle.abort();
+                        _ = remote.send(0);
+                        return;
+                    }
+                    info!("SSH key added successfully for user: {}", remote_login.user);
+                }
+
+                _ = remote.send(port);
 
                 self.ports.insert(
                     local,

--- a/smithd/src/utils/files.rs
+++ b/smithd/src/utils/files.rs
@@ -102,7 +102,7 @@ pub async fn add_key(user: &str, pubkey: &str, tag: String) -> Result<()> {
 
 pub async fn remove_key(user: &str, tag: &str) -> Result<()> {
     info!("Removing key for user {user} with tag {tag}");
-    let (ssh_folder, _uid, _gid) = ensure_ssh_dir(user).await?;
+    let (ssh_folder, uid, gid) = ensure_ssh_dir(user).await?;
     let mut auth_keys = ssh_folder.clone();
     auth_keys.push("authorized_keys");
     let mut lock_file = ssh_folder.clone();
@@ -127,6 +127,7 @@ pub async fn remove_key(user: &str, tag: &str) -> Result<()> {
         };
 
         let mut lines = Vec::<String>::new();
+        let mut found = false;
         for l in BufReader::new(file).lines() {
             let l = l?;
             if l.split_whitespace()
@@ -134,7 +135,13 @@ pub async fn remove_key(user: &str, tag: &str) -> Result<()> {
                 .is_none_or(|last_part| last_part != tag)
             {
                 lines.push(l);
+            } else {
+                found = true;
             }
+        }
+
+        if !found {
+            return Ok(());
         }
 
         let mut tmp = NamedTempFile::new_in(ssh_folder)?;
@@ -143,6 +150,7 @@ pub async fn remove_key(user: &str, tag: &str) -> Result<()> {
         }
         tmp.as_file()
             .set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        chown(tmp.path(), Some(uid.into()), Some(gid.into()))?;
         tmp.persist(auth_keys)?;
 
         Ok::<_, anyhow::Error>(())


### PR DESCRIPTION
## What
Fix `authorized_keys` ownership corruption in smithd that caused SSH auth to fail permanently after a bore outage and recovery.

## Why
Closes #459

`sm tunnel` stopped working after bore went down then came back up. The root cause was two composing defects that corrupted `authorized_keys` ownership (leaving the file root-owned, which OpenSSH rejects under `StrictModes yes`).

## Approach

Three defects were identified:

**Defect 1 (actor.rs): `add_key` called before bore connection was confirmed.**
If bore was unavailable, a key was written to `authorized_keys` with a fresh UUID tag but the corresponding `ForwardConnection` was never inserted. `remove_key` was therefore never called for that tag, leaving an orphan entry. Fix: defer `add_key` until after `rx.await` confirms a non-zero port. If bore returns port 0, return immediately without touching `authorized_keys`. If `add_key` fails after bore connects, abort the bore task and return port 0.

**Defect 2 (files.rs): `remove_key` rewrote the file even when the tag was absent.**
Every rewrite by the root process produced a root-owned file (no `chown` call). If an orphan tag was present when a new tunnel was opened, `remove_key` would be called on a non-existent tag, rewrite the file as root, and corrupt ownership. Fix: track a `found` flag during line iteration; return `Ok(())` early without touching the file when the tag is not found. When the tag is found and the file is legitimately rewritten, call `chown` before `persist`.

**Defect 3 (files.rs): `add_key` early-return without `chown`.**
The issue's own fix direction for this defect was to address Defects 1 and 2 instead. With Defect 1 fixed, orphan tags no longer accumulate, so the early-return path in `add_key` (key already exists) is unreachable in any root-owned-file state. No change made.

Rejected alternative: fixing only `remove_key` + `add_key` ownership without reordering the actor. Ownership would be correct but orphan tags would still accumulate on each bore-down cycle.

## Testing
- [x] `cargo clippy --all-features -- -Dwarnings` passes
- [x] `cargo fmt` applied
- [x] Manual smoke test: ran `sm tunnel` against Docker dev stack; SSH in, typed `exit`, reconnected after timeout — `authorized_keys` owned by `nightingale` throughout; bore-down scenario produces no orphan tags and port 0 is returned cleanly.

## Checklist
- [x] No unintended side effects on adjacent features
- [x] Breaking change? No — no public API or signature changes
- [x] Docs / changelog updated if user-facing