### PR TITLE
fix: "Back to Devices" always returns to the originating device list URL

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @LudeeD @Alw3ys @dduuukk
+* @LudeeD @Alw3ys @dduuukk @wajntr-a

--- a/dashboard/app/(private)/devices/[serial]/DeviceDetailLayout.tsx
+++ b/dashboard/app/(private)/devices/[serial]/DeviceDetailLayout.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { useNavigate } from "react-router";
+import { useLocation } from "react-router";
 import type { Device } from "@/app/api-client";
 import { BackLink, TabNav } from "@/app/components/ui";
 import DeviceHeader from "./DeviceHeader";
@@ -28,7 +28,9 @@ export function DeviceDetailLayout({
 	fill?: boolean;
 	children: ReactNode;
 }) {
-	const navigate = useNavigate();
+	const back =
+		(useLocation().state as { back?: string } | null)?.back ?? "/devices";
+	const backState = { back };
 
 	const base = "flex-1 px-4 sm:px-6 lg:px-8 py-6 space-y-6";
 
@@ -40,7 +42,7 @@ export function DeviceDetailLayout({
 					: `${base} overflow-y-auto`
 			}
 		>
-			<BackLink onClick={() => navigate(-1)}>Back to Devices</BackLink>
+			<BackLink to={back}>Back to Devices</BackLink>
 
 			{device && <DeviceHeader device={device} serial={serial} />}
 
@@ -50,16 +52,19 @@ export function DeviceDetailLayout({
 						label: "Overview",
 						to: `/devices/${serial}`,
 						active: activeTab === "overview",
+						state: backState,
 					},
 					{
 						label: "Commands",
 						to: `/devices/${serial}/commands`,
 						active: activeTab === "commands",
+						state: backState,
 					},
 					{
 						label: "Services",
 						to: `/devices/${serial}/services`,
 						active: activeTab === "services",
+						state: backState,
 					},
 				]}
 			/>

--- a/dashboard/app/(private)/devices/page.tsx
+++ b/dashboard/app/(private)/devices/page.tsx
@@ -17,7 +17,7 @@ import {
 	XCircle,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router";
+import { useLocation, useNavigate, useSearchParams } from "react-router";
 import LabelAutocomplete from "@/app/components/LabelAutocomplete";
 import { Modal } from "@/app/components/modal";
 import NetworkQualityIndicator from "@/app/components/NetworkQualityIndicator";
@@ -143,6 +143,7 @@ const PAGE_SIZE = 100;
 const DevicesPage = () => {
 	const { isAuthenticated } = useAuth0();
 	const navigate = useNavigate();
+	const location = useLocation();
 	const [searchParams] = useSearchParams();
 	const queryClient = useQueryClient();
 	const [searchTerm, setSearchTerm] = useState("");
@@ -1147,7 +1148,11 @@ const DevicesPage = () => {
 								<div
 									key={device.id}
 									className="block px-4 py-3 hover:bg-gray-50 cursor-pointer transition-colors"
-									onClick={() => navigate(`/devices/${device.serial_number}`)}
+									onClick={() =>
+										navigate(`/devices/${device.serial_number}`, {
+											state: { back: location.pathname + location.search },
+										})
+									}
 								>
 									<div className="grid grid-cols-[auto_2fr_2fr_2fr_1fr_1fr] gap-4 items-center">
 										<div className="w-6 flex items-center justify-center">

--- a/dashboard/app/components/ui/detail.tsx
+++ b/dashboard/app/components/ui/detail.tsx
@@ -40,6 +40,7 @@ export interface TabItem {
 	label: string;
 	to?: string;
 	active?: boolean;
+	state?: unknown;
 }
 
 /** Underlined tab bar used across the device detail subpages. The active tab
@@ -53,7 +54,12 @@ export function TabNav({ items }: { items: TabItem[] }) {
 						? "py-2 px-1 border-b-2 border-blue-500 text-blue-600 font-medium text-sm"
 						: "py-2 px-1 border-b-2 border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 font-medium text-sm transition-colors cursor-pointer";
 					return item.to && !item.active ? (
-						<Link key={item.label} to={item.to} className={cls}>
+						<Link
+							key={item.label}
+							to={item.to}
+							state={item.state}
+							className={cls}
+						>
 							{item.label}
 						</Link>
 					) : (


### PR DESCRIPTION
## What
"Back to Devices" on device detail pages now always returns to the exact device list URL the user came from, including any active filters, regardless of how many tabs were visited.

## Why
Closes #465

Each tab switch on the device detail page (`/devices/:serial` → `/devices/:serial/commands`) pushed a new browser history entry. `navigate(-1)` only stepped back one entry, so clicking "Back to Devices" after a tab switch landed on the previous tab instead of the device list.

## Approach
The originating device-list URL is passed as React Router location state (`state.back`) when navigating from the device list into a device detail page. `DeviceDetailLayout` reads this state and uses it as the `to` prop on `BackLink`. Each tab link forwards `state.back` so it is not dropped on tab switches.

Fallback when state is absent (direct URL navigation): `BackLink` goes to `/devices`.

Rejected: `navigate(-1)` as fallback — unpredictable for deep-linked pages. URL-encoding the back URL in query params — leaks routing into URLs and would require changes to filter logic.

## Testing
- [x] Manual: visit `/devices?online=online`, click a device, switch tabs, click "Back to Devices" — lands on `/devices?online=online`
- [x] Manual: navigate directly to `/devices/:serial` via the URL bar, click "Back to Devices" — lands on `/devices`
- [x] Tab switching continues to work normally

## Checklist
- [x] No unintended side effects on adjacent features (`BackLink` and `TabNav` usages in releases and distributions pages verified — unaffected)
- [x] Breaking change? No
- [x] Docs / changelog updated if user-facing — N/A