### PR TITLE
feat: settings (users/roles) admin pages, device variables, network t…

### DIFF
--- a/api/.sqlx/query-82307cfea30911397d3b9ae5f820daca1479e6d7c6f6392b4dee2ac1bea8e111.json
+++ b/api/.sqlx/query-82307cfea30911397d3b9ae5f820daca1479e6d7c6f6392b4dee2ac1bea8e111.json
@@ -1,0 +1,44 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                u.id,\n                u.email,\n                u.created_at AS \"created_at!\",\n                u.updated_at AS \"updated_at!\",\n                COALESCE(\n                    ARRAY_AGG(ur.role ORDER BY ur.role) FILTER (WHERE ur.role IS NOT NULL),\n                    '{}'\n                ) AS \"roles!\"\n            FROM auth.users u\n            LEFT JOIN auth.users_roles ur ON ur.user_id = u.id\n            GROUP BY u.id\n            ORDER BY u.created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "created_at!",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "updated_at!",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "roles!",
+        "type_info": "TextArray"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      true,
+      null
+    ]
+  },
+  "hash": "82307cfea30911397d3b9ae5f820daca1479e6d7c6f6392b4dee2ac1bea8e111"
+}

--- a/api/roles.toml
+++ b/api/roles.toml
@@ -11,6 +11,8 @@
 # Recipe permissions:
 #   recipes:trigger    run a pre-authored recipe against devices
 #   recipes:write      create / update / delete recipes
+# User permissions:
+#   users:read         view the user list and role definitions
 
 [roles.default]
 description = "Standard user: manage devices, run safe commands, trigger vetted recipes"
@@ -31,4 +33,5 @@ permissions = [
     { action = "tunnel", resource = "commands" },
     { action = "ota", resource = "commands" },
     { action = "write", resource = "recipes" },
+    { action = "read", resource = "users" },
 ]

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -345,6 +345,8 @@ async fn start_main_server(config: &'static Config, authorization: Authorization
         ))
         .routes(routes!(command::route::trigger_recipe))
         .routes(routes!(event::route::sse_handler))
+        .routes(routes!(user::route::get_users))
+        .routes(routes!(user::route::get_roles))
         .route_layer(middleware::from_fn(middlewares::authentication::check))
         // TODO: Check why we have this, not good for all routes
         .layer(DefaultBodyLimit::max(891289600))

--- a/api/src/user/mod.rs
+++ b/api/src/user/mod.rs
@@ -4,6 +4,8 @@ use crate::middlewares::{
 };
 use sqlx::PgPool;
 
+pub mod route;
+
 #[derive(Clone, Debug)]
 pub struct CurrentUser {
     pub user_id: i32,

--- a/api/src/user/route.rs
+++ b/api/src/user/route.rs
@@ -1,0 +1,147 @@
+use crate::State;
+use crate::middlewares::authorization;
+use crate::user::CurrentUser;
+use axum::http::StatusCode;
+use axum::{Extension, Json};
+use serde::Serialize;
+use tracing::error;
+use utoipa::ToSchema;
+
+const TAG: &str = "users";
+
+/// A user together with every role assigned to them.
+#[derive(Serialize, ToSchema)]
+pub struct UserWithRoles {
+    pub id: i32,
+    pub email: Option<String>,
+    pub roles: Vec<String>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/users",
+    responses(
+        (status = 200, description = "List of users retrieved successfully", body = Vec<UserWithRoles>),
+        (status = 403, description = "Forbidden"),
+        (status = 500, description = "Failed to retrieve users"),
+    ),
+    security(
+        ("auth_token" = [])
+    ),
+    tag = TAG
+)]
+pub async fn get_users(
+    Extension(state): Extension<State>,
+    Extension(current_user): Extension<CurrentUser>,
+) -> Result<Json<Vec<UserWithRoles>>, StatusCode> {
+    if !authorization::check(current_user, "users", "read") {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    let users = sqlx::query_as!(
+        UserWithRoles,
+        r#"
+            SELECT
+                u.id,
+                u.email,
+                u.created_at AS "created_at!",
+                u.updated_at AS "updated_at!",
+                COALESCE(
+                    ARRAY_AGG(ur.role ORDER BY ur.role) FILTER (WHERE ur.role IS NOT NULL),
+                    '{}'
+                ) AS "roles!"
+            FROM auth.users u
+            LEFT JOIN auth.users_roles ur ON ur.user_id = u.id
+            GROUP BY u.id
+            ORDER BY u.created_at DESC
+        "#
+    )
+    .fetch_all(&state.pg_pool)
+    .await
+    .map_err(|err| {
+        error!("error: failed to get users: {:?}", err);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok(Json(users))
+}
+
+/// A single { action, resource } permission, flattened for the dashboard.
+#[derive(Serialize, ToSchema)]
+pub struct PermissionInfo {
+    pub action: String,
+    pub resource: String,
+}
+
+/// A role definition with both its directly declared permissions and the full
+/// effective set (its own plus everything resolved transitively via `inherits`).
+#[derive(Serialize, ToSchema)]
+pub struct RoleInfo {
+    pub name: String,
+    pub description: String,
+    pub inherits: Vec<String>,
+    pub permissions: Vec<PermissionInfo>,
+    pub effective_permissions: Vec<PermissionInfo>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/roles",
+    responses(
+        (status = 200, description = "List of roles retrieved successfully", body = Vec<RoleInfo>),
+        (status = 403, description = "Forbidden"),
+    ),
+    security(
+        ("auth_token" = [])
+    ),
+    tag = TAG
+)]
+pub async fn get_roles(
+    Extension(state): Extension<State>,
+    Extension(current_user): Extension<CurrentUser>,
+) -> Result<Json<Vec<RoleInfo>>, StatusCode> {
+    if !authorization::check(current_user, "users", "read") {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    let mut roles: Vec<RoleInfo> = state
+        .authorization
+        .roles
+        .iter()
+        .map(|(name, role)| {
+            let permissions = role
+                .permissions
+                .iter()
+                .map(|p| PermissionInfo {
+                    action: p.action.clone(),
+                    resource: p.resource.clone(),
+                })
+                .collect();
+
+            let effective_permissions = state
+                .authorization
+                .permissions_for_role(name)
+                .into_iter()
+                .map(|p| PermissionInfo {
+                    action: p.action,
+                    resource: p.resource,
+                })
+                .collect();
+
+            RoleInfo {
+                name: name.clone(),
+                description: role.description.clone(),
+                inherits: role.inherits.clone(),
+                permissions,
+                effective_permissions,
+            }
+        })
+        .collect();
+
+    // The config is a HashMap, so sort for a stable order in the UI.
+    roles.sort_by(|a, b| a.name.cmp(&b.name));
+
+    Ok(Json(roles))
+}

--- a/dashboard/app/(private)/devices/[serial]/DeviceHeader.tsx
+++ b/dashboard/app/(private)/devices/[serial]/DeviceHeader.tsx
@@ -408,68 +408,70 @@ const DeviceHeader: React.FC<DeviceHeaderProps> = ({ device, serial }) => {
 
 	return (
 		<div className="bg-white rounded-lg border border-gray-200 p-4">
-			<div className="flex items-center space-x-3">
-				<div className="p-2 bg-gray-100 text-gray-600 rounded">
-					<Cpu className="w-5 h-5" />
-				</div>
-				<div className="flex-1">
-					<div className="flex items-center space-x-3">
-						<h1 className="text-xl font-bold text-gray-900">
-							{getDeviceName()}
-						</h1>
-						<Tooltip content={getNetworkQualityTooltip()}>
-							<div className="flex-shrink-0 cursor-help">
-								<NetworkQualityIndicator
-									isOnline={status === "online"}
-									networkScore={device?.network?.network_score}
-								/>
-							</div>
-						</Tooltip>
-						{getUpdateStatus()?.status === "updating" && (
-							<Tooltip
-								content={`Updating for ${getUpdateStatus()?.duration}: ${device.release?.distribution_name}@${device.release?.version || device.release_id} → ${device.target_release?.distribution_name}@${device.target_release?.version || device.target_release_id}`}
-							>
-								<span className="px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded-full cursor-help">
-									Updating {getUpdateStatus()?.duration}
-								</span>
-							</Tooltip>
-						)}
-						{getUpdateStatus()?.status === "outdated" && (
-							<Tooltip
-								content={`Update failed after ${getUpdateStatus()?.duration}: ${device.release?.distribution_name}@${device.release?.version || device.release_id} → ${device.target_release?.distribution_name}@${device.target_release?.version || device.target_release_id}`}
-							>
-								<span className="px-2 py-1 text-xs font-medium bg-orange-100 text-orange-800 rounded-full cursor-help">
-									Update Failed {getUpdateStatus()?.duration}
-								</span>
-							</Tooltip>
-						)}
+			<div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+				<div className="flex flex-1 items-center space-x-3 min-w-0">
+					<div className="p-2 bg-gray-100 text-gray-600 rounded flex-shrink-0">
+						<Cpu className="w-5 h-5" />
 					</div>
-					<div className="flex items-center space-x-4 mt-1 text-sm text-gray-600">
-						{device.release && (
-							<div className="flex items-center space-x-2">
-								<div className="flex items-center space-x-1">
-									<GitBranch className="w-4 h-4" />
-									<span className="font-medium">
-										{device.release.distribution_name}
+					<div className="flex-1 min-w-0">
+						<div className="flex items-center space-x-3">
+							<h1 className="text-xl font-bold text-gray-900">
+								{getDeviceName()}
+							</h1>
+							<Tooltip content={getNetworkQualityTooltip()}>
+								<div className="flex-shrink-0 cursor-help">
+									<NetworkQualityIndicator
+										isOnline={status === "online"}
+										networkScore={device?.network?.network_score}
+									/>
+								</div>
+							</Tooltip>
+							{getUpdateStatus()?.status === "updating" && (
+								<Tooltip
+									content={`Updating for ${getUpdateStatus()?.duration}: ${device.release?.distribution_name}@${device.release?.version || device.release_id} → ${device.target_release?.distribution_name}@${device.target_release?.version || device.target_release_id}`}
+								>
+									<span className="px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded-full cursor-help">
+										Updating {getUpdateStatus()?.duration}
 									</span>
+								</Tooltip>
+							)}
+							{getUpdateStatus()?.status === "outdated" && (
+								<Tooltip
+									content={`Update failed after ${getUpdateStatus()?.duration}: ${device.release?.distribution_name}@${device.release?.version || device.release_id} → ${device.target_release?.distribution_name}@${device.target_release?.version || device.target_release_id}`}
+								>
+									<span className="px-2 py-1 text-xs font-medium bg-orange-100 text-orange-800 rounded-full cursor-help">
+										Update Failed {getUpdateStatus()?.duration}
+									</span>
+								</Tooltip>
+							)}
+						</div>
+						<div className="flex items-center space-x-4 mt-1 text-sm text-gray-600">
+							{device.release && (
+								<div className="flex items-center space-x-2">
+									<div className="flex items-center space-x-1">
+										<GitBranch className="w-4 h-4" />
+										<span className="font-medium">
+											{device.release.distribution_name}
+										</span>
+									</div>
+									<div className="flex items-center space-x-1">
+										<Tag className="w-4 h-4" />
+										<span>v{device.release.version}</span>
+									</div>
 								</div>
-								<div className="flex items-center space-x-1">
-									<Tag className="w-4 h-4" />
-									<span>v{device.release.version}</span>
-								</div>
-							</div>
-						)}
-						{connectionType && (
-							<Tooltip content={getConnectionTooltip(connectionType)}>
-								<div className="flex items-center space-x-1 cursor-help">
-									{getConnectionIcon(connectionType)}
-									<span className="capitalize">{connectionType}</span>
-								</div>
-							</Tooltip>
-						)}
+							)}
+							{connectionType && (
+								<Tooltip content={getConnectionTooltip(connectionType)}>
+									<div className="flex items-center space-x-1 cursor-help">
+										{getConnectionIcon(connectionType)}
+										<span className="capitalize">{connectionType}</span>
+									</div>
+								</Tooltip>
+							)}
+						</div>
 					</div>
 				</div>
-				<div className="flex-shrink-0 flex items-center space-x-3">
+				<div className="flex flex-wrap items-center gap-2 lg:flex-shrink-0 lg:gap-3">
 					<Tooltip content="Run a command on this device">
 						<Button
 							variant="soft"

--- a/dashboard/app/(private)/devices/[serial]/DeviceVariables.tsx
+++ b/dashboard/app/(private)/devices/[serial]/DeviceVariables.tsx
@@ -1,0 +1,73 @@
+import { Eye, EyeOff, KeyRound } from "lucide-react";
+import { useState } from "react";
+import { useGetVariablesForDevice } from "@/app/api-client";
+import { Button, Panel, SECTION_THEMES } from "@/app/components/ui";
+
+/** Length-agnostic mask so a hidden secret never leaks its length. */
+const MASK = "••••••••••••";
+
+/** Device variables panel for the overview. Values are secrets, so they are
+ *  masked by default and only shown after the user reveals them. */
+const DeviceVariables = ({ deviceId }: { deviceId?: number }) => {
+	const [revealed, setRevealed] = useState(false);
+	const { data: variables, isLoading } = useGetVariablesForDevice(
+		deviceId ?? 0,
+		{ query: { enabled: !!deviceId } },
+	);
+
+	const hasVariables = variables && variables.length > 0;
+
+	return (
+		<Panel
+			title="Variables"
+			icon={KeyRound}
+			theme={SECTION_THEMES.yellow}
+			count={variables?.length}
+			actions={
+				hasVariables ? (
+					<Button
+						variant="soft"
+						tone="gray"
+						size="sm"
+						onClick={() => setRevealed((r) => !r)}
+						icon={
+							revealed ? (
+								<EyeOff className="w-4 h-4" />
+							) : (
+								<Eye className="w-4 h-4" />
+							)
+						}
+					>
+						{revealed ? "Hide secrets" : "Reveal secrets"}
+					</Button>
+				) : undefined
+			}
+		>
+			{isLoading ? (
+				<div className="py-6 text-gray-500">Loading variables...</div>
+			) : hasVariables ? (
+				<div className="divide-y divide-gray-100">
+					{variables.map((variable) => (
+						<div
+							key={variable.id}
+							className="flex items-center justify-between gap-4 py-3"
+						>
+							<span className="font-mono text-sm font-medium text-gray-900 break-all">
+								{variable.name}
+							</span>
+							<span className="font-mono text-sm text-gray-900 text-right break-all min-w-0">
+								{revealed ? variable.value : MASK}
+							</span>
+						</div>
+					))}
+				</div>
+			) : (
+				<p className="text-sm text-gray-500">
+					No variables are set on this device.
+				</p>
+			)}
+		</Panel>
+	);
+};
+
+export default DeviceVariables;

--- a/dashboard/app/(private)/devices/[serial]/page.tsx
+++ b/dashboard/app/(private)/devices/[serial]/page.tsx
@@ -25,6 +25,7 @@ import {
 	SECTION_THEMES,
 } from "@/app/components/ui";
 import { DeviceDetailLayout } from "./DeviceDetailLayout";
+import DeviceVariables from "./DeviceVariables";
 import SecurityAudit from "./SecurityAudit";
 
 const LocationMap = lazy(() => import("./LocationMap"));
@@ -411,6 +412,14 @@ const DeviceDetailPage = () => {
 					)}
 				</Panel>
 
+				{/* Variables (secrets) */}
+				<DeviceVariables deviceId={device.id} />
+			</div>
+
+			{/* Security Audit (left) and Location Information (right) */}
+			<div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
+				<SecurityAudit serial={serial} deviceId={device.id} />
+
 				{/* Location Information */}
 				<Panel
 					title="Location Information"
@@ -501,9 +510,6 @@ const DeviceDetailPage = () => {
 					)}
 				</Panel>
 			</div>
-
-			{/* Security Audit */}
-			<SecurityAudit serial={serial} deviceId={device.id} />
 		</DeviceDetailLayout>
 	);
 };

--- a/dashboard/app/(private)/distributions/[id]/page.tsx
+++ b/dashboard/app/(private)/distributions/[id]/page.tsx
@@ -27,8 +27,8 @@ import { Modal } from "@/app/components/modal";
 import { RelativeTime } from "@/app/components/RelativeTime";
 import { SidePanel } from "@/app/components/side-panel";
 import {
-	BackLink,
 	BADGE_COLORS,
+	BackLink,
 	Badge,
 	type BadgeVariant,
 	Button,

--- a/dashboard/app/(private)/distributions/[id]/page.tsx
+++ b/dashboard/app/(private)/distributions/[id]/page.tsx
@@ -1,5 +1,4 @@
 import {
-	ArrowLeft,
 	ArrowLeftRight,
 	Calendar,
 	ChevronRight,
@@ -14,32 +13,67 @@ import {
 	X,
 } from "lucide-react";
 import React, { useCallback, useMemo, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router";
+import { useNavigate, useParams } from "react-router";
 import {
 	type Package as PackageType,
+	type Release,
 	useCreateDistributionRelease,
 	useGetDistributionById,
 	useGetDistributionLatestRelease,
 	useGetDistributionReleasePackages,
 	useGetDistributionReleases,
 } from "@/app/api-client";
-import { Button } from "@/app/components/button";
 import { Modal } from "@/app/components/modal";
 import { RelativeTime } from "@/app/components/RelativeTime";
 import { SidePanel } from "@/app/components/side-panel";
+import {
+	BackLink,
+	BADGE_COLORS,
+	Badge,
+	type BadgeVariant,
+	Button,
+	Card,
+	ListRow,
+	PageContainer,
+	SECTION_THEMES,
+	SectionCard,
+} from "@/app/components/ui";
 import { isStableRelease } from "@/app/utils/release";
 
+const getArchIcon = (architecture: string) => {
+	switch (architecture.toLowerCase()) {
+		case "x86_64":
+		case "amd64":
+			return <Monitor className="w-5 h-5" />;
+		case "arm64":
+		case "aarch64":
+			return <Cpu className="w-5 h-5" />;
+		case "armv7":
+		case "arm":
+			return <HardDrive className="w-5 h-5" />;
+		default:
+			return <Package className="w-5 h-5" />;
+	}
+};
+
+const getArchVariant = (architecture: string): BadgeVariant => {
+	switch (architecture.toLowerCase()) {
+		case "x86_64":
+		case "amd64":
+			return "blue";
+		case "arm64":
+		case "aarch64":
+			return "green";
+		case "armv7":
+		case "arm":
+			return "purple";
+		default:
+			return "gray";
+	}
+};
+
 interface ReleaseRowProps {
-	release: {
-		id: number;
-		version: string;
-		draft: boolean;
-		release_candidate: boolean;
-		yanked: boolean;
-		created_at: string;
-		user_email: string | null;
-		user_id: number | null;
-	};
+	release: Release;
 	compareMode: boolean;
 	isSelected: boolean;
 	selectionLabel: string | null;
@@ -55,12 +89,12 @@ const ReleaseRow = React.memo(function ReleaseRow({
 	isDeployed,
 	onSelect,
 }: ReleaseRowProps) {
-	const row = (
-		<div className="flex items-center justify-between">
-			<div className="flex items-center space-x-3">
+	const inner = (
+		<>
+			<div className="flex items-center space-x-3 min-w-0">
 				{compareMode ? (
 					<div
-						className={`w-8 h-8 rounded flex items-center justify-center text-xs font-bold ${
+						className={`w-8 h-8 rounded flex items-center justify-center text-xs font-bold flex-shrink-0 ${
 							isSelected
 								? "bg-blue-500 text-white"
 								: "bg-gray-100 text-gray-400 border border-gray-300 border-dashed"
@@ -69,32 +103,34 @@ const ReleaseRow = React.memo(function ReleaseRow({
 						{selectionLabel ?? ""}
 					</div>
 				) : (
-					<div className="p-2 bg-gray-100 text-gray-600 rounded">
+					<div className="p-2 bg-gray-100 text-gray-600 rounded flex-shrink-0">
 						<Tag className="w-4 h-4" />
 					</div>
 				)}
-				<div>
+				<div className="min-w-0">
 					<div className="flex items-center space-x-2">
-						<h4 className="font-medium text-gray-900">{release.version}</h4>
+						<h4 className="font-medium text-gray-900 truncate">
+							{release.version}
+						</h4>
 						{isDeployed && (
-							<span className="px-2 py-1 text-xs font-medium bg-green-100 text-green-800 rounded-full">
+							<Badge variant="green" pill>
 								Deployed
-							</span>
+							</Badge>
 						)}
 						{release.draft && (
-							<span className="px-2 py-1 text-xs font-medium bg-yellow-100 text-yellow-800 rounded-full">
+							<Badge variant="yellow" pill>
 								Draft
-							</span>
+							</Badge>
 						)}
 						{release.release_candidate && (
-							<span className="px-2 py-1 text-xs font-medium bg-orange-100 text-orange-700 rounded-full">
+							<Badge variant="orange" pill>
 								RC
-							</span>
+							</Badge>
 						)}
 						{release.yanked && (
-							<span className="px-2 py-1 text-xs font-medium bg-red-100 text-red-800 rounded-full">
+							<Badge variant="red" pill>
 								Yanked
-							</span>
+							</Badge>
 						)}
 					</div>
 					<div className="flex items-center space-x-3 mt-1 text-xs text-gray-500">
@@ -113,35 +149,24 @@ const ReleaseRow = React.memo(function ReleaseRow({
 				</div>
 			</div>
 			{!compareMode && (
-				<div className="flex items-center space-x-4">
-					<ChevronRight className="w-4 h-4 text-gray-400" />
-				</div>
+				<ChevronRight className="w-4 h-4 text-gray-400 flex-shrink-0" />
 			)}
-		</div>
+		</>
 	);
 
 	if (compareMode) {
 		return (
-			<button
-				type="button"
-				className={`block w-full text-left p-4 cursor-pointer transition-colors ${
-					isSelected ? "bg-blue-50 hover:bg-blue-100" : "hover:bg-gray-50"
-				}`}
+			<ListRow
 				onClick={() => onSelect(release.id)}
+				className={isSelected ? "bg-blue-50" : ""}
+				hover={isSelected ? "hover:bg-blue-100" : "hover:bg-gray-50"}
 			>
-				{row}
-			</button>
+				{inner}
+			</ListRow>
 		);
 	}
 
-	return (
-		<Link
-			className="block p-4 hover:bg-gray-50 cursor-pointer transition-colors"
-			to={`/releases/${release.id}`}
-		>
-			{row}
-		</Link>
-	);
+	return <ListRow to={`/releases/${release.id}`}>{inner}</ListRow>;
 });
 
 const DistributionDetailPage = () => {
@@ -243,38 +268,6 @@ const DistributionDetailPage = () => {
 			return [...prev, releaseId];
 		});
 	}, []);
-
-	const getArchIcon = (architecture: string) => {
-		switch (architecture.toLowerCase()) {
-			case "x86_64":
-			case "amd64":
-				return <Monitor className="w-5 h-5" />;
-			case "arm64":
-			case "aarch64":
-				return <Cpu className="w-5 h-5" />;
-			case "armv7":
-			case "arm":
-				return <HardDrive className="w-5 h-5" />;
-			default:
-				return <Package className="w-5 h-5" />;
-		}
-	};
-
-	const getArchColor = (architecture: string) => {
-		switch (architecture.toLowerCase()) {
-			case "x86_64":
-			case "amd64":
-				return "bg-blue-100 text-blue-700";
-			case "arm64":
-			case "aarch64":
-				return "bg-green-100 text-green-700";
-			case "armv7":
-			case "arm":
-				return "bg-purple-100 text-purple-700";
-			default:
-				return "bg-gray-100 text-gray-700";
-		}
-	};
 
 	// Parse version and generate options
 	const getVersionOptions = () => {
@@ -381,52 +374,53 @@ const DistributionDetailPage = () => {
 
 	if (loading || !distribution) {
 		return (
-			<div className="flex items-center justify-center h-32">
-				<div className="text-gray-500 text-sm">Loading...</div>
-			</div>
+			<PageContainer>
+				<div className="h-4 w-44 bg-gray-200 rounded animate-pulse" />
+				<Card className="p-4">
+					<div className="flex items-center space-x-3">
+						<div className="p-2 bg-gray-100 rounded">
+							<div className="w-5 h-5 bg-gray-200 rounded animate-pulse" />
+						</div>
+						<div className="space-y-2">
+							<div className="h-6 bg-gray-200 rounded w-48 animate-pulse" />
+							<div className="h-4 bg-gray-200 rounded w-64 animate-pulse" />
+						</div>
+					</div>
+				</Card>
+			</PageContainer>
 		);
 	}
 
+	const archVariant = getArchVariant(distribution.architecture);
+
 	return (
-		<div className="flex-1 overflow-y-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
-			{/* Header with Back Button */}
-			<div className="flex items-center space-x-4">
-				<Link
-					to="/distributions"
-					className="flex items-center space-x-2 text-gray-600 hover:text-gray-900 transition-colors cursor-pointer"
-				>
-					<ArrowLeft className="w-4 h-4" />
-					<span className="text-sm font-medium">Back to Distributions</span>
-				</Link>
-			</div>
+		<PageContainer>
+			{/* Back link */}
+			<BackLink to="/distributions">Back to Distributions</BackLink>
 
 			{/* Distribution Header */}
-			<div className="bg-white rounded-lg border border-gray-200 p-4">
+			<Card className="p-4">
 				<div className="flex items-center space-x-3">
-					<div
-						className={`p-2 rounded ${getArchColor(distribution.architecture)}`}
-					>
+					<div className={`p-2 rounded-lg ${BADGE_COLORS[archVariant]}`}>
 						{getArchIcon(distribution.architecture)}
 					</div>
-					<div className="flex-1">
+					<div className="flex-1 min-w-0">
 						<div className="flex items-center space-x-3">
-							<h1 className="text-xl font-bold text-gray-900">
+							<h1 className="text-xl font-bold text-gray-900 truncate">
 								{distribution.name}
 							</h1>
-							<span
-								className={`px-2 py-1 text-xs font-medium rounded-full ${getArchColor(distribution.architecture)}`}
-							>
+							<Badge variant={archVariant} pill className="flex-shrink-0">
 								{distribution.architecture.toUpperCase()}
-							</span>
+							</Badge>
 						</div>
 						{distribution.description && (
-							<p className="text-sm text-gray-600">
+							<p className="text-sm text-gray-600 mt-0.5">
 								{distribution.description}
 							</p>
 						)}
 					</div>
 				</div>
-			</div>
+			</Card>
 
 			{/* Create Release Modal */}
 			<Modal
@@ -443,7 +437,8 @@ const DistributionDetailPage = () => {
 				footer={
 					<>
 						<Button
-							variant="secondary"
+							variant="soft"
+							tone="gray"
 							disabled={creatingDraft}
 							onClick={() => {
 								setShowCreateModal(false);
@@ -455,7 +450,8 @@ const DistributionDetailPage = () => {
 							Cancel
 						</Button>
 						<Button
-							variant="success"
+							variant="solid"
+							tone="green"
 							loading={creatingDraft}
 							disabled={!canCreate}
 							onClick={handleCreateDraft}
@@ -576,9 +572,7 @@ const DistributionDetailPage = () => {
 							<span className="text-sm font-medium text-gray-900">
 								Release Candidate
 							</span>
-							<span className="px-2 py-1 text-xs font-medium bg-orange-100 text-orange-700 rounded">
-								RC
-							</span>
+							<Badge variant="orange">RC</Badge>
 						</div>
 						<p className="text-xs text-gray-600 mt-1">
 							Adds "-rc" suffix:{" "}
@@ -591,17 +585,18 @@ const DistributionDetailPage = () => {
 			</Modal>
 
 			{/* Releases Section */}
-			<div className="space-y-4">
-				<div className="flex items-center justify-between">
-					<div className="flex items-center space-x-2">
-						<Tag className="w-5 h-5 text-gray-600" />
-						<h2 className="text-lg font-semibold text-gray-900">Releases</h2>
-						<span className="text-sm text-gray-500">({releases.length})</span>
-					</div>
-					<div className="flex items-center space-x-2">
+			<SectionCard
+				icon={Tag}
+				title="Releases"
+				count={releases.length}
+				theme={SECTION_THEMES.blue}
+				actions={
+					<div className="flex items-center gap-2">
 						{releases.length >= 2 && (
 							<Button
-								variant={compareMode ? "primary" : "secondary"}
+								variant="soft"
+								tone={compareMode ? "blue" : "gray"}
+								size="sm"
 								icon={
 									compareMode ? (
 										<X className="w-4 h-4" />
@@ -619,7 +614,9 @@ const DistributionDetailPage = () => {
 						)}
 						{releases.length > 0 && (
 							<Button
-								variant="success"
+								variant="solid"
+								tone="green"
+								size="sm"
 								icon={<Plus className="w-4 h-4" />}
 								onClick={openCreateModal}
 							>
@@ -627,55 +624,53 @@ const DistributionDetailPage = () => {
 							</Button>
 						)}
 					</div>
-				</div>
-
-				<div className="bg-white rounded border border-gray-200 overflow-hidden">
-					{releasesLoading ? (
-						<div className="p-6 text-center">
-							<div className="text-gray-500 text-sm">Loading releases...</div>
-						</div>
-					) : releases.length === 0 ? (
-						<div className="p-6 text-center">
-							<Tag className="w-8 h-8 text-gray-400 mx-auto mb-2" />
-							<p className="text-sm text-gray-500">
-								No releases found for this distribution
-							</p>
-						</div>
-					) : (
-						<div className="divide-y divide-gray-200">
-							{compareMode && (
-								<div className="px-4 py-2 bg-blue-50 border-b border-blue-100 text-xs text-blue-700">
-									{compareSelection.length === 0
-										? "Select two releases to compare"
-										: compareSelection.length === 1
-											? "Select one more release"
-											: "Showing diff below — click a release to change selection"}
-								</div>
-							)}
-							{releases.map((release) => {
-								const selectionIndex = compareSelection.indexOf(release.id);
-								return (
-									<ReleaseRow
-										key={release.id}
-										release={release}
-										compareMode={compareMode}
-										isSelected={selectionIndex !== -1}
-										selectionLabel={
-											selectionIndex === 0
-												? "A"
-												: selectionIndex === 1
-													? "B"
-													: null
-										}
-										isDeployed={deployedRelease?.id === release.id}
-										onSelect={toggleCompareSelection}
-									/>
-								);
-							})}
-						</div>
-					)}
-				</div>
-			</div>
+				}
+			>
+				{releasesLoading ? (
+					<div className="p-6 text-center">
+						<div className="text-gray-500 text-sm">Loading releases...</div>
+					</div>
+				) : releases.length === 0 ? (
+					<div className="p-6 text-center">
+						<Tag className="w-8 h-8 text-gray-400 mx-auto mb-2" />
+						<p className="text-sm text-gray-500">
+							No releases found for this distribution
+						</p>
+					</div>
+				) : (
+					<>
+						{compareMode && (
+							<div className="px-4 py-2 bg-blue-50 border-b border-blue-100 text-xs text-blue-700">
+								{compareSelection.length === 0
+									? "Select two releases to compare"
+									: compareSelection.length === 1
+										? "Select one more release"
+										: "Showing diff below — click a release to change selection"}
+							</div>
+						)}
+						{releases.map((release) => {
+							const selectionIndex = compareSelection.indexOf(release.id);
+							return (
+								<ReleaseRow
+									key={release.id}
+									release={release}
+									compareMode={compareMode}
+									isSelected={selectionIndex !== -1}
+									selectionLabel={
+										selectionIndex === 0
+											? "A"
+											: selectionIndex === 1
+												? "B"
+												: null
+									}
+									isDeployed={deployedRelease?.id === release.id}
+									onSelect={toggleCompareSelection}
+								/>
+							);
+						})}
+					</>
+				)}
+			</SectionCard>
 
 			{/* Compare side panel */}
 			<SidePanel
@@ -863,7 +858,7 @@ const DistributionDetailPage = () => {
 					})()
 				) : null}
 			</SidePanel>
-		</div>
+		</PageContainer>
 	);
 };
 

--- a/dashboard/app/(private)/layout.tsx
+++ b/dashboard/app/(private)/layout.tsx
@@ -7,6 +7,7 @@ import {
 	Home,
 	Layers,
 	ScrollText,
+	Settings,
 	Smartphone,
 	Terminal,
 } from "lucide-react";
@@ -31,6 +32,7 @@ const navigationItems: NavItem[] = [
 	{ path: "/ip-addresses", label: "IP Addresses", icon: Globe },
 	{ path: "/modems", label: "Modems", icon: Smartphone },
 	{ path: "/network-testing", label: "Network Analyzer", icon: Activity },
+	{ path: "/settings", label: "Settings", icon: Settings },
 ];
 
 const bottomItems = [

--- a/dashboard/app/(private)/network-testing/components/SessionHistory.tsx
+++ b/dashboard/app/(private)/network-testing/components/SessionHistory.tsx
@@ -1,14 +1,9 @@
 "use client";
 
-import {
-	Calendar,
-	ChevronRight,
-	Cpu,
-	Loader2,
-	Search,
-	Tag,
-} from "lucide-react";
-import { useMemo, useState } from "react";
+import { Calendar, Cpu, Loader2, Tag } from "lucide-react";
+import moment from "moment";
+import { useMemo } from "react";
+import { Badge, type BadgeVariant } from "@/app/components/ui";
 import {
 	type ExtendedTestSessionSummary,
 	useExtendedTestSessions,
@@ -24,28 +19,23 @@ function formatSessionDate(dateString: string): string {
 	});
 }
 
-function getStatusBadge(status: string) {
-	switch (status) {
-		case "completed":
-			return "bg-green-100 text-green-800";
-		case "canceled":
-			return "bg-amber-100 text-amber-800";
-		case "running":
-		case "partial":
-			return "bg-blue-100 text-blue-800";
-		default:
-			return "bg-gray-100 text-gray-800";
-	}
-}
+const STATUS_VARIANT: Record<string, BadgeVariant> = {
+	completed: "green",
+	canceled: "yellow",
+	running: "blue",
+	partial: "blue",
+	pending: "blue",
+};
 
 interface SessionHistoryProps {
+	searchQuery: string;
 	onSelectSession: (session: ExtendedTestSessionSummary) => void;
 }
 
 export default function SessionHistory({
+	searchQuery,
 	onSelectSession,
 }: SessionHistoryProps) {
-	const [searchQuery, setSearchQuery] = useState("");
 	const { data: sessions, isLoading } = useExtendedTestSessions();
 
 	const filteredSessions = useMemo(() => {
@@ -53,110 +43,93 @@ export default function SessionHistory({
 
 		const query = searchQuery.toLowerCase();
 		return sessions.filter((session) => {
-			// Search in label filter
 			if (session.label_filter?.toLowerCase().includes(query)) return true;
-
-			// Search in date
-			const dateStr = formatSessionDate(session.created_at).toLowerCase();
-			if (dateStr.includes(query)) return true;
-
-			// Search in status
+			if (formatSessionDate(session.created_at).toLowerCase().includes(query))
+				return true;
 			if (session.status.toLowerCase().includes(query)) return true;
-
 			return false;
 		});
 	}, [sessions, searchQuery]);
 
-	if (isLoading) {
-		return (
-			<div className="flex items-center justify-center py-12">
-				<div className="flex flex-col items-center space-y-3">
-					<Loader2 className="w-6 h-6 animate-spin text-blue-600" />
-					<p className="text-sm text-gray-500">Loading test history...</p>
+	return (
+		<div className="border border-gray-200/80 rounded-xl overflow-hidden bg-white shadow-sm">
+			{/* Header */}
+			<div className="bg-gray-50 px-4 py-3 border-b border-gray-200">
+				<div className="grid grid-cols-[2fr_2fr_1fr_1fr_auto] gap-4 text-xs font-medium text-gray-500 uppercase tracking-wide items-center">
+					<div>Started</div>
+					<div>Filter</div>
+					<div>Devices</div>
+					<div>Progress</div>
+					<div className="text-right">Status</div>
 				</div>
 			</div>
-		);
-	}
 
-	if (!sessions || sessions.length === 0) {
-		return (
-			<div className="text-center py-12">
-				<Calendar className="w-10 h-10 text-gray-300 mx-auto mb-3" />
-				<p className="text-gray-500">No test sessions yet</p>
-				<p className="text-sm text-gray-400 mt-1">
-					Select devices above to run your first test
-				</p>
-			</div>
-		);
-	}
-
-	return (
-		<div className="space-y-3">
-			{/* Search Input */}
-			<div className="relative">
-				<Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
-				<input
-					type="text"
-					placeholder="Search by label, date, or status..."
-					value={searchQuery}
-					onChange={(e) => setSearchQuery(e.target.value)}
-					className="w-full pl-10 pr-4 py-2 text-sm text-gray-900 placeholder-gray-400 bg-white border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-				/>
-			</div>
-
-			{/* Sessions List */}
-			<div className="space-y-2 max-h-96 overflow-y-auto">
-				{filteredSessions && filteredSessions.length > 0 ? (
-					filteredSessions.map((session) => (
+			{isLoading ? (
+				<div className="flex items-center justify-center py-12">
+					<Loader2 className="w-6 h-6 animate-spin text-blue-600" />
+				</div>
+			) : !sessions || sessions.length === 0 ? (
+				<div className="text-center py-12">
+					<Calendar className="w-10 h-10 text-gray-300 mx-auto mb-3" />
+					<p className="text-gray-500">No test sessions yet</p>
+					<p className="text-sm text-gray-400 mt-1">
+						Use “New Test” to run your first test
+					</p>
+				</div>
+			) : !filteredSessions || filteredSessions.length === 0 ? (
+				<div className="text-center py-12">
+					<p className="text-sm text-gray-500">No sessions match your search</p>
+				</div>
+			) : (
+				<div className="divide-y divide-gray-200">
+					{filteredSessions.map((session) => (
 						<button
 							key={session.session_id}
+							type="button"
 							onClick={() => onSelectSession(session)}
-							className="w-full px-4 py-3 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 hover:border-gray-300 transition-colors text-left"
+							className="w-full text-left px-4 py-3 cursor-pointer transition-colors"
 						>
-							<div className="flex items-center justify-between">
-								<div className="flex-1 min-w-0">
-									<div className="flex items-center space-x-3">
-										<span className="text-sm font-medium text-gray-900">
-											{formatSessionDate(session.created_at)}
-										</span>
-										<span
-											className={`px-2 py-0.5 text-xs rounded-full ${getStatusBadge(session.status)}`}
-										>
-											{session.status}
-										</span>
-									</div>
-									<div className="flex items-center space-x-4 mt-1 text-xs text-gray-500">
-										<span className="flex items-center space-x-1">
-											<Tag className="w-3 h-3" />
-											<span className="truncate max-w-[200px]">
-												{session.label_filter || "All devices"}
-											</span>
-										</span>
-										<span className="flex items-center space-x-1">
-											<Cpu className="w-3 h-3" />
-											<span>
-												{session.device_count} device
-												{session.device_count !== 1 ? "s" : ""}
-											</span>
-										</span>
-										<span>
-											{session.completed_count}/{session.device_count} completed
-										</span>
-									</div>
+							<div className="grid grid-cols-[2fr_2fr_1fr_1fr_auto] gap-4 items-center">
+								<div className="flex flex-col min-w-0">
+									<span className="text-sm font-medium text-gray-900 truncate">
+										{formatSessionDate(session.created_at)}
+									</span>
+									<span className="text-xs text-gray-400 mt-0.5">
+										{moment(session.created_at).fromNow()}
+									</span>
 								</div>
-								<ChevronRight className="w-5 h-5 text-gray-400 flex-shrink-0" />
+
+								<div className="flex items-center space-x-2 min-w-0">
+									<Tag className="w-3.5 h-3.5 text-gray-400 flex-shrink-0" />
+									<span className="text-sm text-gray-600 truncate">
+										{session.label_filter || "All devices"}
+									</span>
+								</div>
+
+								<div className="flex items-center space-x-2">
+									<Cpu className="w-3.5 h-3.5 text-gray-400 flex-shrink-0" />
+									<span className="text-sm text-gray-600">
+										{session.device_count}
+									</span>
+								</div>
+
+								<div className="text-sm text-gray-600">
+									{session.completed_count}/{session.device_count}
+								</div>
+
+								<div className="text-right">
+									<Badge
+										variant={STATUS_VARIANT[session.status] ?? "gray"}
+										pill
+									>
+										{session.status}
+									</Badge>
+								</div>
 							</div>
 						</button>
-					))
-				) : (
-					<div className="text-center py-8">
-						<Search className="w-8 h-8 text-gray-300 mx-auto mb-2" />
-						<p className="text-sm text-gray-500">
-							No sessions match your search
-						</p>
-					</div>
-				)}
-			</div>
+					))}
+				</div>
+			)}
 		</div>
 	);
 }

--- a/dashboard/app/(private)/network-testing/components/StartTestModal.tsx
+++ b/dashboard/app/(private)/network-testing/components/StartTestModal.tsx
@@ -1,25 +1,21 @@
 "use client";
 
-import { AlertTriangle, Loader2, Play, Tag } from "lucide-react";
+import { AlertTriangle, Loader2, Play } from "lucide-react";
+import { useCallback, useState } from "react";
+import type { Device } from "@/app/api-client";
 import { Button } from "@/app/components/button";
 import { Modal } from "@/app/components/modal";
 import {
 	type DongleInfo,
 	useOnlineDevicesDongleCheck,
+	useStartExtendedTest,
 } from "../hooks/useExtendedTest";
+import DeviceSelector, { type SelectionMode } from "./DeviceSelector";
 
 interface StartTestModalProps {
 	isOpen: boolean;
 	onClose: () => void;
-	onStart: () => void;
-	isPending: boolean;
-	isError: boolean;
-	durationMinutes: number;
-	onDurationChange: (minutes: number) => void;
-	// Selection from landing page
-	selectedLabels?: string[];
-	selectedDeviceCount?: number;
-	selectionMode?: "labels" | "devices";
+	onStarted: (sessionId: string) => void;
 }
 
 function estimateDataUsageMB(durationMinutes: number): string {
@@ -74,19 +70,49 @@ function DongleWarning({
 export default function StartTestModal({
 	isOpen,
 	onClose,
-	onStart,
-	isPending,
-	isError,
-	durationMinutes,
-	onDurationChange,
-	selectedLabels = [],
-	selectedDeviceCount = 0,
-	selectionMode = "labels",
+	onStarted,
 }: StartTestModalProps) {
+	const [selectionMode, setSelectionMode] = useState<SelectionMode>("labels");
+	const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
+	const [selectedDeviceIds, setSelectedDeviceIds] = useState<Set<number>>(
+		new Set(),
+	);
+	const [resolvedDevices, setResolvedDevices] = useState<Device[]>([]);
+	const [durationMinutes, setDurationMinutes] = useState(3);
+
+	const startTestMutation = useStartExtendedTest();
 	const { data: dongleInfo, isLoading: dongleCheckLoading } =
 		useOnlineDevicesDongleCheck();
 
+	const handleDevicesResolved = useCallback((devices: Device[]) => {
+		setResolvedDevices(devices);
+	}, []);
+
+	const hasSelection =
+		selectionMode === "labels"
+			? selectedLabels.length > 0
+			: resolvedDevices.length > 0;
+
 	const hasDongleDevices = dongleInfo && dongleInfo.dongleDevices.length > 0;
+
+	const handleStart = async () => {
+		const labelFilter =
+			selectionMode === "labels" ? selectedLabels.join(",") : "";
+		const serialNumbers =
+			selectionMode === "devices"
+				? resolvedDevices.map((d) => d.serial_number)
+				: undefined;
+		try {
+			const result = await startTestMutation.mutateAsync({
+				label_filter: labelFilter,
+				serial_numbers: serialNumbers,
+				duration_minutes: durationMinutes,
+			});
+			onStarted(result.session_id);
+		} catch (error) {
+			console.error("Failed to start test:", error);
+		}
+	};
 
 	const footer = (
 		<>
@@ -94,13 +120,17 @@ export default function StartTestModal({
 				Cancel
 			</Button>
 			<Button
-				onClick={onStart}
-				disabled={isPending || dongleCheckLoading}
-				loading={isPending}
+				onClick={handleStart}
+				disabled={
+					startTestMutation.isPending || dongleCheckLoading || !hasSelection
+				}
+				loading={startTestMutation.isPending}
 				variant={hasDongleDevices ? "warning" : "primary"}
-				icon={isPending ? undefined : <Play className="w-4 h-4" />}
+				icon={
+					startTestMutation.isPending ? undefined : <Play className="w-4 h-4" />
+				}
 			>
-				{isPending
+				{startTestMutation.isPending
 					? "Starting..."
 					: hasDongleDevices
 						? "Start Anyway"
@@ -113,50 +143,29 @@ export default function StartTestModal({
 		<Modal
 			open={isOpen}
 			onClose={onClose}
-			title="Start Network Analysis"
-			width="w-[520px]"
+			title="Start Network Test"
+			width="w-[560px]"
 			footer={footer}
 		>
 			<div className="space-y-4">
 				{/* Info Banner */}
 				<div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
 					<p className="text-sm text-blue-800">
-						This will run an extended network speed test on all online devices
-						matching your label filter to measure network performance under
-						load.
+						This runs an extended network speed test on the selected online
+						devices to measure network performance under load.
 					</p>
 				</div>
 
-				{/* Selected Devices Display */}
-				<div>
-					<label className="block text-sm font-medium text-gray-700 mb-2">
-						<div className="flex items-center space-x-2">
-							<Tag className="w-4 h-4" />
-							<span>Target Devices</span>
-						</div>
-					</label>
-					<div className="px-3 py-2 bg-gray-50 border border-gray-200 rounded-lg">
-						{selectionMode === "labels" && selectedLabels.length > 0 ? (
-							<div className="flex flex-wrap gap-2">
-								{selectedLabels.map((label) => (
-									<span
-										key={label}
-										className="inline-flex items-center px-2 py-1 rounded-full text-sm bg-blue-100 text-blue-800"
-									>
-										{label}
-									</span>
-								))}
-							</div>
-						) : selectionMode === "devices" && selectedDeviceCount > 0 ? (
-							<p className="text-sm text-gray-900">
-								{selectedDeviceCount} device
-								{selectedDeviceCount !== 1 ? "s" : ""} selected
-							</p>
-						) : (
-							<p className="text-sm text-gray-500">All online devices</p>
-						)}
-					</div>
-				</div>
+				{/* Device Selection */}
+				<DeviceSelector
+					mode={selectionMode}
+					onModeChange={setSelectionMode}
+					selectedLabels={selectedLabels}
+					onLabelsChange={setSelectedLabels}
+					selectedDeviceIds={selectedDeviceIds}
+					onDeviceIdsChange={setSelectedDeviceIds}
+					onDevicesResolved={handleDevicesResolved}
+				/>
 
 				{/* Dongle Warning */}
 				{dongleCheckLoading ? (
@@ -180,7 +189,7 @@ export default function StartTestModal({
 						{[3, 5, 8].map((mins) => (
 							<Button
 								key={mins}
-								onClick={() => onDurationChange(mins)}
+								onClick={() => setDurationMinutes(mins)}
 								variant={durationMinutes === mins ? "primary" : "secondary"}
 								className="flex-1"
 							>
@@ -195,7 +204,7 @@ export default function StartTestModal({
 				</div>
 
 				{/* Error Message */}
-				{isError && (
+				{startTestMutation.isError && (
 					<div className="bg-red-50 border border-red-200 rounded-lg p-3">
 						<p className="text-sm text-red-800">
 							Failed to start test. Make sure there are online devices

--- a/dashboard/app/(private)/network-testing/hooks/useExtendedTest.ts
+++ b/dashboard/app/(private)/network-testing/hooks/useExtendedTest.ts
@@ -110,22 +110,6 @@ export const useExtendedTestSessions = () => {
 	});
 };
 
-// Find sessions that were run for a specific set of devices (by serial numbers)
-export const useSessionsByDevices = (serialNumbers: string[]) => {
-	const fetcher = useClientMutator<ExtendedTestSessionSummary[]>();
-	const sortedSerials = [...serialNumbers].sort().join(",");
-
-	return useQuery({
-		queryKey: ["sessionsByDevices", sortedSerials],
-		queryFn: () =>
-			fetcher({
-				url: `/network/extended-test/sessions/by-devices?serial_numbers=${encodeURIComponent(sortedSerials)}`,
-				method: "GET",
-			}),
-		enabled: serialNumbers.length > 0,
-	});
-};
-
 export const useExtendedTestStatus = (sessionId: string | null) => {
 	const fetcher = useClientMutator<ExtendedTestStatus>();
 	return useQuery({

--- a/dashboard/app/(private)/network-testing/page.tsx
+++ b/dashboard/app/(private)/network-testing/page.tsx
@@ -1,13 +1,9 @@
-import { Activity, ArrowLeft, Loader2, Play } from "lucide-react";
-import { useCallback, useState } from "react";
+import { Activity, ArrowLeft, Loader2, Plus } from "lucide-react";
+import { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
-import type { Device } from "@/app/api-client";
-import { Button } from "@/app/components/button";
+import { Button, SearchInput } from "@/app/components/ui";
 import DepartmentOverview from "./components/DepartmentOverview";
 import DeviceInspector from "./components/DeviceInspector";
-import DeviceSelector, {
-	type SelectionMode,
-} from "./components/DeviceSelector";
 import DeviceTable from "./components/DeviceTable";
 import InsightsCards from "./components/InsightsCards";
 import SessionHistory from "./components/SessionHistory";
@@ -15,20 +11,18 @@ import StartTestModal from "./components/StartTestModal";
 import {
 	type ExtendedTestSessionSummary,
 	useExtendedTestStatus,
-	useSessionsByDevices,
-	useStartExtendedTest,
 } from "./hooks/useExtendedTest";
 
 type ViewMode = "landing" | "results";
 
-export default function HackathonPage() {
+export default function NetworkTestingPage() {
 	const navigate = useNavigate();
 	const [searchParams] = useSearchParams();
 
 	// URL params for deep linking
 	const sessionFromUrl = searchParams.get("session");
 
-	// View mode: landing (device selection + history) or results (test details)
+	// View mode: landing (history) or results (test details)
 	const [viewMode, setViewMode] = useState<ViewMode>(
 		sessionFromUrl ? "results" : "landing",
 	);
@@ -36,46 +30,20 @@ export default function HackathonPage() {
 		sessionFromUrl,
 	);
 
-	// Device selection state
-	const [selectionMode, setSelectionMode] = useState<SelectionMode>("labels");
-	const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
-	const [selectedDeviceIds, setSelectedDeviceIds] = useState<Set<number>>(
-		new Set(),
-	);
-	const [resolvedDevices, setResolvedDevices] = useState<Device[]>([]);
-
-	// Modal and test state
 	const [showStartModal, setShowStartModal] = useState(false);
-	const [durationMinutes, setDurationMinutes] = useState(3);
 	const [selectedDeviceId, setSelectedDeviceId] = useState<number | null>(null);
-
-	// Get serial numbers from resolved devices
-	const serialNumbers = resolvedDevices.map((d) => d.serial_number);
-
-	// Fetch sessions matching the selected devices
-	const {
-		data: matchingSessions,
-		isLoading: matchingSessionsLoading,
-		refetch: refetchMatchingSessions,
-	} = useSessionsByDevices(serialNumbers);
+	const [searchQuery, setSearchQuery] = useState("");
 
 	// Fetch selected session status
 	const { data: sessionStatus, isLoading: statusLoading } =
 		useExtendedTestStatus(selectedSessionId);
-
-	const startTestMutation = useStartExtendedTest();
 
 	// Derive selected device from live session data to avoid stale object during polling
 	const selectedDevice =
 		sessionStatus?.results.find((d) => d.device_id === selectedDeviceId) ??
 		null;
 
-	// Handle devices resolved from selector
-	const handleDevicesResolved = useCallback((devices: Device[]) => {
-		setResolvedDevices(devices);
-	}, []);
-
-	// Handle session selection from history or dropdown
+	// Handle session selection from history
 	const handleSessionSelect = (session: ExtendedTestSessionSummary) => {
 		setSelectedSessionId(session.session_id);
 		setSelectedDeviceId(null);
@@ -85,41 +53,13 @@ export default function HackathonPage() {
 		});
 	};
 
-	// Handle start test
-	const handleStartTest = async () => {
-		const labelFilter =
-			selectionMode === "labels" ? selectedLabels.join(",") : "";
-		const serialNumbers =
-			selectionMode === "devices"
-				? resolvedDevices.map((d) => d.serial_number)
-				: undefined;
-		try {
-			const result = await startTestMutation.mutateAsync({
-				label_filter: labelFilter,
-				serial_numbers: serialNumbers,
-				duration_minutes: durationMinutes,
-			});
-			setShowStartModal(false);
-			setSelectedSessionId(result.session_id);
-			setViewMode("results");
-			navigate(`/network-testing?session=${result.session_id}`, {
-				replace: true,
-			});
-			refetchMatchingSessions();
-		} catch (error) {
-			console.error("Failed to start test:", error);
-		}
-	};
-
-	// Handle view for selected devices
-	const handleViewResults = () => {
-		if (matchingSessions && matchingSessions.length > 0) {
-			const latest = [...matchingSessions].sort(
-				(a, b) =>
-					new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-			)[0];
-			handleSessionSelect(latest);
-		}
+	// Handle a freshly started test
+	const handleTestStarted = (sessionId: string) => {
+		setShowStartModal(false);
+		setSelectedSessionId(sessionId);
+		setSelectedDeviceId(null);
+		setViewMode("results");
+		navigate(`/network-testing?session=${sessionId}`, { replace: true });
 	};
 
 	// Handle back to landing
@@ -130,111 +70,37 @@ export default function HackathonPage() {
 		navigate("/network-testing", { replace: true });
 	};
 
-	const _isTestRunning =
-		sessionStatus?.status === "running" ||
-		sessionStatus?.status === "pending" ||
-		sessionStatus?.status === "partial";
-
-	const hasDevicesSelected = resolvedDevices.length > 0;
-	const hasMatchingSessions = matchingSessions && matchingSessions.length > 0;
-
-	// Landing view - device selection + history
+	// Landing view - test history
 	if (viewMode === "landing") {
 		return (
-			<div className="flex-1 overflow-y-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
-				{/* Header */}
-				<div className="flex items-center space-x-3">
-					<Activity className="w-6 h-6 text-blue-600" />
-					<h1 className="text-2xl font-bold text-gray-900">Network Test</h1>
+			<div className="flex-1 overflow-y-auto px-4 sm:px-6 lg:px-8 py-6 space-y-4">
+				{/* Toolbar: search + new test */}
+				<div className="flex items-center justify-between gap-3">
+					<SearchInput
+						value={searchQuery}
+						onChange={setSearchQuery}
+						placeholder="Search by label, date, or status..."
+						className="max-w-md"
+					/>
+					<Button
+						variant="solid"
+						tone="blue"
+						icon={<Plus className="w-4 h-4" />}
+						onClick={() => setShowStartModal(true)}
+					>
+						New Test
+					</Button>
 				</div>
 
-				<div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-					{/* Device Selection Panel */}
-					<div className="bg-white rounded-lg border border-gray-200 p-6">
-						<h2 className="text-lg font-semibold text-gray-900 mb-4">
-							Select Devices
-						</h2>
-						<DeviceSelector
-							mode={selectionMode}
-							onModeChange={setSelectionMode}
-							selectedLabels={selectedLabels}
-							onLabelsChange={setSelectedLabels}
-							selectedDeviceIds={selectedDeviceIds}
-							onDeviceIdsChange={setSelectedDeviceIds}
-							onDevicesResolved={handleDevicesResolved}
-						/>
-
-						{/* Action Buttons */}
-						{hasDevicesSelected && (
-							<div className="mt-6 pt-4 border-t border-gray-200">
-								{matchingSessionsLoading ? (
-									<div className="flex items-center space-x-2 text-gray-500 text-sm">
-										<Loader2 className="w-4 h-4 animate-spin" />
-										<span>Checking for previous tests...</span>
-									</div>
-								) : hasMatchingSessions ? (
-									<div className="space-y-3">
-										<p className="text-sm text-gray-600">
-											Found {matchingSessions.length} previous test
-											{matchingSessions.length !== 1 ? "s" : ""} for these
-											devices
-										</p>
-										<div className="flex space-x-3">
-											<Button
-												onClick={handleViewResults}
-												className="flex-1"
-												icon={<Activity className="w-4 h-4" />}
-											>
-												View Latest Results
-											</Button>
-											<Button
-												onClick={() => setShowStartModal(true)}
-												variant="secondary"
-												icon={<Play className="w-4 h-4" />}
-											>
-												New Test
-											</Button>
-										</div>
-									</div>
-								) : (
-									<div className="space-y-3">
-										<p className="text-sm text-gray-600">
-											No previous tests found for these {resolvedDevices.length}{" "}
-											devices
-										</p>
-										<Button
-											onClick={() => setShowStartModal(true)}
-											className="w-full"
-											icon={<Play className="w-5 h-5" />}
-										>
-											Start Network Test
-										</Button>
-									</div>
-								)}
-							</div>
-						)}
-					</div>
-
-					{/* History Panel */}
-					<div className="bg-white rounded-lg border border-gray-200 p-6">
-						<h2 className="text-lg font-semibold text-gray-900 mb-4">
-							Test History
-						</h2>
-						<SessionHistory onSelectSession={handleSessionSelect} />
-					</div>
-				</div>
+				<SessionHistory
+					searchQuery={searchQuery}
+					onSelectSession={handleSessionSelect}
+				/>
 
 				<StartTestModal
 					isOpen={showStartModal}
 					onClose={() => setShowStartModal(false)}
-					onStart={handleStartTest}
-					isPending={startTestMutation.isPending}
-					isError={startTestMutation.isError}
-					durationMinutes={durationMinutes}
-					onDurationChange={setDurationMinutes}
-					selectedLabels={selectedLabels}
-					selectedDeviceCount={resolvedDevices.length}
-					selectionMode={selectionMode}
+					onStarted={handleTestStarted}
 				/>
 			</div>
 		);
@@ -247,7 +113,7 @@ export default function HackathonPage() {
 			<div className="flex items-center space-x-3">
 				<button
 					onClick={handleBackToLanding}
-					aria-label="Back to network test landing page"
+					aria-label="Back to network test history"
 					className="p-1 rounded-md hover:bg-gray-100 transition-colors"
 				>
 					<ArrowLeft className="w-5 h-5 text-gray-500" />

--- a/dashboard/app/(private)/releases/[id]/page.tsx
+++ b/dashboard/app/(private)/releases/[id]/page.tsx
@@ -5,7 +5,6 @@ import {
 	ArrowUp,
 	Box,
 	Calendar,
-	CheckCircle,
 	ChevronsUpDown,
 	Clock,
 	Cog,
@@ -19,12 +18,10 @@ import {
 	Tag,
 	Trash2,
 	X,
-	XCircle,
 	Zap,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import { createPortal } from "react-dom";
-import { Link, useNavigate, useParams } from "react-router";
+import { useNavigate, useParams } from "react-router";
 import {
 	type DeploymentRequest,
 	type Device,
@@ -41,10 +38,38 @@ import {
 	useGetReleaseServices,
 	usePatchRelease,
 } from "@/app/api-client";
-import { Button, IconButton } from "@/app/components/button";
 import LabelAutocomplete from "@/app/components/LabelAutocomplete";
 import { Modal } from "@/app/components/modal";
 import { RelativeTime } from "@/app/components/RelativeTime";
+import {
+	BackLink,
+	Badge,
+	type BadgeVariant,
+	Button,
+	Card,
+	ListRow,
+	PageContainer,
+	SECTION_THEMES,
+	SectionCard,
+	Toast,
+	type ToastState,
+} from "@/app/components/ui";
+
+const getArchVariant = (architecture: string): BadgeVariant => {
+	switch (architecture.toLowerCase()) {
+		case "x86_64":
+		case "amd64":
+			return "blue";
+		case "arm64":
+		case "aarch64":
+			return "green";
+		case "armv7":
+		case "arm":
+			return "purple";
+		default:
+			return "gray";
+	}
+};
 
 const ReleaseDetailPage = () => {
 	const navigate = useNavigate();
@@ -76,10 +101,7 @@ const ReleaseDetailPage = () => {
 	const [showYankModal, setShowYankModal] = useState(false);
 	const [yanking, setYanking] = useState(false);
 	const [yankReason, setYankReason] = useState("");
-	const [toast, setToast] = useState<{
-		message: string;
-		type: "success" | "error";
-	} | null>(null);
+	const [toast, setToast] = useState<ToastState | null>(null);
 	const [upgradingPackages, setUpgradingPackages] = useState<Set<number>>(
 		new Set(),
 	);
@@ -200,18 +222,12 @@ const ReleaseDetailPage = () => {
 				className={`inline-block w-2 h-2 rounded-full ${networkDotColor(device.network?.network_score)}`}
 			/>
 			{unhealthyDeviceIds.has(device.id) && (
-				<AlertTriangle
-					className="w-3 h-3 text-amber-500"
-					title="Unhealthy services"
-				/>
+				<span title="Unhealthy services" className="inline-flex">
+					<AlertTriangle className="w-3 h-3 text-amber-500" />
+				</span>
 			)}
 		</div>
 	);
-
-	const [mounted, setMounted] = useState(false);
-	useEffect(() => {
-		setMounted(true);
-	}, []);
 
 	useEffect(() => {
 		if (toast) {
@@ -226,22 +242,6 @@ const ReleaseDetailPage = () => {
 		}, 300);
 		return () => clearTimeout(timer);
 	}, [deviceSearchQuery]);
-
-	const getArchColor = (architecture: string) => {
-		switch (architecture.toLowerCase()) {
-			case "x86_64":
-			case "amd64":
-				return "bg-blue-100 text-blue-700";
-			case "arm64":
-			case "aarch64":
-				return "bg-green-100 text-green-700";
-			case "armv7":
-			case "arm":
-				return "bg-purple-100 text-purple-700";
-			default:
-				return "bg-gray-100 text-gray-700";
-		}
-	};
 
 	const updateReleaseHook = usePatchRelease({
 		mutation: {
@@ -486,88 +486,75 @@ const ReleaseDetailPage = () => {
 
 	if (loading || !release) {
 		return (
-			<div className="flex items-center justify-center h-32">
-				<div className="text-gray-500 text-sm">Loading...</div>
-			</div>
+			<PageContainer>
+				<div className="h-4 w-44 bg-gray-200 rounded animate-pulse" />
+				<Card className="p-4">
+					<div className="flex items-center space-x-3">
+						<div className="p-2 bg-gray-100 rounded">
+							<div className="w-5 h-5 bg-gray-200 rounded animate-pulse" />
+						</div>
+						<div className="space-y-2">
+							<div className="h-6 bg-gray-200 rounded w-48 animate-pulse" />
+							<div className="h-4 bg-gray-200 rounded w-64 animate-pulse" />
+						</div>
+					</div>
+				</Card>
+			</PageContainer>
 		);
 	}
 
 	return (
-		<div className="flex-1 overflow-y-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
+		<PageContainer>
 			{/* Toast Notification */}
-			{mounted &&
-				toast &&
-				createPortal(
-					<div className="fixed top-4 right-4 z-50 animate-in slide-in-from-top-5 duration-300">
-						<div
-							className={`flex items-center space-x-3 px-4 py-3 rounded-lg shadow-lg ${
-								toast.type === "success" ? "bg-green-600" : "bg-red-600"
-							}`}
-						>
-							{toast.type === "success" ? (
-								<CheckCircle className="w-5 h-5 text-white" />
-							) : (
-								<XCircle className="w-5 h-5 text-white" />
-							)}
-							<span className="text-white font-medium text-sm">
-								{toast.message}
-							</span>
-						</div>
-					</div>,
-					document.body,
-				)}
+			<Toast toast={toast} onClose={() => setToast(null)} />
 
-			{/* Header with Back Button */}
-			<div className="flex items-center space-x-4">
-				<Link
-					to={
-						distribution
-							? `/distributions/${distribution.id}`
-							: "/distributions"
-					}
-					className="flex items-center space-x-2 text-gray-600 hover:text-gray-900 transition-colors cursor-pointer"
-				>
-					<ArrowLeft className="w-4 h-4" />
-					<span className="text-sm font-medium">
-						{distribution
-							? `Back to ${distribution.name}`
-							: "Back to Distributions"}
-					</span>
-				</Link>
-			</div>
+			{/* Back link */}
+			<BackLink
+				to={
+					distribution ? `/distributions/${distribution.id}` : "/distributions"
+				}
+			>
+				{distribution
+					? `Back to ${distribution.name}`
+					: "Back to Distributions"}
+			</BackLink>
 
 			{/* Release Header */}
-			<div className="bg-white rounded-lg border border-gray-200 p-4">
-				<div className="flex items-center justify-between">
-					<div className="flex items-center space-x-3">
-						<div className="p-2 bg-gray-100 text-gray-600 rounded">
+			<Card className="p-4">
+				<div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+					<div className="flex items-center space-x-3 min-w-0">
+						<div className="p-2 bg-gray-100 text-gray-600 rounded flex-shrink-0">
 							<Tag className="w-5 h-5" />
 						</div>
-						<div className="flex-1">
+						<div className="min-w-0">
 							<div className="flex items-center space-x-3">
 								<h1 className="text-xl font-bold text-gray-900">
 									Release {release.version}
 								</h1>
 								{release.draft && (
-									<span className="px-2 py-1 text-xs font-medium bg-yellow-100 text-yellow-800 rounded-full">
+									<Badge variant="yellow" pill>
 										Draft
-									</span>
+									</Badge>
 								)}
 								{release.release_candidate && (
-									<span className="px-2 py-1 text-xs font-medium bg-orange-100 text-orange-700 rounded-full">
+									<Badge variant="orange" pill>
 										RC
-									</span>
+									</Badge>
 								)}
 								{release.yanked && (
-									<span className="px-2 py-1 text-xs font-medium bg-red-100 text-red-800 rounded-full">
+									<Badge variant="red" pill>
 										Yanked
-									</span>
+									</Badge>
 								)}
 								{existingDeployment?.status === "InProgress" && (
-									<span className="px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded-full flex items-center">
+									<Badge
+										variant="blue"
+										pill
+										className="inline-flex items-center"
+									>
 										<Loader2 className="w-3 h-3 mr-1 animate-spin" />
 										Deploying
-									</span>
+									</Badge>
 								)}
 							</div>
 							<div className="flex items-center space-x-4 mt-1 text-sm text-gray-600">
@@ -580,27 +567,30 @@ const ReleaseDetailPage = () => {
 								{distribution && (
 									<div className="flex items-center space-x-2">
 										<span className="font-medium">{distribution.name}</span>
-										<span
-											className={`px-2 py-1 text-xs font-medium rounded-full ${getArchColor(distribution.architecture)}`}
+										<Badge
+											variant={getArchVariant(distribution.architecture)}
+											pill
 										>
 											{distribution.architecture.toUpperCase()}
-										</span>
+										</Badge>
 									</div>
 								)}
 							</div>
 						</div>
 					</div>
-					<div className="flex items-center space-x-3">
-						<Link
+					<div className="flex flex-wrap items-center gap-2 lg:flex-shrink-0 lg:gap-3">
+						<Button
+							variant="soft"
+							tone="gray"
 							to={`/devices?release_id=${release.id}`}
-							className="flex items-center space-x-2 px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors cursor-pointer"
+							icon={<Cpu className="w-4 h-4" />}
 						>
-							<Cpu className="w-4 h-4" />
-							<span>View Devices</span>
-						</Link>
+							View Devices
+						</Button>
 						{release?.draft ? (
 							<Button
-								variant="success"
+								variant="solid"
+								tone="green"
 								loading={updateReleaseHook.isPending}
 								icon={<Eye className="w-4 h-4" />}
 								onClick={handlePublishRelease}
@@ -611,22 +601,26 @@ const ReleaseDetailPage = () => {
 							!release?.yanked && (
 								<>
 									<Button
-										variant="danger"
+										variant="solid"
+										tone="red"
 										icon={<AlertTriangle className="w-4 h-4" />}
 										onClick={() => setShowYankModal(true)}
 									>
 										Yank
 									</Button>
 									{existingDeployment?.status === "InProgress" ? (
-										<Link
+										<Button
+											variant="solid"
+											tone="blue"
 											to={`/releases/${releaseId}/deployment`}
-											className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-700 transition-colors cursor-pointer"
+											icon={<Loader2 className="w-4 h-4 animate-spin" />}
 										>
-											<Loader2 className="w-4 h-4 animate-spin" />
-											<span>View Deployment</span>
-										</Link>
+											View Deployment
+										</Button>
 									) : (
 										<Button
+											variant="solid"
+											tone="blue"
 											icon={<Rocket className="w-4 h-4" />}
 											onClick={handleOpenDeployModal}
 										>
@@ -638,7 +632,7 @@ const ReleaseDetailPage = () => {
 						)}
 					</div>
 				</div>
-			</div>
+			</Card>
 
 			{/* Deploy Confirmation Modal */}
 			<Modal
@@ -655,7 +649,8 @@ const ReleaseDetailPage = () => {
 					deployStep === 1 ? (
 						<>
 							<Button
-								variant="secondary"
+								variant="soft"
+								tone="gray"
 								disabled={deploying}
 								onClick={() => setShowDeployModal(false)}
 							>
@@ -663,6 +658,8 @@ const ReleaseDetailPage = () => {
 							</Button>
 							{canaryMode === "automatic" ? (
 								<Button
+									variant="solid"
+									tone="blue"
 									loading={deploying}
 									icon={<Rocket className="w-4 h-4" />}
 									onClick={handleDeployRelease}
@@ -670,7 +667,11 @@ const ReleaseDetailPage = () => {
 									{deploying ? "Starting..." : "Start Deployment"}
 								</Button>
 							) : (
-								<Button onClick={() => setDeployStep(2)}>
+								<Button
+									variant="solid"
+									tone="blue"
+									onClick={() => setDeployStep(2)}
+								>
 									Next: Select Devices
 								</Button>
 							)}
@@ -678,7 +679,8 @@ const ReleaseDetailPage = () => {
 					) : (
 						<div className="flex justify-between w-full">
 							<Button
-								variant="secondary"
+								variant="soft"
+								tone="gray"
 								icon={<ArrowLeft className="w-4 h-4" />}
 								disabled={deploying}
 								onClick={() => setDeployStep(1)}
@@ -686,6 +688,8 @@ const ReleaseDetailPage = () => {
 								Back
 							</Button>
 							<Button
+								variant="solid"
+								tone="blue"
 								loading={deploying}
 								icon={<Rocket className="w-4 h-4" />}
 								disabled={
@@ -1042,7 +1046,8 @@ const ReleaseDetailPage = () => {
 				footer={
 					<>
 						<Button
-							variant="secondary"
+							variant="soft"
+							tone="gray"
 							disabled={yanking}
 							onClick={() => {
 								setShowYankModal(false);
@@ -1052,7 +1057,8 @@ const ReleaseDetailPage = () => {
 							Cancel
 						</Button>
 						<Button
-							variant="danger"
+							variant="solid"
+							tone="red"
 							loading={yanking}
 							disabled={!yankReason.trim()}
 							icon={<AlertTriangle className="w-4 h-4" />}
@@ -1104,12 +1110,15 @@ const ReleaseDetailPage = () => {
 					footer={
 						<>
 							<Button
-								variant="secondary"
+								variant="soft"
+								tone="gray"
 								onClick={() => setShowReplacePackageModal(false)}
 							>
 								Cancel
 							</Button>
 							<Button
+								variant="solid"
+								tone="blue"
 								disabled={!selectedAvailablePackage}
 								onClick={handleReplacePackage}
 							>
@@ -1201,11 +1210,11 @@ const ReleaseDetailPage = () => {
 																<span className="text-xs text-gray-500">
 																	v{pkg.version}
 																</span>
-																<span
-																	className={`px-2 py-0.5 text-xs font-medium rounded ${getArchColor(pkg.architecture)}`}
+																<Badge
+																	variant={getArchVariant(pkg.architecture)}
 																>
 																	{pkg.architecture}
-																</span>
+																</Badge>
 															</div>
 															<div className="text-xs text-gray-500 mt-1 truncate">
 																{pkg.file}
@@ -1251,12 +1260,15 @@ const ReleaseDetailPage = () => {
 				footer={
 					<>
 						<Button
-							variant="secondary"
+							variant="soft"
+							tone="gray"
 							onClick={() => setShowAddPackageModal(false)}
 						>
 							Cancel
 						</Button>
 						<Button
+							variant="solid"
+							tone="blue"
 							disabled={!selectedAvailablePackage}
 							onClick={handleAddPackage}
 						>
@@ -1355,11 +1367,9 @@ const ReleaseDetailPage = () => {
 															<span className="text-xs text-gray-500">
 																v{pkg.version}
 															</span>
-															<span
-																className={`px-2 py-0.5 text-xs font-medium rounded ${getArchColor(pkg.architecture)}`}
-															>
+															<Badge variant={getArchVariant(pkg.architecture)}>
 																{pkg.architecture}
-															</span>
+															</Badge>
 														</div>
 														<div className="text-xs text-gray-500 mt-1 truncate">
 															{pkg.file}
@@ -1396,170 +1406,156 @@ const ReleaseDetailPage = () => {
 			</Modal>
 
 			{/* Packages and Services Grid */}
-			<div className="grid grid-cols-2 gap-6">
+			<div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
 				{/* Packages Section */}
-				<div className="space-y-4">
-					<div className="flex items-center justify-between">
-						<div className="flex items-center space-x-2">
-							<Box className="w-5 h-5 text-gray-600" />
-							<h2 className="text-lg font-semibold text-gray-900">Packages</h2>
-							<span className="text-sm text-gray-500">({packages.length})</span>
-						</div>
-						{release?.draft && (
+				<SectionCard
+					icon={Box}
+					title="Packages"
+					count={packages.length}
+					theme={SECTION_THEMES.blue}
+					actions={
+						release?.draft ? (
 							<Button
+								variant="solid"
+								tone="blue"
+								size="sm"
 								icon={<Plus className="w-4 h-4" />}
 								onClick={openAddModal}
 							>
 								Add
 							</Button>
-						)}
-					</div>
-
-					<div className="bg-white rounded border border-gray-200 overflow-hidden">
-						{packagesLoading ? (
-							<div className="p-6 text-center">
-								<div className="text-gray-500 text-sm">Loading packages...</div>
-							</div>
-						) : packages.length === 0 ? (
-							<div className="p-6 text-center">
-								<Box className="w-8 h-8 text-gray-400 mx-auto mb-2" />
-								<p className="text-sm text-gray-500">No packages found</p>
-							</div>
-						) : (
-							<div className="divide-y divide-gray-200">
-								{packages.map((pkg) => {
-									const latestVersion = getLatestVersionForPackage(pkg);
-									const isUpgrading = upgradingPackages.has(pkg.id);
-									return (
-										<div
-											key={pkg.id}
-											className="p-4 hover:bg-gray-50 transition-colors"
-										>
-											<div className="flex items-center justify-between">
-												<div className="flex items-center space-x-3 min-w-0">
-													<div className="p-2 bg-gray-100 text-gray-600 rounded flex-shrink-0">
-														<PackageIcon className="w-4 h-4" />
-													</div>
-													<div className="min-w-0">
-														<div className="flex items-center space-x-2">
-															<span className="font-medium text-gray-900 truncate">
-																{pkg.name}
-															</span>
-															<span className="text-xs text-gray-500 flex-shrink-0">
-																v{pkg.version}
-															</span>
-															{release?.draft && latestVersion && (
-																<button
-																	onClick={() => handleUpgradePackage(pkg)}
-																	disabled={isUpgrading}
-																	className={`flex items-center space-x-0.5 px-1.5 py-0.5 text-[10px] font-medium rounded-md transition-all ${
-																		isUpgrading
-																			? "bg-gray-200 text-gray-400 cursor-not-allowed"
-																			: "bg-green-100 text-green-700 hover:bg-green-200 cursor-pointer"
-																	}`}
-																	title={`Upgrade to v${latestVersion.version}`}
-																>
-																	{isUpgrading ? (
-																		<div className="w-2.5 h-2.5 border-2 border-gray-400 border-t-transparent rounded-full animate-spin"></div>
-																	) : (
-																		<>
-																			<ArrowUp className="w-2.5 h-2.5" />
-																			<span>v{latestVersion.version}</span>
-																		</>
-																	)}
-																</button>
-															)}
-														</div>
-													</div>
-												</div>
-												{release?.draft && (
-													<div className="flex items-center space-x-1 flex-shrink-0">
-														<IconButton
-															icon={<ChevronsUpDown className="w-4 h-4" />}
-															onClick={() => openReplaceModal(pkg)}
-															title="Select different version"
-														/>
-														<IconButton
-															icon={<Trash2 className="w-4 h-4" />}
-															onClick={() => handleDeletePackage(pkg.id)}
-															className="hover:text-red-600 hover:bg-red-50"
-															title="Remove package"
-														/>
-													</div>
+						) : undefined
+					}
+				>
+					{packagesLoading ? (
+						<div className="p-6 text-center">
+							<div className="text-gray-500 text-sm">Loading packages...</div>
+						</div>
+					) : packages.length === 0 ? (
+						<div className="p-6 text-center">
+							<Box className="w-8 h-8 text-gray-400 mx-auto mb-2" />
+							<p className="text-sm text-gray-500">No packages found</p>
+						</div>
+					) : (
+						packages.map((pkg) => {
+							const latestVersion = getLatestVersionForPackage(pkg);
+							const isUpgrading = upgradingPackages.has(pkg.id);
+							return (
+								<ListRow key={pkg.id}>
+									<div className="flex items-center space-x-3 min-w-0">
+										<div className="p-2 bg-gray-100 text-gray-600 rounded flex-shrink-0">
+											<PackageIcon className="w-4 h-4" />
+										</div>
+										<div className="min-w-0">
+											<div className="flex items-center space-x-2">
+												<span className="font-medium text-gray-900 truncate">
+													{pkg.name}
+												</span>
+												<span className="text-xs text-gray-500 flex-shrink-0">
+													v{pkg.version}
+												</span>
+												{release?.draft && latestVersion && (
+													<button
+														onClick={() => handleUpgradePackage(pkg)}
+														disabled={isUpgrading}
+														className={`flex items-center space-x-0.5 px-1.5 py-0.5 text-[10px] font-medium rounded-md transition-all ${
+															isUpgrading
+																? "bg-gray-200 text-gray-400 cursor-not-allowed"
+																: "bg-green-100 text-green-700 hover:bg-green-200 cursor-pointer"
+														}`}
+														title={`Upgrade to v${latestVersion.version}`}
+													>
+														{isUpgrading ? (
+															<div className="w-2.5 h-2.5 border-2 border-gray-400 border-t-transparent rounded-full animate-spin"></div>
+														) : (
+															<>
+																<ArrowUp className="w-2.5 h-2.5" />
+																<span>v{latestVersion.version}</span>
+															</>
+														)}
+													</button>
 												)}
 											</div>
 										</div>
-									);
-								})}
-							</div>
-						)}
-					</div>
-				</div>
+									</div>
+									{release?.draft && (
+										<div className="flex items-center space-x-1 flex-shrink-0">
+											<Button
+												variant="ghost"
+												tone="gray"
+												icon={<ChevronsUpDown className="w-4 h-4" />}
+												onClick={() => openReplaceModal(pkg)}
+												title="Select different version"
+											/>
+											<Button
+												variant="ghost"
+												tone="red"
+												icon={<Trash2 className="w-4 h-4" />}
+												onClick={() => handleDeletePackage(pkg.id)}
+												title="Remove package"
+											/>
+										</div>
+									)}
+								</ListRow>
+							);
+						})
+					)}
+				</SectionCard>
 
 				{/* Services Section */}
-				<div className="space-y-4">
-					<div className="flex items-center space-x-2">
-						<Cog className="w-5 h-5 text-gray-600" />
-						<h2 className="text-lg font-semibold text-gray-900">Services</h2>
-						<span className="text-sm text-gray-500">({services.length})</span>
-					</div>
-
-					<div className="bg-white rounded border border-gray-200 overflow-hidden">
-						{servicesLoading ? (
-							<div className="p-6 text-center">
-								<div className="text-gray-500 text-sm">Loading services...</div>
-							</div>
-						) : services.length === 0 ? (
-							<div className="p-6 text-center">
-								<Cog className="w-8 h-8 text-gray-400 mx-auto mb-2" />
-								<p className="text-sm text-gray-500">No services found</p>
-								<p className="text-xs text-gray-400 mt-1">
-									Extracted from .deb packages
-								</p>
-							</div>
-						) : (
-							<div className="divide-y divide-gray-200">
-								{services.map((service) => {
-									const packageName = getPackageNameForService(
-										service.package_id,
-									);
-									return (
-										<div
-											key={service.id}
-											className="p-4 hover:bg-gray-50 transition-colors"
-										>
-											<div className="flex items-center space-x-3">
-												<div className="p-2 bg-purple-100 text-purple-600 rounded flex-shrink-0">
-													<Cog className="w-4 h-4" />
-												</div>
-												<div className="min-w-0">
-													<div className="flex items-center space-x-2">
-														<span className="font-medium text-gray-900 truncate">
-															{service.service_name}
-														</span>
-														{service.watchdog_sec && (
-															<span className="flex items-center space-x-1 px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-700 rounded-full flex-shrink-0">
-																<Clock className="w-3 h-3" />
-																<span>{service.watchdog_sec}s</span>
-															</span>
-														)}
-													</div>
-													{packageName && (
-														<p className="text-xs text-gray-500 mt-1">
-															From: {packageName}
-														</p>
-													)}
-												</div>
-											</div>
+				<SectionCard
+					icon={Cog}
+					title="Services"
+					count={services.length}
+					theme={SECTION_THEMES.purple}
+				>
+					{servicesLoading ? (
+						<div className="p-6 text-center">
+							<div className="text-gray-500 text-sm">Loading services...</div>
+						</div>
+					) : services.length === 0 ? (
+						<div className="p-6 text-center">
+							<Cog className="w-8 h-8 text-gray-400 mx-auto mb-2" />
+							<p className="text-sm text-gray-500">No services found</p>
+							<p className="text-xs text-gray-400 mt-1">
+								Extracted from .deb packages
+							</p>
+						</div>
+					) : (
+						services.map((service) => {
+							const packageName = getPackageNameForService(service.package_id);
+							return (
+								<ListRow key={service.id}>
+									<div className="flex items-center space-x-3 min-w-0">
+										<div className="p-2 bg-purple-100 text-purple-600 rounded flex-shrink-0">
+											<Cog className="w-4 h-4" />
 										</div>
-									);
-								})}
-							</div>
-						)}
-					</div>
-				</div>
+										<div className="min-w-0">
+											<div className="flex items-center space-x-2">
+												<span className="font-medium text-gray-900 truncate">
+													{service.service_name}
+												</span>
+												{service.watchdog_sec && (
+													<span className="flex items-center space-x-1 px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-700 rounded-full flex-shrink-0">
+														<Clock className="w-3 h-3" />
+														<span>{service.watchdog_sec}s</span>
+													</span>
+												)}
+											</div>
+											{packageName && (
+												<p className="text-xs text-gray-500 mt-1">
+													From: {packageName}
+												</p>
+											)}
+										</div>
+									</div>
+								</ListRow>
+							);
+						})
+					)}
+				</SectionCard>
 			</div>
-		</div>
+		</PageContainer>
 	);
 };
 

--- a/dashboard/app/(private)/settings/SettingsLayout.tsx
+++ b/dashboard/app/(private)/settings/SettingsLayout.tsx
@@ -1,0 +1,53 @@
+import { Shield, Users } from "lucide-react";
+import type { ReactNode } from "react";
+import { type BadgeVariant, PageContainer, SideNav } from "@/app/components/ui";
+
+export type SettingsTab = "users" | "roles";
+
+// Stable color per role so a role reads the same on the users + roles pages.
+export const roleVariant = (role: string): BadgeVariant => {
+	if (role === "admin") return "purple";
+	if (role === "default") return "gray";
+	return "blue";
+};
+
+/**
+ * Shared scaffold for the settings sub-pages (Users / Roles). Renders a
+ * GitHub-style left sub-nav next to the active page's content.
+ */
+export function SettingsLayout({
+	activeTab,
+	children,
+}: {
+	activeTab: SettingsTab;
+	children: ReactNode;
+}) {
+	return (
+		<PageContainer>
+			<div className="flex flex-col md:flex-row gap-6 md:gap-8">
+				<aside className="md:w-56 lg:w-60 shrink-0">
+					<h2 className="px-3 mb-2 text-xs font-semibold uppercase tracking-wider text-gray-400">
+						Settings
+					</h2>
+					<SideNav
+						items={[
+							{
+								label: "Users",
+								to: "/settings/users",
+								icon: Users,
+								active: activeTab === "users",
+							},
+							{
+								label: "Roles",
+								to: "/settings/roles",
+								icon: Shield,
+								active: activeTab === "roles",
+							},
+						]}
+					/>
+				</aside>
+				<div className="flex-1 min-w-0 space-y-6">{children}</div>
+			</div>
+		</PageContainer>
+	);
+}

--- a/dashboard/app/(private)/settings/api.ts
+++ b/dashboard/app/(private)/settings/api.ts
@@ -1,0 +1,47 @@
+// Hand-written data hooks for the users/roles endpoints, mirroring the shape of
+// the Orval-generated client (app/api-client.ts). They use the same auth-aware
+// mutator and React Query so they behave identically. Once the backend is up,
+// `npm run gen-api-client` will emit equivalent `useGetUsers`/`useGetRoles`
+// hooks into api-client.ts and this file can be removed in favor of those.
+import { type UseQueryResult, useQuery } from "@tanstack/react-query";
+import { useClientMutator } from "@/app/api-client-mutator";
+
+export interface PermissionInfo {
+	action: string;
+	resource: string;
+}
+
+export interface UserWithRoles {
+	id: number;
+	email: string | null;
+	roles: string[];
+	created_at: string;
+	updated_at: string;
+}
+
+export interface RoleInfo {
+	name: string;
+	description: string;
+	inherits: string[];
+	permissions: PermissionInfo[];
+	effective_permissions: PermissionInfo[];
+}
+
+export const getGetUsersQueryKey = () => ["/users"] as const;
+export const getGetRolesQueryKey = () => ["/roles"] as const;
+
+export function useGetUsers(): UseQueryResult<UserWithRoles[], unknown> {
+	const fetcher = useClientMutator<UserWithRoles[]>();
+	return useQuery({
+		queryKey: getGetUsersQueryKey(),
+		queryFn: ({ signal }) => fetcher({ url: "/users", method: "GET", signal }),
+	});
+}
+
+export function useGetRoles(): UseQueryResult<RoleInfo[], unknown> {
+	const fetcher = useClientMutator<RoleInfo[]>();
+	return useQuery({
+		queryKey: getGetRolesQueryKey(),
+		queryFn: ({ signal }) => fetcher({ url: "/roles", method: "GET", signal }),
+	});
+}

--- a/dashboard/app/(private)/settings/roles/page.tsx
+++ b/dashboard/app/(private)/settings/roles/page.tsx
@@ -1,0 +1,90 @@
+import { Shield, ShieldCheck } from "lucide-react";
+import {
+	Badge,
+	Card,
+	LabelChip,
+	Panel,
+	SECTION_THEMES,
+} from "@/app/components/ui";
+import { type RoleInfo, useGetRoles } from "../api";
+import { roleVariant, SettingsLayout } from "../SettingsLayout";
+
+// One panel per role: description, what it inherits, and the full effective
+// permission set (its own permissions plus everything pulled in via inherits).
+const RoleCard = ({ role }: { role: RoleInfo }) => {
+	const Icon = role.name === "admin" ? ShieldCheck : Shield;
+	return (
+		<Panel
+			icon={Icon}
+			title={<span className="capitalize">{role.name}</span>}
+			theme={SECTION_THEMES[role.name === "admin" ? "purple" : "gray"]}
+			count={role.effective_permissions.length}
+			bodyClassName="p-4 space-y-3"
+		>
+			<p className="text-sm text-gray-600">{role.description}</p>
+
+			{role.inherits.length > 0 && (
+				<div className="flex flex-wrap items-center gap-1.5">
+					<span className="text-xs text-gray-500">Inherits</span>
+					{role.inherits.map((parent) => (
+						<Badge key={parent} variant={roleVariant(parent)}>
+							{parent}
+						</Badge>
+					))}
+				</div>
+			)}
+
+			<div className="space-y-1.5">
+				<span className="text-xs font-medium text-gray-500">Permissions</span>
+				<div className="flex flex-wrap gap-1.5">
+					{role.effective_permissions.map((perm) => (
+						<LabelChip
+							key={`${perm.resource}:${perm.action}`}
+							name={perm.resource}
+							value={perm.action}
+						/>
+					))}
+				</div>
+			</div>
+		</Panel>
+	);
+};
+
+const SettingsRolesPage = () => {
+	const { data: roles = [], isLoading, error } = useGetRoles();
+
+	// A 403 means the signed-in user lacks the `users:read` permission (admin).
+	const forbidden =
+		(error as { response?: { status?: number } } | null)?.response?.status ===
+		403;
+
+	return (
+		<SettingsLayout activeTab="roles">
+			{forbidden ? (
+				<Card className="overflow-hidden">
+					<div className="p-12 text-center text-gray-500">
+						<Shield className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+						<h3 className="text-lg font-medium text-gray-900 mb-2">
+							Not authorized
+						</h3>
+						<p className="text-gray-500">
+							You need the admin role to view roles.
+						</p>
+					</div>
+				</Card>
+			) : isLoading ? (
+				<Card className="overflow-hidden">
+					<div className="p-12 text-center text-gray-400">Loading...</div>
+				</Card>
+			) : (
+				<div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+					{roles.map((role) => (
+						<RoleCard key={role.name} role={role} />
+					))}
+				</div>
+			)}
+		</SettingsLayout>
+	);
+};
+
+export default SettingsRolesPage;

--- a/dashboard/app/(private)/settings/users/page.tsx
+++ b/dashboard/app/(private)/settings/users/page.tsx
@@ -1,0 +1,282 @@
+import { Search, Shield, User } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+import { Badge, Button, type ButtonTone, Card } from "@/app/components/ui";
+import { useGetUsers } from "../api";
+import { roleVariant, SettingsLayout } from "../SettingsLayout";
+
+// Role → button tone, for the filter toggles (matches the badge colors).
+const roleTone = (role: string): ButtonTone => {
+	if (role === "admin") return "purple";
+	if (role === "default") return "gray";
+	return "blue";
+};
+
+// Column template shared by the table header and every row so they stay aligned.
+// All tracks are proportional (fr) — not `auto` — so the header grid and each
+// row grid (which are separate grids) compute identical column widths.
+const COLS = "grid grid-cols-[2fr_2fr_1fr] gap-4 items-center";
+
+const UserSkeleton = () => (
+	<div className={`${COLS} px-4 py-3 animate-pulse`}>
+		<div className="flex items-center space-x-3">
+			<div className="w-8 h-8 bg-gray-200 rounded-full flex-shrink-0" />
+			<div className="h-4 bg-gray-300 rounded w-48" />
+		</div>
+		<div className="flex gap-1">
+			<div className="h-5 bg-gray-200 rounded w-16" />
+		</div>
+		<div className="h-3 bg-gray-200 rounded w-16 justify-self-end" />
+	</div>
+);
+
+const formatDate = (date: string) =>
+	new Date(date).toLocaleDateString(undefined, {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+	});
+
+const SettingsUsersPage = () => {
+	const navigate = useNavigate();
+	const [searchParams] = useSearchParams();
+	const [searchTerm, setSearchTerm] = useState("");
+	const searchInputRef = useRef<HTMLInputElement>(null);
+
+	const { data: users = [], isLoading: usersLoading, error } = useGetUsers();
+
+	useEffect(() => {
+		setSearchTerm(searchParams.get("search") || "");
+	}, [searchParams]);
+
+	// Focus search on "/" keypress, like the devices page.
+	useEffect(() => {
+		function handleKeyDown(e: KeyboardEvent) {
+			if (e.key !== "/") return;
+			if (e.ctrlKey || e.metaKey || e.altKey) return;
+			const target = e.target as HTMLElement;
+			if (
+				target.tagName === "INPUT" ||
+				target.tagName === "TEXTAREA" ||
+				target.tagName === "SELECT" ||
+				target.isContentEditable
+			)
+				return;
+			e.preventDefault();
+			searchInputRef.current?.focus();
+		}
+		document.addEventListener("keydown", handleKeyDown);
+		return () => document.removeEventListener("keydown", handleKeyDown);
+	}, []);
+
+	// Filter state lives in the URL so a view is shareable.
+	const roleFilter = searchParams.get("role") ?? "";
+
+	const updateParams = (mutate: (params: URLSearchParams) => void) => {
+		const params = new URLSearchParams(searchParams);
+		mutate(params);
+		const qs = params.toString();
+		navigate(qs ? `/settings/users?${qs}` : "/settings/users", {
+			preventScrollReset: true,
+		});
+	};
+
+	const handleSearchChange = (value: string) => {
+		setSearchTerm(value);
+		updateParams((params) => {
+			if (value) params.set("search", value);
+			else params.delete("search");
+		});
+	};
+
+	const toggleRole = (name: string) =>
+		updateParams((params) => {
+			if (!name || roleFilter === name) params.delete("role");
+			else params.set("role", name);
+		});
+
+	// A 403 means the signed-in user lacks the `users:read` permission (admin).
+	const forbidden =
+		(error as { response?: { status?: number } } | null)?.response?.status ===
+		403;
+
+	// Roles to offer as filters: those actually assigned to a user.
+	const roleNames = Array.from(new Set(users.flatMap((u) => u.roles))).sort();
+
+	const term = searchTerm.toLowerCase();
+	const visibleUsers = users
+		.filter((user) => {
+			const matchesSearch =
+				term === "" ||
+				(user.email ?? "").toLowerCase().includes(term) ||
+				user.roles.some((role) => role.toLowerCase().includes(term));
+			const matchesRole = roleFilter === "" || user.roles.includes(roleFilter);
+			return matchesSearch && matchesRole;
+		})
+		// Always sorted by role: the user's first (alphabetically-first) role,
+		// with role-less users last, then by email within a role.
+		.sort((a, b) => {
+			const ar = a.roles[0] ?? "~";
+			const br = b.roles[0] ?? "~";
+			return (
+				ar.localeCompare(br) || (a.email ?? "").localeCompare(b.email ?? "")
+			);
+		});
+
+	return (
+		<SettingsLayout activeTab="users">
+			{/* Search + filters in one row, like the devices page */}
+			<div className="flex flex-wrap items-center gap-3">
+				<div className="relative">
+					<Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4 pointer-events-none" />
+					<input
+						ref={searchInputRef}
+						type="text"
+						placeholder="Search users..."
+						value={searchTerm}
+						onChange={(e) => handleSearchChange(e.target.value)}
+						className="pl-10 pr-10 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm text-gray-900 placeholder-gray-400"
+					/>
+					{!searchTerm && (
+						<kbd className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 text-xs border border-gray-300 rounded px-1 py-0.5 font-mono leading-none pointer-events-none">
+							/
+						</kbd>
+					)}
+				</div>
+
+				{/* Role filter toggles */}
+				{!usersLoading && !forbidden && roleNames.length > 0 && (
+					<div className="flex flex-wrap items-center gap-1.5">
+						<Button
+							variant={roleFilter === "" ? "solid" : "soft"}
+							tone={roleFilter === "" ? "blue" : "gray"}
+							onClick={() => toggleRole("")}
+						>
+							All
+						</Button>
+						{roleNames.map((name) => (
+							<Button
+								key={name}
+								className="capitalize"
+								variant={roleFilter === name ? "solid" : "soft"}
+								tone={roleFilter === name ? roleTone(name) : "gray"}
+								onClick={() => toggleRole(name)}
+							>
+								{name}
+							</Button>
+						))}
+					</div>
+				)}
+
+				{!usersLoading && !forbidden && (
+					<span className="ml-auto text-sm text-gray-500">
+						{visibleUsers.length} user{visibleUsers.length !== 1 ? "s" : ""}
+					</span>
+				)}
+			</div>
+
+			{/* Users table */}
+			<Card className="overflow-hidden">
+				{forbidden ? (
+					<div className="p-12 text-center text-gray-500">
+						<Shield className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+						<h3 className="text-lg font-medium text-gray-900 mb-2">
+							Not authorized
+						</h3>
+						<p className="text-gray-500">
+							You need the admin role to view users.
+						</p>
+					</div>
+				) : (
+					<>
+						{/* Header row */}
+						<div className="bg-gray-50 px-4 py-3 border-b border-gray-200">
+							<div
+								className={`${COLS} text-xs font-medium text-gray-500 uppercase tracking-wide`}
+							>
+								<div>User</div>
+								<div>Roles</div>
+								<div
+									className="justify-self-end"
+									title="When the user first signed in"
+								>
+									Joined
+								</div>
+							</div>
+						</div>
+
+						{usersLoading ? (
+							<div className="divide-y divide-gray-100">
+								{Array.from({ length: 6 }, (_, i) => (
+									<UserSkeleton key={i} />
+								))}
+							</div>
+						) : visibleUsers.length === 0 ? (
+							<div className="p-12 text-center text-gray-500">
+								<User className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+								<h3 className="text-lg font-medium text-gray-900 mb-2">
+									{searchTerm || roleFilter
+										? "No matching users found"
+										: "No users found"}
+								</h3>
+								<p className="text-gray-500">
+									{searchTerm || roleFilter
+										? "Try adjusting your search or filters."
+										: "No users have signed in yet."}
+								</p>
+							</div>
+						) : (
+							<div className="divide-y divide-gray-100">
+								{visibleUsers.map((user) => (
+									<div
+										key={user.id}
+										className={`${COLS} px-4 py-3 hover:bg-gray-50 transition-colors`}
+									>
+										<div className="flex items-center space-x-3 min-w-0">
+											<div className="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
+												<User className="w-4 h-4 text-gray-500" />
+											</div>
+											<div className="flex items-baseline gap-2 min-w-0">
+												<span className="text-sm text-gray-900 truncate">
+													{user.email ?? (
+														<span className="text-gray-400 italic">
+															no email
+														</span>
+													)}
+												</span>
+												<span className="text-xs text-gray-400 flex-shrink-0">
+													#{user.id}
+												</span>
+											</div>
+										</div>
+										<div className="flex flex-wrap items-center gap-1">
+											{user.roles.length === 0 ? (
+												<span className="text-xs text-gray-400 italic">
+													no roles
+												</span>
+											) : (
+												user.roles.map((role) => (
+													<Badge key={role} variant={roleVariant(role)}>
+														{role}
+													</Badge>
+												))
+											)}
+										</div>
+										<span
+											className="text-xs text-gray-500 tabular-nums justify-self-end"
+											title="When the user first signed in"
+										>
+											{formatDate(user.created_at)}
+										</span>
+									</div>
+								))}
+							</div>
+						)}
+					</>
+				)}
+			</Card>
+		</SettingsLayout>
+	);
+};
+
+export default SettingsUsersPage;

--- a/dashboard/app/components/ui/button.tsx
+++ b/dashboard/app/components/ui/button.tsx
@@ -93,7 +93,7 @@ export function Button({
 	className?: string;
 	children?: ReactNode;
 }) {
-	const cls = `inline-flex items-center justify-center font-medium rounded-lg transition-all cursor-pointer active:scale-[.98] ${SIZE_STYLES[size]} ${VARIANT_EXTRA[variant]} ${BUTTON_STYLES[variant][tone]} ${className}`;
+	const cls = `inline-flex items-center justify-center font-medium rounded-lg transition-colors duration-100 cursor-pointer active:scale-[.98] ${SIZE_STYLES[size]} ${VARIANT_EXTRA[variant]} ${BUTTON_STYLES[variant][tone]} ${className}`;
 	const inner = (
 		<>
 			{loading ? <Loader2 className="w-4 h-4 animate-spin" /> : icon}

--- a/dashboard/app/components/ui/detail.tsx
+++ b/dashboard/app/components/ui/detail.tsx
@@ -67,6 +67,54 @@ export function TabNav({ items }: { items: TabItem[] }) {
 	);
 }
 
+export interface SideNavItem {
+	label: string;
+	to: string;
+	icon?: IconComponent;
+	active?: boolean;
+}
+
+/** Vertical settings sub-nav: a stacked list of links with an icon, label and
+ *  an animated left accent bar on the active item — matching the main sidebar's
+ *  look (blue active state, icon lift on hover). The active item renders as
+ *  static text; the rest are router links. */
+export function SideNav({ items }: { items: SideNavItem[] }) {
+	return (
+		<nav className="space-y-1">
+			{items.map((item) => {
+				const Icon = item.icon;
+				const cls = `group/side relative flex items-center gap-3 h-10 rounded-md px-3 text-sm transition-all duration-200 cursor-pointer ${
+					item.active
+						? "bg-blue-50 text-blue-700 font-medium"
+						: "text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+				}`;
+				const inner = (
+					<>
+						<span
+							className={`absolute left-0 top-1.5 bottom-1.5 w-[3px] rounded-r-full bg-blue-600 transition-all duration-300 ease-out ${
+								item.active ? "opacity-100 scale-y-100" : "opacity-0 scale-y-0"
+							}`}
+						/>
+						{Icon && (
+							<Icon className="w-[18px] h-[18px] shrink-0 transition-transform duration-200 group-hover/side:scale-110" />
+						)}
+						<span className="truncate">{item.label}</span>
+					</>
+				);
+				return item.active ? (
+					<span key={item.to} className={cls} aria-current="page">
+						{inner}
+					</span>
+				) : (
+					<Link key={item.to} to={item.to} className={cls}>
+						{inner}
+					</Link>
+				);
+			})}
+		</nav>
+	);
+}
+
 /** A label/value row for detail panels (`label` on the left, `children` on
  *  the right). Optional leading `icon` next to the label. */
 export function InfoRow({

--- a/dashboard/app/components/ui/index.ts
+++ b/dashboard/app/components/ui/index.ts
@@ -8,7 +8,14 @@ export {
 } from "./button";
 export { Card, ListRow, Panel, SectionCard, ViewAllFooter } from "./card";
 export { CountryFlag } from "./country-flag";
-export { BackLink, InfoRow, type TabItem, TabNav } from "./detail";
+export {
+	BackLink,
+	InfoRow,
+	SideNav,
+	type SideNavItem,
+	type TabItem,
+	TabNav,
+} from "./detail";
 export { PageContainer } from "./page-container";
 export { SearchInput } from "./search-input";
 export { StatCard } from "./stat-card";

--- a/dashboard/app/not-found/page.tsx
+++ b/dashboard/app/not-found/page.tsx
@@ -1,0 +1,55 @@
+import { Compass, Home, MoveLeft } from "lucide-react";
+import { useNavigate } from "react-router";
+import { Button, Card } from "@/app/components/ui";
+
+export default function NotFoundPage() {
+	const navigate = useNavigate();
+
+	return (
+		<div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+			<div className="w-full max-w-md">
+				<Card className="p-10">
+					<div className="flex flex-col items-center text-center">
+						<div className="flex h-16 w-16 items-center justify-center rounded-xl bg-blue-50 text-blue-600 shadow-sm">
+							<Compass className="h-8 w-8" />
+						</div>
+
+						<p className="mt-6 text-6xl font-bold tracking-tight text-gray-900">
+							404
+						</p>
+						<h1 className="mt-2 text-xl font-semibold text-gray-900">
+							Page not found
+						</h1>
+						<p className="mt-2 text-sm text-gray-500">
+							The page you&#39;re looking for doesn&#39;t exist or may have been
+							moved.
+						</p>
+
+						<div className="mt-8 flex w-full flex-col gap-3 sm:flex-row">
+							<Button
+								tone="gray"
+								variant="soft"
+								size="md"
+								icon={<MoveLeft className="h-4 w-4" />}
+								onClick={() => navigate(-1)}
+								className="w-full py-2.5"
+							>
+								Go back
+							</Button>
+							<Button
+								tone="blue"
+								variant="solid"
+								size="md"
+								icon={<Home className="h-4 w-4" />}
+								onClick={() => navigate("/dashboard")}
+								className="w-full py-2.5"
+							>
+								Dashboard
+							</Button>
+						</div>
+					</div>
+				</Card>
+			</div>
+		</div>
+	);
+}

--- a/dashboard/src/router.tsx
+++ b/dashboard/src/router.tsx
@@ -29,6 +29,10 @@ const Modems = lazy(() => import("@/app/(private)/modems/page"));
 const NetworkTesting = lazy(
 	() => import("@/app/(private)/network-testing/page"),
 );
+const SettingsUsers = lazy(() => import("@/app/(private)/settings/users/page"));
+const SettingsRoles = lazy(() => import("@/app/(private)/settings/roles/page"));
+
+const NotFound = lazy(() => import("@/app/not-found/page"));
 
 const ComponentsLayout = lazy(() => import("@/app/components/layout"));
 const ButtonsPage = lazy(() => import("@/app/components/buttons/page"));
@@ -78,6 +82,9 @@ export const router = createBrowserRouter([
 			{ path: "/ip-addresses", element: withSuspense(<IpAddresses />) },
 			{ path: "/modems", element: withSuspense(<Modems />) },
 			{ path: "/network-testing", element: withSuspense(<NetworkTesting />) },
+			{ path: "/settings", element: <Navigate to="/settings/users" replace /> },
+			{ path: "/settings/users", element: withSuspense(<SettingsUsers />) },
+			{ path: "/settings/roles", element: withSuspense(<SettingsRoles />) },
 		],
 	},
 	{
@@ -94,5 +101,9 @@ export const router = createBrowserRouter([
 			{ path: "/components/overlay", element: withSuspense(<OverlayPage />) },
 			{ path: "/components/text", element: withSuspense(<TextPage />) },
 		],
+	},
+	{
+		path: "*",
+		element: withSuspense(<NotFound />),
 	},
 ]);


### PR DESCRIPTION
…est flow refactor

  Add a Settings area, a device variables panel, a 404 page, and migrate the
  distributions/releases pages onto the shared UI kit.

  Settings (users & roles):
  - api: GET /users and GET /roles endpoints behind a new users:read permission
  - api: document and grant users:read in roles.toml
  - dashboard: /settings/users and /settings/roles pages with search, role filters, and a shared SettingsLayout sub-nav
  - dashboard: hand-written useGetUsers/useGetRoles hooks (to be replaced by the generated client)

  Device variables:
  - dashboard: masked-by-default secrets panel on the device detail page
  - dashboard: rework device header for responsiveness; place Security Audit and Location side-by-side

  Network testing:
  - dashboard: move device selection into StartTestModal; landing is now search + New Test + history
  - dashboard: render session history as a table; drop useSessionsByDevices

  UI:
  - dashboard: add SideNav component; add a 404 page and catch-all route
  - dashboard: migrate distributions/releases pages to the shared ui kit (PageContainer, Card, SectionCard, ListRow, Badge, Toast, Button variant/tone API)