### PR TITLE
Add fast smithd dev-deploy workflow for Docker devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,22 @@ seed:
 debug.smithd:
 	cargo build --release -p smith
 	sudo ln -sf $(CURDIR)/target/release/smithd /usr/bin/smithd
+
+DEVICES ?= $(shell docker ps --filter "name=smith-device" --format "{{.Names}}")
+
+watch.smithd:
+	cargo watch -s "make deploy.smithd" -w smithd -w models
+
+deploy.smithd:
+	docker compose up -d smithd-builder
+	docker exec smith-smithd-builder cargo build --package smith --bin smithd
+	docker cp smith-smithd-builder:/app/target/debug/smithd /tmp/smithd-deploy
+	@pids=""; status=0; \
+	for device in $(DEVICES); do \
+		(echo "Deploying to $$device..." && \
+		docker cp /tmp/smithd-deploy $$device:/usr/bin/smithd && \
+		docker exec $$device systemctl restart smithd) & \
+		pids="$$pids $$!"; \
+	done; \
+	for pid in $$pids; do wait $$pid || status=1; done; \
+	exit $$status

--- a/compose.yaml
+++ b/compose.yaml
@@ -89,6 +89,20 @@ services:
       - api
       - bore
 
+  smithd-builder:
+    build:
+      context: .
+      dockerfile: smithd/dev.Dockerfile
+      target: toolchain
+      args:
+        BASE_IMAGE: ${DEVICE_BASE_IMAGE:-nvcr.io/nvidia/l4t-base:r36.2.0}
+    container_name: smith-smithd-builder
+    volumes:
+      - .:/app
+      - smithd-cargo-registry:/root/.cargo/registry
+      - smithd-cargo-git:/root/.cargo/git
+      - smithd-target:/app/target
+
   dashboard:
     build:
       context: ./dashboard
@@ -118,3 +132,6 @@ volumes:
   target-cache:
   postgres-data:
   node_modules-cache:
+  smithd-cargo-registry:
+  smithd-cargo-git:
+  smithd-target:

--- a/smithd/dev.Dockerfile
+++ b/smithd/dev.Dockerfile
@@ -8,11 +8,13 @@
 #   docker build --build-arg BASE_IMAGE=ubuntu:22.04 -f smithd/dev.Dockerfile .
 ARG BASE_IMAGE=nvcr.io/nvidia/l4t-base:r36.2.0
 
-FROM ${BASE_IMAGE} AS builder
+# Stage 1: toolchain - just the build environment, no source code
+# Used directly by the smithd-builder service (with source mounted as a volume)
+FROM ${BASE_IMAGE} AS toolchain
 
 ARG RUST_VERSION=1.91.0
 
-WORKDIR /build
+WORKDIR /app
 
 # Install build dependencies and Rust
 RUN apt-get update && apt-get install -y \
@@ -28,6 +30,11 @@ RUN apt-get update && apt-get install -y \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_VERSION}
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+CMD ["tail", "-f", "/dev/null"]
+
+# Stage 2: builder - compiles the binaries for the device image
+FROM toolchain AS builder
+
 # Copy the workspace
 COPY . .
 
@@ -35,7 +42,7 @@ COPY . .
 RUN cargo build --package smith --bin smithd
 RUN cargo build --package smith-updater
 
-# Runtime stage - Linux for tegra to emulate real devices
+# Stage 3: runtime - the actual device container
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
@@ -74,8 +81,8 @@ RUN echo 'PasswordAuthentication no' >> /etc/ssh/sshd_config
 RUN mkdir -p /root/.ssh
 
 # Copy binaries from builder
-COPY --from=builder /build/target/debug/smithd /usr/bin/smithd
-COPY --from=builder /build/target/debug/smith-updater /usr/bin/smith-updater
+COPY --from=builder /app/target/debug/smithd /usr/bin/smithd
+COPY --from=builder /app/target/debug/smith-updater /usr/bin/smith-updater
 
 # Copy systemd service files
 COPY smithd/debian/smithd.service /etc/systemd/system/smithd.service


### PR DESCRIPTION
## What
Add an incremental deploy path for smithd into running Docker device containers, replacing the 5-minute `docker compose build device` cycle with a workflow that takes seconds after the first warm build.

## Why
Iterating on smithd during local development required a full Docker image rebuild on every change (~5 min). This made the inner loop impractical.

## Approach
Introduces a persistent `smithd-builder` service in compose: an ubuntu:22.04 container with Rust installed and the source tree mounted as a volume. This sidesteps the glibc mismatch between the host (2.39) and device containers (2.35).

`dev.Dockerfile` is refactored from 2 stages to 3:
- `toolchain`: ubuntu:22.04 + Rust, no source. Used by `smithd-builder` (stays alive with `tail -f /dev/null`).
- `builder`: extends toolchain with `COPY` + `cargo build`. Used to bake the binary into the device image.
- `runtime`: unchanged, copies binary from `builder`.

Two new Makefile targets:
- `make deploy.smithd`: builds inside `smithd-builder` (incremental, warm cargo cache), copies the binary in parallel to all running device containers via `docker cp`, restarts smithd via `systemctl restart`.
- `make watch.smithd`: runs `cargo watch` on the host, triggers `deploy.smithd` on every save in `smithd/` or `models/`.

`DEVICES` defaults to all running `smith-device-*` containers, overridable: `make deploy.smithd DEVICES=smith-device-1`.

## Testing
- [x] Tests pass
- [x] `make deploy.smithd` builds and deploys to all device containers after first warm build
- [x] `make watch.smithd` triggers auto-deploy on file save
- [x] `docker compose up -d --build device` still works as before (full image rebuild path unchanged)

## Checklist
- [x] No unintended side effects on adjacent features
- [x] Breaking change? No — existing workflows unchanged, new targets are additive
- [x] Docs / changelog updated if user-facing