### PR TITLE
Add device network intent CRUD and apply endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6796,6 +6796,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,4 @@ sqlx = { version = "0.7", features = [
     "uuid",
     "ipnetwork",
 ] }
-utoipa = { version = "5", features = ["chrono"] }
+utoipa = { version = "5", features = ["chrono", "uuid"] }

--- a/api/.sqlx/query-0d61e715d355c970fc9d5c7506e64fcea14eb943263c850ae463316528f78483.json
+++ b/api/.sqlx/query-0d61e715d355c970fc9d5c7506e64fcea14eb943263c850ae463316528f78483.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            dni.priority,\n            n.ssid,\n            n.name,\n            n.password\n        FROM device_network_intent dni\n        JOIN network n ON n.id = dni.network_id\n        WHERE dni.device_id = $1\n        ORDER BY dni.priority ASC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "ssid",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "password",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      true
+    ]
+  },
+  "hash": "0d61e715d355c970fc9d5c7506e64fcea14eb943263c850ae463316528f78483"
+}

--- a/api/.sqlx/query-1784039c22e1806207c4de62c2341c0fa448f2aa475faedc9d6f2ea75e87265a.json
+++ b/api/.sqlx/query-1784039c22e1806207c4de62c2341c0fa448f2aa475faedc9d6f2ea75e87265a.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE device SET intent_version = intent_version + 1 WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1784039c22e1806207c4de62c2341c0fa448f2aa475faedc9d6f2ea75e87265a"
+}

--- a/api/.sqlx/query-2dcdef6c918e1d3f83295f3418920e5e8d46a128ffe20e3aaf976844d12dbcdf.json
+++ b/api/.sqlx/query-2dcdef6c918e1d3f83295f3418920e5e8d46a128ffe20e3aaf976844d12dbcdf.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id FROM device\n        WHERE\n            CASE\n                WHEN $1 ~ '^[0-9]+$' AND length($1) <= 9 THEN\n                    id = $1::int4\n                ELSE\n                    serial_number = $1\n            END\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "2dcdef6c918e1d3f83295f3418920e5e8d46a128ffe20e3aaf976844d12dbcdf"
+}

--- a/api/.sqlx/query-2f010807a09820ddfd4a7a4fda103692962f8542041f4b98be1f10ea3345098a.json
+++ b/api/.sqlx/query-2f010807a09820ddfd4a7a4fda103692962f8542041f4b98be1f10ea3345098a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT\n            d.id,\n            d.serial_number,\n            d.note,\n            d.last_ping as last_seen,\n            CASE WHEN d.last_ping > NOW() - INTERVAL '3 minutes' THEN true ELSE false END as \"online!\",\n            d.created_on,\n            d.approved,\n            d.token IS NOT NULL as has_token,\n            d.release_id,\n            d.target_release_id,\n            d.target_release_id_set_at,\n            d.system_info,\n            d.modem_id,\n            d.ip_address_id,\n            ip.id as \"ip_id?\",\n            ip.ip_address as \"ip_address?\",\n            ip.name as \"ip_name?\",\n            ip.continent as \"ip_continent?\",\n            ip.continent_code as \"ip_continent_code?\",\n            ip.country_code as \"ip_country_code?\",\n            ip.country as \"ip_country?\",\n            ip.region as \"ip_region?\",\n            ip.city as \"ip_city?\",\n            ip.isp as \"ip_isp?\",\n            ip.coordinates[0] as \"ip_longitude?\",\n            ip.coordinates[1] as \"ip_latitude?\",\n            ip.proxy as \"ip_proxy?\",\n            ip.hosting as \"ip_hosting?\",\n            ip.created_at as \"ip_created_at?\",\n            ip.updated_at as \"ip_updated_at?\",\n            m.id as \"modem_id_nested?\",\n            m.imei as \"modem_imei?\",\n            m.network_provider as \"modem_network_provider?\",\n            m.updated_at as \"modem_updated_at?\",\n            m.created_at as \"modem_created_at?\",\n            r.id as \"release_id_nested?\",\n            r.distribution_id as \"release_distribution_id?\",\n            rd.architecture as \"release_distribution_architecture?\",\n            rd.name as \"release_distribution_name?\",\n            r.version as \"release_version?\",\n            r.draft as \"release_draft?\",\n            r.yanked as \"release_yanked?\",\n            r.release_candidate as \"release_release_candidate?\",\n            r.created_at as \"release_created_at?\",\n            r.user_id as \"release_user_id?\",\n            tr.id as \"target_release_id_nested?\",\n            tr.distribution_id as \"target_release_distribution_id?\",\n            trd.architecture as \"target_release_distribution_architecture?\",\n            trd.name as \"target_release_distribution_name?\",\n            tr.version as \"target_release_version?\",\n            tr.draft as \"target_release_draft?\",\n            tr.yanked as \"target_release_yanked?\",\n            tr.release_candidate as \"target_release_release_candidate?\",\n            tr.created_at as \"target_release_created_at?\",\n            tr.user_id as \"target_release_user_id?\",\n            dn.network_score as \"network_score?\",\n            dn.download_speed_mbps as \"network_download_speed_mbps?\",\n            dn.upload_speed_mbps as \"network_upload_speed_mbps?\",\n            dn.source as \"network_source?\",\n            dn.updated_at as \"network_updated_at?\",\n            COALESCE(JSONB_OBJECT_AGG(l.name, dl.value) FILTER (WHERE l.name IS NOT NULL), '{}') as \"labels!: SqlxJson<HashMap<String, String>>\"\n        FROM device d\n        LEFT JOIN ip_address ip ON d.ip_address_id = ip.id\n        LEFT JOIN modem m ON d.modem_id = m.id\n        LEFT JOIN release r ON d.release_id = r.id\n        LEFT JOIN distribution rd ON r.distribution_id = rd.id\n        LEFT JOIN release tr ON d.target_release_id = tr.id\n        LEFT JOIN distribution trd ON tr.distribution_id = trd.id\n        LEFT JOIN device_network dn ON d.id = dn.device_id\n        LEFT JOIN device_label dl ON dl.device_id = d.id\n        LEFT JOIN label l ON l.id = dl.label_id\n        WHERE ($1::text IS NULL OR d.serial_number = $1)\n          AND ($2::boolean IS NULL OR d.approved = $2)\n          AND (COALESCE($3, false) = true OR d.archived = false)\n          AND (CARDINALITY($4::text[]) = 0 OR l.name || '=' || dl.value = ANY($4))\n          AND ($5::boolean IS NULL OR\n               ($5 = true AND d.last_ping >= now() - INTERVAL '3 minutes') OR\n               ($5 = false AND d.last_ping < now() - INTERVAL '3 minutes'))\n          AND ($6::boolean IS NULL OR\n               ($6 = true AND d.release_id != d.target_release_id) OR\n               ($6 = false AND d.release_id = d.target_release_id))\n          AND ($12::bigint IS NULL OR\n               d.target_release_id_set_at <= now() - make_interval(mins => $12::int))\n          AND (CARDINALITY($7::text[]) = 0 OR NOT EXISTS (\n              SELECT 1 FROM device_label edl\n              JOIN label el ON el.id = edl.label_id\n              WHERE edl.device_id = d.id\n              AND el.name || '=' || edl.value = ANY($7)\n          ))\n          AND ($10::text IS NULL OR $10 = '' OR (\n              POSITION(LOWER($10) IN LOWER(d.serial_number)) > 0 OR\n              POSITION(LOWER($10) IN LOWER(COALESCE(d.system_info->>'hostname', ''))) > 0 OR\n              POSITION(LOWER($10) IN LOWER(COALESCE(d.system_info->'device_tree'->>'model', ''))) > 0\n          ))\n          AND ($11::int IS NULL OR d.release_id = $11)\n          AND ($13::int IS NULL OR rd.id = $13)\n          AND ($14::boolean IS NULL OR\n               ($14 = true AND EXISTS (\n                   SELECT 1 FROM device_service_status dss\n                   JOIN release_services rs ON rs.id = dss.release_service_id\n                   WHERE dss.device_id = d.id\n                     AND rs.release_id = d.release_id\n                     AND rs.watchdog_sec IS NOT NULL\n                     AND dss.active_state != 'active'\n               )))\n        GROUP BY d.id, ip.id, m.id, r.id, rd.id, tr.id, trd.id, dn.device_id\n        ORDER BY d.last_ping DESC NULLS LAST, d.serial_number\n        LIMIT $8\n        OFFSET $9\n        ",
+  "query": "\n        SELECT\n        d.id,\n        d.serial_number,\n        d.note,\n        d.last_ping as last_seen,\n        CASE WHEN d.last_ping > NOW() - INTERVAL '3 minutes' THEN true ELSE false END as \"online!\",\n        d.created_on,\n        d.approved,\n        d.token IS NOT NULL as has_token,\n        d.release_id,\n        d.target_release_id,\n        d.target_release_id_set_at,\n        d.system_info,\n        d.modem_id,\n        d.ip_address_id,\n        ip.id as \"ip_id?\",\n        ip.ip_address as \"ip_address?\",\n        ip.name as \"ip_name?\",\n        ip.continent as \"ip_continent?\",\n        ip.continent_code as \"ip_continent_code?\",\n        ip.country_code as \"ip_country_code?\",\n        ip.country as \"ip_country?\",\n        ip.region as \"ip_region?\",\n        ip.city as \"ip_city?\",\n        ip.isp as \"ip_isp?\",\n        ip.coordinates[0] as \"ip_longitude?\",\n        ip.coordinates[1] as \"ip_latitude?\",\n        ip.proxy as \"ip_proxy?\",\n        ip.hosting as \"ip_hosting?\",\n        ip.created_at as \"ip_created_at?\",\n        ip.updated_at as \"ip_updated_at?\",\n        m.id as \"modem_id_nested?\",\n        m.imei as \"modem_imei?\",\n        m.network_provider as \"modem_network_provider?\",\n        m.updated_at as \"modem_updated_at?\",\n        m.created_at as \"modem_created_at?\",\n        r.id as \"release_id_nested?\",\n        r.distribution_id as \"release_distribution_id?\",\n        rd.architecture as \"release_distribution_architecture?\",\n        rd.name as \"release_distribution_name?\",\n        r.version as \"release_version?\",\n        r.draft as \"release_draft?\",\n        r.yanked as \"release_yanked?\",\n        r.release_candidate as \"release_release_candidate?\",\n        r.created_at as \"release_created_at?\",\n        r.user_id as \"release_user_id?\",\n        tr.id as \"target_release_id_nested?\",\n        tr.distribution_id as \"target_release_distribution_id?\",\n        trd.architecture as \"target_release_distribution_architecture?\",\n        trd.name as \"target_release_distribution_name?\",\n        tr.version as \"target_release_version?\",\n        tr.draft as \"target_release_draft?\",\n        tr.yanked as \"target_release_yanked?\",\n        tr.release_candidate as \"target_release_release_candidate?\",\n        tr.created_at as \"target_release_created_at?\",\n        tr.user_id as \"target_release_user_id?\",\n        dn.network_score as \"network_score?\",\n        dn.download_speed_mbps as \"network_download_speed_mbps?\",\n        dn.upload_speed_mbps as \"network_upload_speed_mbps?\",\n        dn.source as \"network_source?\",\n        dn.updated_at as \"network_updated_at?\",\n        d.intent_version,\n        d.observed_intent_version,\n        d.network_conditions,\n        COALESCE(JSONB_OBJECT_AGG(l.name, dl.value) FILTER (WHERE l.name IS NOT NULL), '{}') as \"labels!: SqlxJson<HashMap<String, String>>\"\n        FROM device d\n        LEFT JOIN ip_address ip ON d.ip_address_id = ip.id\n        LEFT JOIN modem m ON d.modem_id = m.id\n        LEFT JOIN release r ON d.release_id = r.id\n        LEFT JOIN distribution rd ON r.distribution_id = rd.id\n        LEFT JOIN release tr ON d.target_release_id = tr.id\n        LEFT JOIN distribution trd ON tr.distribution_id = trd.id\n        LEFT JOIN device_network dn ON d.id = dn.device_id\n        LEFT JOIN device_label dl ON dl.device_id = d.id\n        LEFT JOIN label l ON l.id = dl.label_id\n        WHERE\n            CASE\n                WHEN $1 ~ '^[0-9]+$' AND length($1) <= 10 THEN\n                    d.id = $1::int4\n                ELSE\n                    d.serial_number = $1\n            END\n        GROUP BY d.id, ip.id, m.id, r.id, rd.id, tr.id, trd.id, dn.device_id\n        ",
   "describe": {
     "columns": [
       {
@@ -305,26 +305,28 @@
       },
       {
         "ordinal": 60,
+        "name": "intent_version",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 61,
+        "name": "observed_intent_version",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 62,
+        "name": "network_conditions",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 63,
         "name": "labels!: SqlxJson<HashMap<String, String>>",
         "type_info": "Jsonb"
       }
     ],
     "parameters": {
       "Left": [
-        "Text",
-        "Bool",
-        "Bool",
-        "TextArray",
-        "Bool",
-        "Bool",
-        "TextArray",
-        "Int8",
-        "Int8",
-        "Text",
-        "Int4",
-        "Int8",
-        "Int4",
-        "Bool"
+        "Text"
       ]
     },
     "nullable": [
@@ -388,8 +390,11 @@
       true,
       false,
       false,
+      false,
+      true,
+      true,
       null
     ]
   },
-  "hash": "c860b8b869b67276c202741acd3d3380dbff945e30bdc57a5337129ed636aed5"
+  "hash": "2f010807a09820ddfd4a7a4fda103692962f8542041f4b98be1f10ea3345098a"
 }

--- a/api/.sqlx/query-4ccb242b22498d0f49f3a905696536b3e84f148a0c0de0eddb88a60be8bc78ef.json
+++ b/api/.sqlx/query-4ccb242b22498d0f49f3a905696536b3e84f148a0c0de0eddb88a60be8bc78ef.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO command_queue (device_id, cmd, continue_on_error, canceled, bundle)\n         VALUES ($1, $2::jsonb, false, false, $3)\n         RETURNING id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Jsonb",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "4ccb242b22498d0f49f3a905696536b3e84f148a0c0de0eddb88a60be8bc78ef"
+}

--- a/api/.sqlx/query-6b2636a1a97a395c3d676df3f00bc6edd9a3a64488d50be92e9d6f9c8886c588.json
+++ b/api/.sqlx/query-6b2636a1a97a395c3d676df3f00bc6edd9a3a64488d50be92e9d6f9c8886c588.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM device_network_intent WHERE id = $2 AND device_id = $1 RETURNING id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "6b2636a1a97a395c3d676df3f00bc6edd9a3a64488d50be92e9d6f9c8886c588"
+}

--- a/api/.sqlx/query-8a8f4d60e3e90c4eeea43274d253b28cb6f856a1cc583e6bef54d5a11de6172b.json
+++ b/api/.sqlx/query-8a8f4d60e3e90c4eeea43274d253b28cb6f856a1cc583e6bef54d5a11de6172b.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            d.*,\n            COALESCE(JSONB_OBJECT_AGG(l.name, dl.value) FILTER (WHERE l.name IS NOT NULL), '{}') as \"labels!: SqlxJson<HashMap<String, String>>\"\n        FROM device d\n        LEFT JOIN device_label dl ON dl.device_id = d.id\n        LEFT JOIN label l ON l.id = dl.label_id\n        WHERE\n            d.id = $1\n        GROUP BY d.id\n        ",
+  "query": "\n        SELECT\n            d.id,\n            d.serial_number,\n            d.wifi_mac,\n            d.created_on,\n            d.modified_on,\n            d.last_ping,\n            d.note,\n            d.approved,\n            d.token,\n            d.release_id,\n            d.target_release_id,\n            d.target_release_id_set_at,\n            d.system_info,\n            d.network_id,\n            d.current_network_id,\n            d.modem_id,\n            d.archived,\n            d.ip_address_id,\n            d.intent_version,\n            d.observed_intent_version,\n            d.network_conditions,\n            COALESCE(JSONB_OBJECT_AGG(l.name, dl.value) FILTER (WHERE l.name IS NOT NULL), '{}') as \"labels!: SqlxJson<HashMap<String, String>>\"\n        FROM device d\n        LEFT JOIN device_label dl ON dl.device_id = d.id\n        LEFT JOIN label l ON l.id = dl.label_id\n        WHERE\n            d.id = $1\n        GROUP BY d.id\n        ",
   "describe": {
     "columns": [
       {
@@ -60,41 +60,56 @@
       },
       {
         "ordinal": 11,
-        "name": "system_info",
-        "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 12,
-        "name": "network_id",
-        "type_info": "Int4"
-      },
-      {
-        "ordinal": 13,
-        "name": "modem_id",
-        "type_info": "Int4"
-      },
-      {
-        "ordinal": 14,
-        "name": "archived",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 15,
-        "name": "ip_address_id",
-        "type_info": "Int8"
-      },
-      {
-        "ordinal": 16,
         "name": "target_release_id_set_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 17,
+        "ordinal": 12,
+        "name": "system_info",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 13,
+        "name": "network_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 14,
         "name": "current_network_id",
         "type_info": "Int4"
       },
       {
+        "ordinal": 15,
+        "name": "modem_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "archived",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "ip_address_id",
+        "type_info": "Int8"
+      },
+      {
         "ordinal": 18,
+        "name": "intent_version",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 19,
+        "name": "observed_intent_version",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 20,
+        "name": "network_conditions",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 21,
         "name": "labels!: SqlxJson<HashMap<String, String>>",
         "type_info": "Jsonb"
       }
@@ -119,12 +134,15 @@
       true,
       true,
       true,
+      true,
+      true,
       false,
       true,
+      false,
       true,
       true,
       null
     ]
   },
-  "hash": "239428235364f8fa13ef3417fe982fb0baa59490e38f948e84639a0ce355d54f"
+  "hash": "8a8f4d60e3e90c4eeea43274d253b28cb6f856a1cc583e6bef54d5a11de6172b"
 }

--- a/api/.sqlx/query-b9817e3380af8852d04dfff15b74aacf12d00ec14903828f90eedd7c7fb34b4f.json
+++ b/api/.sqlx/query-b9817e3380af8852d04dfff15b74aacf12d00ec14903828f90eedd7c7fb34b4f.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            dni.priority,\n            n.ssid,\n            n.password\n        FROM device_network_intent dni\n        JOIN network n ON n.id = dni.network_id\n        WHERE dni.device_id = $1\n        ORDER BY dni.priority ASC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "ssid",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "password",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "b9817e3380af8852d04dfff15b74aacf12d00ec14903828f90eedd7c7fb34b4f"
+}

--- a/api/.sqlx/query-bd4c4a522c24daaf5275c3b24d9819e480b1a80e502779a0588f65967114c8dd.json
+++ b/api/.sqlx/query-bd4c4a522c24daaf5275c3b24d9819e480b1a80e502779a0588f65967114c8dd.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO device_network_intent (device_id, network_id, priority, managed_by)\n        VALUES ($1, $2, $3, $4)\n        RETURNING id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4",
+        "Int4",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "bd4c4a522c24daaf5275c3b24d9819e480b1a80e502779a0588f65967114c8dd"
+}

--- a/api/.sqlx/query-cc2ebe8a352803aa12d43b2cb21ea18b49b5cde3a42b58c2ac602b5ded7d77e8.json
+++ b/api/.sqlx/query-cc2ebe8a352803aa12d43b2cb21ea18b49b5cde3a42b58c2ac602b5ded7d77e8.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE device_network_intent\n        SET\n            priority   = COALESCE($3, priority),\n            managed_by = COALESCE($4, managed_by),\n            updated_at = now()\n        WHERE id = $2 AND device_id = $1\n        RETURNING id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4",
+        "Int4",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "cc2ebe8a352803aa12d43b2cb21ea18b49b5cde3a42b58c2ac602b5ded7d77e8"
+}

--- a/api/.sqlx/query-de603391b4e956f02b02c29df67ea8a525033ec39f5cc46be43bf548ba2be831.json
+++ b/api/.sqlx/query-de603391b4e956f02b02c29df67ea8a525033ec39f5cc46be43bf548ba2be831.json
@@ -1,0 +1,76 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            dni.id,\n            dni.device_id,\n            dni.network_id,\n            dni.priority,\n            dni.managed_by,\n            dni.created_at,\n            dni.updated_at,\n            n.ssid,\n            n.name,\n            n.network_type::TEXT as \"network_type!\"\n        FROM device_network_intent dni\n        JOIN network n ON n.id = dni.network_id\n        WHERE dni.id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "device_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "network_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 4,
+        "name": "managed_by",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "ssid",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "network_type!",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      null
+    ]
+  },
+  "hash": "de603391b4e956f02b02c29df67ea8a525033ec39f5cc46be43bf548ba2be831"
+}

--- a/api/.sqlx/query-ded97843415d347975e5002ee4575bd2ee5e0d7bff896422ef07f774d7dda8cd.json
+++ b/api/.sqlx/query-ded97843415d347975e5002ee4575bd2ee5e0d7bff896422ef07f774d7dda8cd.json
@@ -1,0 +1,76 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            dni.id,\n            dni.device_id,\n            dni.network_id,\n            dni.priority,\n            dni.managed_by,\n            dni.created_at,\n            dni.updated_at,\n            n.ssid,\n            n.name,\n            n.network_type::TEXT as \"network_type!\"\n        FROM device_network_intent dni\n        JOIN network n ON n.id = dni.network_id\n        WHERE dni.device_id = $1\n        ORDER BY dni.priority ASC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "device_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "network_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 4,
+        "name": "managed_by",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "ssid",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "network_type!",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      null
+    ]
+  },
+  "hash": "ded97843415d347975e5002ee4575bd2ee5e0d7bff896422ef07f774d7dda8cd"
+}

--- a/api/.sqlx/query-f06c760b4a6729cd877274b50a12f726e529897ef88f01510ad8ebe74fb9e651.json
+++ b/api/.sqlx/query-f06c760b4a6729cd877274b50a12f726e529897ef88f01510ad8ebe74fb9e651.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT intent_version FROM device WHERE id = $1 FOR UPDATE",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "intent_version",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "f06c760b4a6729cd877274b50a12f726e529897ef88f01510ad8ebe74fb9e651"
+}

--- a/api/.sqlx/query-f48551844dc14b9f799db2e9db549d3c6e64282fbbdeacf2693e2f31b18576f2.json
+++ b/api/.sqlx/query-f48551844dc14b9f799db2e9db549d3c6e64282fbbdeacf2693e2f31b18576f2.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n        d.id,\n        d.serial_number,\n        d.note,\n        d.last_ping as last_seen,\n        CASE WHEN d.last_ping > NOW() - INTERVAL '3 minutes' THEN true ELSE false END as \"online!\",\n        d.created_on,\n        d.approved,\n        d.token IS NOT NULL as has_token,\n        d.release_id,\n        d.target_release_id,\n        d.target_release_id_set_at,\n        d.system_info,\n        d.modem_id,\n        d.ip_address_id,\n        ip.id as \"ip_id?\",\n        ip.ip_address as \"ip_address?\",\n        ip.name as \"ip_name?\",\n        ip.continent as \"ip_continent?\",\n        ip.continent_code as \"ip_continent_code?\",\n        ip.country_code as \"ip_country_code?\",\n        ip.country as \"ip_country?\",\n        ip.region as \"ip_region?\",\n        ip.city as \"ip_city?\",\n        ip.isp as \"ip_isp?\",\n        ip.coordinates[0] as \"ip_longitude?\",\n        ip.coordinates[1] as \"ip_latitude?\",\n        ip.proxy as \"ip_proxy?\",\n        ip.hosting as \"ip_hosting?\",\n        ip.created_at as \"ip_created_at?\",\n        ip.updated_at as \"ip_updated_at?\",\n        m.id as \"modem_id_nested?\",\n        m.imei as \"modem_imei?\",\n        m.network_provider as \"modem_network_provider?\",\n        m.updated_at as \"modem_updated_at?\",\n        m.created_at as \"modem_created_at?\",\n        r.id as \"release_id_nested?\",\n        r.distribution_id as \"release_distribution_id?\",\n        rd.architecture as \"release_distribution_architecture?\",\n        rd.name as \"release_distribution_name?\",\n        r.version as \"release_version?\",\n        r.draft as \"release_draft?\",\n        r.yanked as \"release_yanked?\",\n        r.release_candidate as \"release_release_candidate?\",\n        r.created_at as \"release_created_at?\",\n        r.user_id as \"release_user_id?\",\n        tr.id as \"target_release_id_nested?\",\n        tr.distribution_id as \"target_release_distribution_id?\",\n        trd.architecture as \"target_release_distribution_architecture?\",\n        trd.name as \"target_release_distribution_name?\",\n        tr.version as \"target_release_version?\",\n        tr.draft as \"target_release_draft?\",\n        tr.yanked as \"target_release_yanked?\",\n        tr.release_candidate as \"target_release_release_candidate?\",\n        tr.created_at as \"target_release_created_at?\",\n        tr.user_id as \"target_release_user_id?\",\n        dn.network_score as \"network_score?\",\n        dn.download_speed_mbps as \"network_download_speed_mbps?\",\n        dn.upload_speed_mbps as \"network_upload_speed_mbps?\",\n        dn.source as \"network_source?\",\n        dn.updated_at as \"network_updated_at?\",\n        COALESCE(JSONB_OBJECT_AGG(l.name, dl.value) FILTER (WHERE l.name IS NOT NULL), '{}') as \"labels!: SqlxJson<HashMap<String, String>>\"\n        FROM device d\n        LEFT JOIN ip_address ip ON d.ip_address_id = ip.id\n        LEFT JOIN modem m ON d.modem_id = m.id\n        LEFT JOIN release r ON d.release_id = r.id\n        LEFT JOIN distribution rd ON r.distribution_id = rd.id\n        LEFT JOIN release tr ON d.target_release_id = tr.id\n        LEFT JOIN distribution trd ON tr.distribution_id = trd.id\n        LEFT JOIN device_network dn ON d.id = dn.device_id\n        LEFT JOIN device_label dl ON dl.device_id = d.id\n        LEFT JOIN label l ON l.id = dl.label_id\n        WHERE\n            CASE\n                WHEN $1 ~ '^[0-9]+$' AND length($1) <= 10 THEN\n                    d.id = $1::int4\n                ELSE\n                    d.serial_number = $1\n            END\n        GROUP BY d.id, ip.id, m.id, r.id, rd.id, tr.id, trd.id, dn.device_id\n        ",
+  "query": "SELECT\n            d.id,\n            d.serial_number,\n            d.note,\n            d.last_ping as last_seen,\n            CASE WHEN d.last_ping > NOW() - INTERVAL '3 minutes' THEN true ELSE false END as \"online!\",\n            d.created_on,\n            d.approved,\n            d.token IS NOT NULL as has_token,\n            d.release_id,\n            d.target_release_id,\n            d.target_release_id_set_at,\n            d.system_info,\n            d.modem_id,\n            d.ip_address_id,\n            ip.id as \"ip_id?\",\n            ip.ip_address as \"ip_address?\",\n            ip.name as \"ip_name?\",\n            ip.continent as \"ip_continent?\",\n            ip.continent_code as \"ip_continent_code?\",\n            ip.country_code as \"ip_country_code?\",\n            ip.country as \"ip_country?\",\n            ip.region as \"ip_region?\",\n            ip.city as \"ip_city?\",\n            ip.isp as \"ip_isp?\",\n            ip.coordinates[0] as \"ip_longitude?\",\n            ip.coordinates[1] as \"ip_latitude?\",\n            ip.proxy as \"ip_proxy?\",\n            ip.hosting as \"ip_hosting?\",\n            ip.created_at as \"ip_created_at?\",\n            ip.updated_at as \"ip_updated_at?\",\n            m.id as \"modem_id_nested?\",\n            m.imei as \"modem_imei?\",\n            m.network_provider as \"modem_network_provider?\",\n            m.updated_at as \"modem_updated_at?\",\n            m.created_at as \"modem_created_at?\",\n            r.id as \"release_id_nested?\",\n            r.distribution_id as \"release_distribution_id?\",\n            rd.architecture as \"release_distribution_architecture?\",\n            rd.name as \"release_distribution_name?\",\n            r.version as \"release_version?\",\n            r.draft as \"release_draft?\",\n            r.yanked as \"release_yanked?\",\n            r.release_candidate as \"release_release_candidate?\",\n            r.created_at as \"release_created_at?\",\n            r.user_id as \"release_user_id?\",\n            tr.id as \"target_release_id_nested?\",\n            tr.distribution_id as \"target_release_distribution_id?\",\n            trd.architecture as \"target_release_distribution_architecture?\",\n            trd.name as \"target_release_distribution_name?\",\n            tr.version as \"target_release_version?\",\n            tr.draft as \"target_release_draft?\",\n            tr.yanked as \"target_release_yanked?\",\n            tr.release_candidate as \"target_release_release_candidate?\",\n            tr.created_at as \"target_release_created_at?\",\n            tr.user_id as \"target_release_user_id?\",\n            dn.network_score as \"network_score?\",\n            dn.download_speed_mbps as \"network_download_speed_mbps?\",\n            dn.upload_speed_mbps as \"network_upload_speed_mbps?\",\n            dn.source as \"network_source?\",\n            dn.updated_at as \"network_updated_at?\",\n            d.intent_version,\n            d.observed_intent_version,\n            d.network_conditions,\n            COALESCE(JSONB_OBJECT_AGG(l.name, dl.value) FILTER (WHERE l.name IS NOT NULL), '{}') as \"labels!: SqlxJson<HashMap<String, String>>\"\n        FROM device d\n        LEFT JOIN ip_address ip ON d.ip_address_id = ip.id\n        LEFT JOIN modem m ON d.modem_id = m.id\n        LEFT JOIN release r ON d.release_id = r.id\n        LEFT JOIN distribution rd ON r.distribution_id = rd.id\n        LEFT JOIN release tr ON d.target_release_id = tr.id\n        LEFT JOIN distribution trd ON tr.distribution_id = trd.id\n        LEFT JOIN device_network dn ON d.id = dn.device_id\n        LEFT JOIN device_label dl ON dl.device_id = d.id\n        LEFT JOIN label l ON l.id = dl.label_id\n        WHERE ($1::text IS NULL OR d.serial_number = $1)\n          AND ($2::boolean IS NULL OR d.approved = $2)\n          AND (COALESCE($3, false) = true OR d.archived = false)\n          AND (CARDINALITY($4::text[]) = 0 OR l.name || '=' || dl.value = ANY($4))\n          AND ($5::boolean IS NULL OR\n               ($5 = true AND d.last_ping >= now() - INTERVAL '3 minutes') OR\n               ($5 = false AND d.last_ping < now() - INTERVAL '3 minutes'))\n          AND ($6::boolean IS NULL OR\n               ($6 = true AND d.release_id != d.target_release_id) OR\n               ($6 = false AND d.release_id = d.target_release_id))\n          AND ($12::bigint IS NULL OR\n               d.target_release_id_set_at <= now() - make_interval(mins => $12::int))\n          AND (CARDINALITY($7::text[]) = 0 OR NOT EXISTS (\n              SELECT 1 FROM device_label edl\n              JOIN label el ON el.id = edl.label_id\n              WHERE edl.device_id = d.id\n              AND el.name || '=' || edl.value = ANY($7)\n          ))\n          AND ($10::text IS NULL OR $10 = '' OR (\n              POSITION(LOWER($10) IN LOWER(d.serial_number)) > 0 OR\n              POSITION(LOWER($10) IN LOWER(COALESCE(d.system_info->>'hostname', ''))) > 0 OR\n              POSITION(LOWER($10) IN LOWER(COALESCE(d.system_info->'device_tree'->>'model', ''))) > 0\n          ))\n          AND ($11::int IS NULL OR d.release_id = $11)\n          AND ($13::int IS NULL OR rd.id = $13)\n          AND ($14::boolean IS NULL OR\n               ($14 = true AND EXISTS (\n                   SELECT 1 FROM device_service_status dss\n                   JOIN release_services rs ON rs.id = dss.release_service_id\n                   WHERE dss.device_id = d.id\n                     AND rs.release_id = d.release_id\n                     AND rs.watchdog_sec IS NOT NULL\n                     AND dss.active_state != 'active'\n               )))\n        GROUP BY d.id, ip.id, m.id, r.id, rd.id, tr.id, trd.id, dn.device_id\n        ORDER BY d.last_ping DESC NULLS LAST, d.serial_number\n        LIMIT $8\n        OFFSET $9\n        ",
   "describe": {
     "columns": [
       {
@@ -305,13 +305,41 @@
       },
       {
         "ordinal": 60,
+        "name": "intent_version",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 61,
+        "name": "observed_intent_version",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 62,
+        "name": "network_conditions",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 63,
         "name": "labels!: SqlxJson<HashMap<String, String>>",
         "type_info": "Jsonb"
       }
     ],
     "parameters": {
       "Left": [
-        "Text"
+        "Text",
+        "Bool",
+        "Bool",
+        "TextArray",
+        "Bool",
+        "Bool",
+        "TextArray",
+        "Int8",
+        "Int8",
+        "Text",
+        "Int4",
+        "Int8",
+        "Int4",
+        "Bool"
       ]
     },
     "nullable": [
@@ -375,8 +403,11 @@
       true,
       false,
       false,
+      false,
+      true,
+      true,
       null
     ]
   },
-  "hash": "27f9c095c62c7bf89996be389be584cb48db643b5fc9e5ed53f7550eb07c14d0"
+  "hash": "f48551844dc14b9f799db2e9db549d3c6e64282fbbdeacf2693e2f31b18576f2"
 }

--- a/api/.sqlx/query-f61f33068688acc0753c5b0e97e2eac92c39502ec3b23d85634314edf32776fa.json
+++ b/api/.sqlx/query-f61f33068688acc0753c5b0e97e2eac92c39502ec3b23d85634314edf32776fa.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT EXISTS (\n            SELECT 1\n            FROM device_network_intent dni\n            JOIN network existing_n ON existing_n.id = dni.network_id\n            JOIN network new_n ON new_n.id = $2\n            WHERE dni.device_id = $1\n              AND existing_n.name = new_n.name\n              AND dni.network_id != $2\n        ) as \"exists!\"\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "f61f33068688acc0753c5b0e97e2eac92c39502ec3b23d85634314edf32776fa"
+}

--- a/api/.sqlx/query-fa00c8e2526cd90d1f36e2b2a34c95c1d80d2c3a0d8b1a09ae0280f5166d3269.json
+++ b/api/.sqlx/query-fa00c8e2526cd90d1f36e2b2a34c95c1d80d2c3a0d8b1a09ae0280f5166d3269.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT 1 as x FROM device WHERE id = $1 FOR UPDATE",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "x",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "fa00c8e2526cd90d1f36e2b2a34c95c1d80d2c3a0d8b1a09ae0280f5166d3269"
+}

--- a/api/migrations/20260708000000_device_network_intent.sql
+++ b/api/migrations/20260708000000_device_network_intent.sql
@@ -1,0 +1,12 @@
+CREATE TABLE device_network_intent (
+    id         SERIAL PRIMARY KEY,
+    device_id  INTEGER NOT NULL REFERENCES device(id) ON DELETE CASCADE,
+    network_id INTEGER NOT NULL REFERENCES network(id) ON DELETE RESTRICT,
+    priority   INTEGER NOT NULL,
+    managed_by TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT device_network_intent_device_network_unique UNIQUE (device_id, network_id)
+);
+
+CREATE INDEX idx_device_network_intent_device_id ON device_network_intent(device_id);

--- a/api/migrations/20260708000001_device_intent_columns.sql
+++ b/api/migrations/20260708000001_device_intent_columns.sql
@@ -1,0 +1,4 @@
+ALTER TABLE device
+    ADD COLUMN intent_version          INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN observed_intent_version INTEGER,
+    ADD COLUMN network_conditions      JSONB;

--- a/api/src/command/mod.rs
+++ b/api/src/command/mod.rs
@@ -6,6 +6,23 @@ use sqlx::types::chrono;
 
 pub mod route;
 
+pub fn redact_cmd_data(mut cmd: serde_json::Value) -> serde_json::Value {
+    if let Some(networks) = cmd
+        .get_mut("ApplyNetworks")
+        .and_then(|v| v.get_mut("networks"))
+        .and_then(|v| v.as_array_mut())
+    {
+        for network in networks.iter_mut() {
+            if let Some(creds) = network.get_mut("credentials")
+                && let Some(obj) = creds.as_object_mut()
+            {
+                obj.remove("psk");
+            }
+        }
+    }
+    cmd
+}
+
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct BundleWithCommandsPaginated {
     pub bundles: Vec<BundleWithCommands>,

--- a/api/src/command/route.rs
+++ b/api/src/command/route.rs
@@ -17,6 +17,8 @@ use sqlx::PgPool;
 use std::collections::HashMap;
 use tracing::error;
 
+use crate::command::redact_cmd_data;
+
 /// Queue `commands` against every device in `devices` as a single bundle.
 /// Shared by raw bundle issuing and recipe triggering so both produce identical
 /// `command_bundles` / `command_queue` rows and the same receipt shape.
@@ -254,7 +256,7 @@ pub async fn get_bundle_commands(
             serial_number: raw_bundle.serial_number,
             cmd_id: raw_bundle.cmd_id,
             issued_at: raw_bundle.issued_at,
-            cmd_data: raw_bundle.cmd_data,
+            cmd_data: redact_cmd_data(raw_bundle.cmd_data),
             cancelled: raw_bundle.cancelled,
             fetched: raw_bundle.fetched,
             fetched_at: raw_bundle.fetched_at,
@@ -440,7 +442,7 @@ pub async fn get_bundle(
             serial_number: raw.serial_number,
             cmd_id: raw.cmd_id,
             issued_at: raw.issued_at,
-            cmd_data: raw.cmd_data,
+            cmd_data: redact_cmd_data(raw.cmd_data),
             cancelled: raw.cancelled,
             fetched: raw.fetched,
             fetched_at: raw.fetched_at,

--- a/api/src/device/mod.rs
+++ b/api/src/device/mod.rs
@@ -12,6 +12,7 @@ use std::net::IpAddr;
 use std::time::Duration;
 use thiserror::Error;
 use tracing::{debug, error, info, warn};
+use uuid::Uuid;
 
 pub mod route;
 
@@ -39,6 +40,9 @@ pub struct RawDevice {
     pub modem_id: Option<i32>,
     pub archived: bool,
     pub ip_address_id: Option<i64>,
+    pub intent_version: i32,
+    pub observed_intent_version: Option<i32>,
+    pub network_conditions: Option<serde_json::Value>,
 }
 
 fn serialize_token_presence<S>(token: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
@@ -161,6 +165,39 @@ pub struct WifiScanResult {
     pub channel: Option<i32>,
     pub band: Option<String>,
     pub scanned_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, sqlx::FromRow, utoipa::ToSchema)]
+pub struct DeviceNetworkIntent {
+    pub id: i32,
+    pub device_id: i32,
+    pub network_id: i32,
+    pub ssid: Option<String>,
+    pub name: String,
+    pub network_type: String,
+    pub priority: i32,
+    pub managed_by: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct CreateIntentRequest {
+    pub network_id: i32,
+    pub priority: i32,
+    pub managed_by: String,
+}
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct PatchIntentRequest {
+    pub priority: Option<i32>,
+    pub managed_by: Option<String>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct ApplyIntentResponse {
+    pub bundle_uuid: Uuid,
+    pub command_id: i32,
 }
 
 async fn update_ip_geolocation(

--- a/api/src/device/route.rs
+++ b/api/src/device/route.rs
@@ -1,8 +1,9 @@
 use crate::State;
 use crate::device::{
-    ApproveDeviceBody, ConfiguredNetwork, DeviceHealth, DeviceLedgerItem,
-    DeviceLedgerItemPaginated, DeviceRelease, LabelWithValues, NewVariable, Note, RawDevice,
-    UpdateDeviceRelease, UpdateDevicesRelease, Variable, WifiScanResult,
+    ApplyIntentResponse, ApproveDeviceBody, ConfiguredNetwork, CreateIntentRequest, DeviceHealth,
+    DeviceLedgerItem, DeviceLedgerItemPaginated, DeviceNetworkIntent, DeviceRelease,
+    LabelWithValues, NewVariable, Note, PatchIntentRequest, RawDevice, UpdateDeviceRelease,
+    UpdateDevicesRelease, Variable, WifiScanResult,
 };
 use crate::event::PublicEvent;
 use crate::handlers::AuthedDevice;
@@ -52,7 +53,27 @@ pub async fn get_device(
         RawDevice,
         r#"
         SELECT
-            d.*,
+            d.id,
+            d.serial_number,
+            d.wifi_mac,
+            d.created_on,
+            d.modified_on,
+            d.last_ping,
+            d.note,
+            d.approved,
+            d.token,
+            d.release_id,
+            d.target_release_id,
+            d.target_release_id_set_at,
+            d.system_info,
+            d.network_id,
+            d.current_network_id,
+            d.modem_id,
+            d.archived,
+            d.ip_address_id,
+            d.intent_version,
+            d.observed_intent_version,
+            d.network_conditions,
             COALESCE(JSONB_OBJECT_AGG(l.name, dl.value) FILTER (WHERE l.name IS NOT NULL), '{}') as "labels!: SqlxJson<HashMap<String, String>>"
         FROM device d
         LEFT JOIN device_label dl ON dl.device_id = d.id
@@ -157,6 +178,9 @@ pub async fn get_devices(
             dn.upload_speed_mbps as "network_upload_speed_mbps?",
             dn.source as "network_source?",
             dn.updated_at as "network_updated_at?",
+            d.intent_version,
+            d.observed_intent_version,
+            d.network_conditions,
             COALESCE(JSONB_OBJECT_AGG(l.name, dl.value) FILTER (WHERE l.name IS NOT NULL), '{}') as "labels!: SqlxJson<HashMap<String, String>>"
         FROM device d
         LEFT JOIN ip_address ip ON d.ip_address_id = ip.id
@@ -342,6 +366,9 @@ pub async fn get_devices(
                 release,
                 target_release,
                 network,
+                intent_version: row.intent_version,
+                observed_intent_version: row.observed_intent_version,
+                network_conditions: row.network_conditions,
                 labels: row.labels,
             }
         })
@@ -1076,6 +1103,13 @@ pub async fn get_all_commands_for_device(
     // so it is a unique, stable ordering key even within a bundle (whose rows
     // all share the same created_at).
     commands.sort_by(|a, b| b.cmd_id.cmp(&a.cmd_id));
+    let commands: Vec<_> = commands
+        .into_iter()
+        .map(|mut c| {
+            c.cmd_data = crate::command::redact_cmd_data(c.cmd_data);
+            c
+        })
+        .collect();
 
     let first_id = commands.first().map(|c| c.cmd_id);
     let last_id = commands.last().map(|c| c.cmd_id);
@@ -1632,6 +1666,9 @@ pub async fn get_device_info(
         dn.upload_speed_mbps as "network_upload_speed_mbps?",
         dn.source as "network_source?",
         dn.updated_at as "network_updated_at?",
+        d.intent_version,
+        d.observed_intent_version,
+        d.network_conditions,
         COALESCE(JSONB_OBJECT_AGG(l.name, dl.value) FILTER (WHERE l.name IS NOT NULL), '{}') as "labels!: SqlxJson<HashMap<String, String>>"
         FROM device d
         LEFT JOIN ip_address ip ON d.ip_address_id = ip.id
@@ -1775,6 +1812,9 @@ pub async fn get_device_info(
         release,
         target_release,
         network,
+        intent_version: device_row.intent_version,
+        observed_intent_version: device_row.observed_intent_version,
+        network_conditions: device_row.network_conditions,
         labels: device_row.labels,
     };
 
@@ -2697,4 +2737,545 @@ pub async fn get_wifi_scan_for_device(
         .collect();
 
     Ok(Json(results))
+}
+
+async fn resolve_device_id(device_id: &str, pool: &sqlx::PgPool) -> Result<i32, StatusCode> {
+    sqlx::query_scalar!(
+        r#"
+        SELECT id FROM device
+        WHERE
+            CASE
+                WHEN $1 ~ '^[0-9]+$' AND length($1) <= 9 THEN
+                    id = $1::int4
+                ELSE
+                    serial_number = $1
+            END
+        "#,
+        device_id
+    )
+    .fetch_optional(pool)
+    .await
+    .map_err(|err| {
+        error!("Failed to resolve device {device_id}: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?
+    .ok_or(StatusCode::NOT_FOUND)
+}
+
+#[utoipa::path(
+    get,
+    path = "/devices/{device_id}/intent",
+    params(
+        ("device_id" = String, Path),
+    ),
+    responses(
+        (status = StatusCode::OK, description = "Intent list for the device", body = Vec<DeviceNetworkIntent>),
+        (status = StatusCode::NOT_FOUND, description = "Device not found"),
+        (status = StatusCode::INTERNAL_SERVER_ERROR, description = "Failed to retrieve device intent"),
+    ),
+    security(
+        ("auth_token" = [])
+    ),
+    tag = DEVICES_TAG
+)]
+pub async fn get_device_intent(
+    Path(device_id): Path<String>,
+    Extension(state): Extension<State>,
+    Extension(current_user): Extension<CurrentUser>,
+) -> Result<Json<Vec<DeviceNetworkIntent>>, StatusCode> {
+    if !authorization::check(current_user, "devices", "read") {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    let resolved_id = resolve_device_id(&device_id, &state.pg_pool).await?;
+
+    let intents = sqlx::query_as!(
+        DeviceNetworkIntent,
+        r#"
+        SELECT
+            dni.id,
+            dni.device_id,
+            dni.network_id,
+            dni.priority,
+            dni.managed_by,
+            dni.created_at,
+            dni.updated_at,
+            n.ssid,
+            n.name,
+            n.network_type::TEXT as "network_type!"
+        FROM device_network_intent dni
+        JOIN network n ON n.id = dni.network_id
+        WHERE dni.device_id = $1
+        ORDER BY dni.priority ASC
+        "#,
+        resolved_id
+    )
+    .fetch_all(&state.pg_pool)
+    .await
+    .map_err(|err| {
+        error!("Failed to get intent for device {resolved_id}: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok(Json(intents))
+}
+
+#[utoipa::path(
+    post,
+    path = "/devices/{device_id}/intent",
+    params(
+        ("device_id" = String, Path),
+    ),
+    request_body = CreateIntentRequest,
+    responses(
+        (status = StatusCode::CREATED, description = "Intent row created", body = DeviceNetworkIntent),
+        (status = StatusCode::CONFLICT, description = "Profile name already in intent or duplicate network_id"),
+        (status = StatusCode::BAD_REQUEST, description = "Unknown network_id"),
+        (status = StatusCode::NOT_FOUND, description = "Device not found"),
+        (status = StatusCode::INTERNAL_SERVER_ERROR, description = "Failed to create intent"),
+    ),
+    security(
+        ("auth_token" = [])
+    ),
+    tag = DEVICES_TAG
+)]
+pub async fn create_device_intent(
+    Path(device_id): Path<String>,
+    Extension(state): Extension<State>,
+    Extension(current_user): Extension<CurrentUser>,
+    Json(payload): Json<CreateIntentRequest>,
+) -> Result<(StatusCode, Json<DeviceNetworkIntent>), StatusCode> {
+    if !authorization::check(current_user, "devices", "write") {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    let resolved_id = resolve_device_id(&device_id, &state.pg_pool).await?;
+
+    let mut tx = state.pg_pool.begin().await.map_err(|err| {
+        error!("Failed to start transaction: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    sqlx::query!(
+        "SELECT 1 as x FROM device WHERE id = $1 FOR UPDATE",
+        resolved_id
+    )
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|err| {
+        error!("Failed to lock device row {resolved_id}: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let profile_name_conflict = sqlx::query_scalar!(
+        r#"
+        SELECT EXISTS (
+            SELECT 1
+            FROM device_network_intent dni
+            JOIN network existing_n ON existing_n.id = dni.network_id
+            JOIN network new_n ON new_n.id = $2
+            WHERE dni.device_id = $1
+              AND existing_n.name = new_n.name
+              AND dni.network_id != $2
+        ) as "exists!"
+        "#,
+        resolved_id,
+        payload.network_id
+    )
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|err| {
+        error!("Failed to check profile name uniqueness: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    if profile_name_conflict {
+        return Err(StatusCode::CONFLICT);
+    }
+
+    let intent_id = sqlx::query_scalar!(
+        r#"
+        INSERT INTO device_network_intent (device_id, network_id, priority, managed_by)
+        VALUES ($1, $2, $3, $4)
+        RETURNING id
+        "#,
+        resolved_id,
+        payload.network_id,
+        payload.priority,
+        payload.managed_by,
+    )
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|err| {
+        let msg = err.to_string();
+        if msg.contains("device_network_intent_device_network_unique") {
+            StatusCode::CONFLICT
+        } else if msg.contains("violates foreign key constraint") {
+            StatusCode::BAD_REQUEST
+        } else {
+            error!("Failed to insert device network intent: {err}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
+    })?;
+
+    sqlx::query!(
+        "UPDATE device SET intent_version = intent_version + 1 WHERE id = $1",
+        resolved_id
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(|err| {
+        error!("Failed to increment intent_version: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let row = sqlx::query_as!(
+        DeviceNetworkIntent,
+        r#"
+        SELECT
+            dni.id,
+            dni.device_id,
+            dni.network_id,
+            dni.priority,
+            dni.managed_by,
+            dni.created_at,
+            dni.updated_at,
+            n.ssid,
+            n.name,
+            n.network_type::TEXT as "network_type!"
+        FROM device_network_intent dni
+        JOIN network n ON n.id = dni.network_id
+        WHERE dni.id = $1
+        "#,
+        intent_id
+    )
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|err| {
+        error!("Failed to fetch created intent: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    tx.commit().await.map_err(|err| {
+        error!("Failed to commit transaction: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok((StatusCode::CREATED, Json(row)))
+}
+
+#[utoipa::path(
+    patch,
+    path = "/devices/{device_id}/intent/{intent_id}",
+    params(
+        ("device_id" = String, Path),
+        ("intent_id" = i32, Path),
+    ),
+    request_body = PatchIntentRequest,
+    responses(
+        (status = StatusCode::OK, description = "Intent row updated", body = DeviceNetworkIntent),
+        (status = StatusCode::NOT_FOUND, description = "Device or intent not found"),
+        (status = StatusCode::INTERNAL_SERVER_ERROR, description = "Failed to update intent"),
+    ),
+    security(
+        ("auth_token" = [])
+    ),
+    tag = DEVICES_TAG
+)]
+pub async fn update_device_intent(
+    Path((device_id, intent_id)): Path<(String, i32)>,
+    Extension(state): Extension<State>,
+    Extension(current_user): Extension<CurrentUser>,
+    Json(payload): Json<PatchIntentRequest>,
+) -> Result<Json<DeviceNetworkIntent>, StatusCode> {
+    if !authorization::check(current_user, "devices", "write") {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    let resolved_id = resolve_device_id(&device_id, &state.pg_pool).await?;
+
+    let mut tx = state.pg_pool.begin().await.map_err(|err| {
+        error!("Failed to start transaction: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let updated = sqlx::query_scalar!(
+        r#"
+        UPDATE device_network_intent
+        SET
+            priority   = COALESCE($3, priority),
+            managed_by = COALESCE($4, managed_by),
+            updated_at = now()
+        WHERE id = $2 AND device_id = $1
+        RETURNING id
+        "#,
+        resolved_id,
+        intent_id,
+        payload.priority,
+        payload.managed_by,
+    )
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|err| {
+        error!("Failed to update device network intent {intent_id}: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    if updated.is_none() {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    sqlx::query!(
+        "UPDATE device SET intent_version = intent_version + 1 WHERE id = $1",
+        resolved_id
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(|err| {
+        error!("Failed to increment intent_version: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let row = sqlx::query_as!(
+        DeviceNetworkIntent,
+        r#"
+        SELECT
+            dni.id,
+            dni.device_id,
+            dni.network_id,
+            dni.priority,
+            dni.managed_by,
+            dni.created_at,
+            dni.updated_at,
+            n.ssid,
+            n.name,
+            n.network_type::TEXT as "network_type!"
+        FROM device_network_intent dni
+        JOIN network n ON n.id = dni.network_id
+        WHERE dni.id = $1
+        "#,
+        intent_id
+    )
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|err| {
+        error!("Failed to fetch updated intent: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    tx.commit().await.map_err(|err| {
+        error!("Failed to commit transaction: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok(Json(row))
+}
+
+#[utoipa::path(
+    delete,
+    path = "/devices/{device_id}/intent/{intent_id}",
+    params(
+        ("device_id" = String, Path),
+        ("intent_id" = i32, Path),
+    ),
+    responses(
+        (status = StatusCode::NO_CONTENT, description = "Intent row deleted"),
+        (status = StatusCode::NOT_FOUND, description = "Device or intent not found"),
+        (status = StatusCode::INTERNAL_SERVER_ERROR, description = "Failed to delete intent"),
+    ),
+    security(
+        ("auth_token" = [])
+    ),
+    tag = DEVICES_TAG
+)]
+pub async fn delete_device_intent(
+    Path((device_id, intent_id)): Path<(String, i32)>,
+    Extension(state): Extension<State>,
+    Extension(current_user): Extension<CurrentUser>,
+) -> Result<StatusCode, StatusCode> {
+    if !authorization::check(current_user, "devices", "write") {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    let resolved_id = resolve_device_id(&device_id, &state.pg_pool).await?;
+
+    let mut tx = state.pg_pool.begin().await.map_err(|err| {
+        error!("Failed to start transaction: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let deleted = sqlx::query_scalar!(
+        "DELETE FROM device_network_intent WHERE id = $2 AND device_id = $1 RETURNING id",
+        resolved_id,
+        intent_id,
+    )
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|err| {
+        error!("Failed to delete device network intent {intent_id}: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    if deleted.is_none() {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    sqlx::query!(
+        "UPDATE device SET intent_version = intent_version + 1 WHERE id = $1",
+        resolved_id
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(|err| {
+        error!("Failed to increment intent_version: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    tx.commit().await.map_err(|err| {
+        error!("Failed to commit transaction: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[utoipa::path(
+    post,
+    path = "/devices/{device_id}/intent/apply",
+    params(
+        ("device_id" = String, Path),
+    ),
+    responses(
+        (status = StatusCode::ACCEPTED, description = "ApplyNetworks command queued", body = ApplyIntentResponse),
+        (status = StatusCode::BAD_REQUEST, description = "No intent (version 0) or network with NULL SSID"),
+        (status = StatusCode::NOT_FOUND, description = "Device not found"),
+        (status = StatusCode::INTERNAL_SERVER_ERROR, description = "Failed to queue command"),
+    ),
+    security(
+        ("auth_token" = [])
+    ),
+    tag = DEVICES_TAG
+)]
+pub async fn apply_device_intent(
+    Path(device_id): Path<String>,
+    Extension(state): Extension<State>,
+    Extension(current_user): Extension<CurrentUser>,
+) -> Result<(StatusCode, Json<ApplyIntentResponse>), StatusCode> {
+    if !authorization::check(current_user, "devices", "write") {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    let resolved_id = resolve_device_id(&device_id, &state.pg_pool).await?;
+
+    let mut tx = state.pg_pool.begin().await.map_err(|err| {
+        error!("Failed to start transaction: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let intent_version: i32 = sqlx::query_scalar!(
+        "SELECT intent_version FROM device WHERE id = $1 FOR UPDATE",
+        resolved_id
+    )
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|err| {
+        error!("Failed to read intent_version for device {resolved_id}: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    if intent_version == 0 {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let networks = sqlx::query!(
+        r#"
+        SELECT
+            dni.priority,
+            n.ssid,
+            n.name,
+            n.password
+        FROM device_network_intent dni
+        JOIN network n ON n.id = dni.network_id
+        WHERE dni.device_id = $1
+        ORDER BY dni.priority ASC
+        "#,
+        resolved_id
+    )
+    .fetch_all(&mut *tx)
+    .await
+    .map_err(|err| {
+        error!("Failed to fetch intent networks for device {resolved_id}: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    if networks.is_empty() || networks.iter().any(|n| n.ssid.is_none()) {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let bundle = sqlx::query!("INSERT INTO command_bundles DEFAULT VALUES RETURNING uuid")
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|err| {
+            error!("Failed to insert command bundle: {err}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    // ApplyNetworks command shape (read by smithd):
+    // {
+    //   "ApplyNetworks": {
+    //     "version": <intent_version: i32>,
+    //     "networks": [
+    //       { "profile_name": "<catalog name>", "ssid": "<ssid>", "priority": <i32>,
+    //         "credentials": { "key_mgmt": "wpa-psk", "psk": "<password>" } }
+    //       { "profile_name": "<catalog name>", "ssid": "<ssid>", "priority": <i32>,
+    //         "credentials": { "key_mgmt": "none" } }  // open network
+    //     ]
+    //   }
+    // }
+    let cmd = serde_json::json!({
+        "ApplyNetworks": {
+            "version": intent_version,
+            "networks": networks.iter().map(|n| {
+                let credentials = if let Some(psk) = n.password.as_deref() {
+                    serde_json::json!({ "key_mgmt": "wpa-psk", "psk": psk })
+                } else {
+                    serde_json::json!({ "key_mgmt": "none" })
+                };
+                serde_json::json!({
+                    "profile_name": n.name,
+                    "ssid": n.ssid.as_deref().unwrap_or(""),
+                    "priority": n.priority,
+                    "credentials": credentials
+                })
+            }).collect::<Vec<_>>()
+        }
+    });
+
+    let command_id: i32 = sqlx::query_scalar!(
+        "INSERT INTO command_queue (device_id, cmd, continue_on_error, canceled, bundle)
+         VALUES ($1, $2::jsonb, false, false, $3)
+         RETURNING id",
+        resolved_id,
+        cmd,
+        bundle.uuid,
+    )
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|err| {
+        error!("Failed to insert ApplyNetworks command for device {resolved_id}: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    tx.commit().await.map_err(|err| {
+        error!("Failed to commit transaction: {err}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(ApplyIntentResponse {
+            bundle_uuid: bundle.uuid,
+            command_id,
+        }),
+    ))
 }

--- a/api/src/home.rs
+++ b/api/src/home.rs
@@ -143,6 +143,12 @@ pub async fn save_responses(
                     profiles_resolved.push((network_id, profile.is_active, profile.name.clone()));
                 }
 
+                // Guard against duplicate NM profile names (broken NM state where two
+                // connections share the same connection.id). Keep the first occurrence so
+                // the INSERT doesn't hit the (device_id, profile_name) PK constraint.
+                let mut seen_names = std::collections::HashSet::new();
+                profiles_resolved.retain(|(_, _, name)| seen_names.insert(name.clone()));
+
                 sqlx::query!(
                     "DELETE FROM device_configured_network WHERE device_id = $1",
                     device_id

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -335,6 +335,15 @@ async fn start_main_server(
         .routes(routes!(device::route::get_audit_for_device))
         .routes(routes!(device::route::get_configured_networks_for_device))
         .routes(routes!(device::route::get_wifi_scan_for_device))
+        .routes(routes!(
+            device::route::get_device_intent,
+            device::route::create_device_intent,
+        ))
+        .routes(routes!(
+            device::route::update_device_intent,
+            device::route::delete_device_intent,
+        ))
+        .routes(routes!(device::route::apply_device_intent))
         .routes(routes!(rollout::route::api_rollout,))
         .routes(routes!(rollout::route::get_distribution_rollouts))
         .routes(routes!(deployment::route::api_get_deployment_devices))

--- a/models/src/device.rs
+++ b/models/src/device.rs
@@ -39,6 +39,10 @@ pub struct Device {
     pub release: Option<Release>,
     pub target_release: Option<Release>,
     pub network: Option<DeviceNetwork>,
+    pub intent_version: i32,
+    pub observed_intent_version: Option<i32>,
+    #[schema(value_type = Option<serde_json::Value>)]
+    pub network_conditions: Option<Value>,
     #[schema(value_type = HashMap<String, String>)]
     pub labels: Json<HashMap<String, String>>,
 }


### PR DESCRIPTION
## What

Adds a `device_network_intent` table and five REST endpoints that let operators define which WiFi networks a device should be configured with, and queue an apply command to push that intent to the device.

## Why

Part of RFC-003 WiFi network management. This is PR A (API layer) of a multi-PR series. The full design is documented in [decisions/003-wifi-apply-rfc.md](https://github.com/Teton-ai/smith/blob/feat/apply-new-wifi/decisions/003-wifi-apply-rfc.md).

Closes #

## Approach

Intent is modelled as a junction table (`device_network_intent`) between `device` and the existing `network` catalog. Each mutation increments `intent_version` on the device row atomically in the same transaction — PR B (smithd) will use this to detect drift without polling.

Five handlers added to `api/src/device/route.rs`:

| Method | Path | Returns |
|---|---|---|
| GET | `/devices/{id}/intent` | `Vec<DeviceNetworkIntent>` 200 |
| POST | `/devices/{id}/intent` | `DeviceNetworkIntent` 201, 409 on SSID dup |
| PATCH | `/devices/{id}/intent/{intent_id}` | `DeviceNetworkIntent` 200 |
| DELETE | `/devices/{id}/intent/{intent_id}` | 204 |
| POST | `/devices/{id}/intent/apply` | `ApplyIntentResponse` 202 |

The Apply endpoint reads the current intent from DB, validates that no password is NULL and the list is non-empty, then queues an `ApplyNetworks` command via the existing `command_bundles`/`command_queue` pattern. The command shape is documented in a comment at the INSERT site for PR B to match.

Three columns added to `device`: `intent_version` (sync counter), `observed_intent_version` (echoed back by smithd in PR C), `network_conditions` (JSONB diagnostics, written by smithd in PR C).

**Rejected alternatives:** separate `intent` module (unnecessary at this scope), denormalized SSID on the intent table (sync hazard), reusing the generic multi-device command endpoint (Apply is per-device and DB-driven).

**Note:** `get_device` was rewritten from `SELECT d.*` to explicit column enumeration. sqlx 0.7 offline mode does not propagate new columns through `SELECT *` in the query cache, which broke `SQLX_OFFLINE=true` builds after the migration.

## Testing

- [x] `SQLX_OFFLINE=true cargo clippy --all-features -- -Dwarnings` passes
- [x] Manual smoke test: GET (empty list), POST (201), PATCH (priority updated, `updated_at` bumped), duplicate POST (409), unknown `network_id` (400), Apply (202 + row in `command_queue`), Apply with empty intent (400), DELETE (204), DELETE again (404) — all passed against local stack

## Checklist

- [x] No unintended side effects on adjacent features
- [x] Breaking change? No — additive only; existing `GET /device` response gains three new nullable fields
