### PR TITLE
fix: sm run --recipe calls trigger endpoint, not bundles

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -664,6 +664,27 @@ impl SmithAPI {
         Ok(recipes)
     }
 
+    pub async fn trigger_recipe(
+        &self,
+        recipe_id: i32,
+        device_ids: Vec<i32>,
+    ) -> Result<BundleReceipt> {
+        let client = Client::new();
+        let receipt = client
+            .post(format!(
+                "{}/commands/recipes/{recipe_id}/trigger",
+                self.domain
+            ))
+            .header("Authorization", format!("Bearer {}", &self.bearer_token))
+            .json(&serde_json::json!({ "devices": device_ids }))
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(receipt)
+    }
+
     pub async fn approve_device(&self, device_id: u64) -> Result<()> {
         let client = Client::new();
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,6 +18,7 @@ use clap::{CommandFactory, Parser};
 use clap_complete::generate;
 use colored::Colorize;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use models::command::BundleReceipt;
 use models::device::{Device, DeviceFilter};
 use smith::utils::schema;
 use std::{
@@ -366,19 +367,29 @@ async fn resolve_target_devices(
     resolve_devices_from_selector(api, &selector).await
 }
 
-/// Issue a bundle of commands to the given (already resolved, deduplicated, and
-/// confirmed) devices, then optionally poll the bundle until every command
-/// completes. The bundle receipt tells us exactly which `command_queue` rows we
-/// created, so tracking is precise even with multiple commands per device.
-async fn issue_bundle(
+fn render_command_output(payload: &serde_json::Value) -> String {
+    if let Some(stdout) = payload["FreeForm"]["stdout"].as_str() {
+        stdout.to_string()
+    } else if let Some(variant) = payload.as_str() {
+        format!("({variant})")
+    } else {
+        payload
+            .as_object()
+            .and_then(|m| m.keys().next())
+            .map(|k| format!("({k})"))
+            .unwrap_or_else(|| String::from("(completed)"))
+    }
+}
+
+/// Poll a bundle until every command completes and display results. The bundle
+/// receipt tells us exactly which `command_queue` rows were created, so
+/// tracking is precise even with multiple commands per device.
+async fn poll_bundle(
     api: &SmithAPI,
     devices: &[Device],
-    commands: Vec<schema::SafeCommandRequest>,
+    receipt: BundleReceipt,
     wait: bool,
 ) -> anyhow::Result<()> {
-    let device_ids: Vec<i32> = devices.iter().map(|d| d.id).collect();
-    let receipt = api.send_bundle(device_ids, commands).await?;
-
     let serials: HashMap<i32, String> = devices
         .iter()
         .map(|d| (d.id, d.serial_number.clone()))
@@ -485,12 +496,8 @@ async fn issue_bundle(
                 ));
             }
 
-            if let Some(output) = &response.response {
-                let output = output["FreeForm"]["stdout"]
-                    .as_str()
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| String::from("(no output)"));
-                results[idx].2 = output;
+            if let Some(payload) = &response.response {
+                results[idx].2 = render_command_output(payload);
                 pb.finish_with_message(format!(
                     "{} [{}:{}] Completed ✓",
                     serial.bright_green(),
@@ -519,6 +526,19 @@ async fn issue_bundle(
     }
 
     Ok(())
+}
+
+/// Send a command bundle to the given devices, then poll until every command
+/// completes. Convenience wrapper around `poll_bundle` for the freeform path.
+async fn issue_bundle(
+    api: &SmithAPI,
+    devices: &[Device],
+    commands: Vec<schema::SafeCommandRequest>,
+    wait: bool,
+) -> anyhow::Result<()> {
+    let device_ids: Vec<i32> = devices.iter().map(|d| d.id).collect();
+    let receipt = api.send_bundle(device_ids, commands).await?;
+    poll_bundle(api, devices, receipt, wait).await
 }
 
 const TUNNEL_CMD_LOOKBACK: u32 = 20;
@@ -1672,11 +1692,7 @@ async fn main() -> anyhow::Result<()> {
                     println!("Fetched: {}", command.fetched);
 
                     if let Some(response) = command.response {
-                        if let Some(stdout) = response["FreeForm"]["stdout"].as_str() {
-                            println!("Output:\n{}", stdout);
-                        } else {
-                            println!("Status: Completed (no output)");
-                        }
+                        println!("Output:\n{}", render_command_output(&response));
                     } else {
                         println!("Status: Pending");
                     }
@@ -1832,6 +1848,7 @@ async fn main() -> anyhow::Result<()> {
                 // Build the command list and a human label, from either a saved
                 // recipe or a free-form command (args after -- or stdin).
                 let cmd_from_stdin;
+                let mut recipe_id: Option<i32> = None;
                 let (commands, label) = if let Some(key) = recipe {
                     cmd_from_stdin = false;
                     let recipe = api
@@ -1844,17 +1861,23 @@ async fn main() -> anyhow::Result<()> {
                         })
                         .ok_or_else(|| anyhow::anyhow!("No recipe found matching '{}'", key))?;
 
-                    let commands: Vec<schema::SafeCommandRequest> =
-                        serde_json::from_value(recipe.commands).with_context(|| {
-                            format!("Recipe '{}' has invalid commands", recipe.name)
-                        })?;
-
-                    if commands.is_empty() {
+                    let cmd_count = recipe
+                        .commands
+                        .as_array()
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "Recipe '{}' has malformed commands (not a JSON array)",
+                                recipe.name
+                            )
+                        })?
+                        .len();
+                    if cmd_count == 0 {
                         bail!("Recipe '{}' has no commands", recipe.name);
                     }
 
-                    let label = format!("recipe '{}' ({} command(s))", recipe.name, commands.len());
-                    (commands, label)
+                    let label = format!("recipe '{}' ({} command(s))", recipe.name, cmd_count);
+                    recipe_id = Some(recipe.id);
+                    (vec![], label)
                 } else {
                     let cmd_string = if !command.is_empty() {
                         // Command provided via args after --, validate that -- was actually present
@@ -1963,7 +1986,13 @@ async fn main() -> anyhow::Result<()> {
 
                 println!();
 
-                issue_bundle(&api, &target_devices, commands, wait).await?;
+                if let Some(id) = recipe_id {
+                    let device_ids: Vec<i32> = target_devices.iter().map(|d| d.id).collect();
+                    let receipt = api.trigger_recipe(id, device_ids).await?;
+                    poll_bundle(&api, &target_devices, receipt, wait).await?;
+                } else {
+                    issue_bundle(&api, &target_devices, commands, wait).await?;
+                }
             }
             Commands::Label {
                 selector,


### PR DESCRIPTION
## What
`sm run --recipe` now calls `POST /commands/recipes/{id}/trigger` instead of
`POST /commands/bundles`, so default-role users can trigger recipes that
contain privileged commands.

## Why
Closes #489

A user with the `default` role has `recipes:trigger` permission but not
`commands:freeform`. The CLI was bypassing the trigger endpoint and
submitting recipe commands directly to `/commands/bundles`, which runs
`authorize_commands` on every command individually. Any recipe containing a
`FreeForm` step would therefore return 403 for default-role users, making
recipes with privileged steps unusable outside of admin accounts.

## Approach
Two changes in the CLI:

**`cli/src/api.rs`**: added `SmithAPI::trigger_recipe(recipe_id, device_ids)`
which calls `POST /commands/recipes/{id}/trigger`. Response is a
`BundleReceipt`, identical in shape to the one returned by `/commands/bundles`,
so downstream polling is unchanged.

**`cli/src/main.rs`**: extracted `poll_bundle` from the monolithic
`issue_bundle` helper so both the recipe path and the freeform path can share
the same progress-bar and polling logic without duplication. `issue_bundle`
becomes a thin wrapper around `send_bundle` + `poll_bundle`. In the
`Commands::Run` recipe branch, dispatch now branches on whether a `recipe_id`
was resolved: if so, `trigger_recipe` + `poll_bundle`; otherwise the existing
`issue_bundle` path (freeform, unchanged).

Deserializing recipe commands client-side was removed entirely — the trigger
endpoint owns that responsibility server-side.

Rejected alternative: inlining the polling block in the recipe branch would
have duplicated ~80 lines of progress-bar code.

## Testing
- [x] `cargo clippy -p cli -- -Dwarnings` passes
- [x] Manual smoke test:
  - Created recipe `smoke-test` with a `FreeForm` step (`echo hello from recipe`) + `Ping`
  - Downgraded own role to `default`
  - `sm run --recipe smoke-test <device>` succeeded (API log confirms `POST /commands/recipes/1/trigger`)
  - `sm run <device> -- echo hello` correctly returned 403 (freeform still blocked)
  - `sm run --recipe smoke-test --wait <device>` polled to completion correctly
  - `sm run --recipe nonexistent <device>` returned "No recipe found matching" cleanly

## Checklist
- [x] No unintended side effects on adjacent features
- [x] Breaking change? No
- [x] Docs / changelog updated if user-facing