### PR TITLE
fix(updater): re-fetch evicted blobs instead of trusting the release cache

### DIFF
--- a/smithd/src/updater/actor.rs
+++ b/smithd/src/updater/actor.rs
@@ -348,8 +348,19 @@ impl Actor {
             .join(release_id.to_string());
 
         if release_cache.exists() {
-            info!("release cache exists, skipping download");
-            return Ok(());
+            // Evicted/missing blobs must be re-fetched, manifest or not.
+            let manifest = tokio::fs::read_to_string(&release_cache).await?;
+            let blobs = self.packages_dir.join("blobs");
+            let all_present = manifest
+                .lines()
+                .filter_map(|line| line.split(' ').nth(2))
+                .all(|file| blobs.join(file).exists());
+            if all_present {
+                info!("release cache exists, skipping download");
+                return Ok(());
+            }
+            warn!("release cache exists but blobs are missing; re-fetching");
+            tokio::fs::remove_file(&release_cache).await?;
         }
 
         // Prefer the short-lived device JWT; falls back to the opaque token when


### PR DESCRIPTION
`ensure_release_cache` short-circuits when the release manifest file exists — but the corrupt-package handling in `upgrade_device` deletes a bad blob precisely so it gets re-downloaded. The manifest survives the eviction, so the next cycle skips the download and the upgrade loops on `Package X does not exist locally` every check interval, forever. The device stays wedged until the release cache is cleared by hand.

Fix: trust the manifest only if every blob it lists is still on disk; otherwise drop it and re-fetch. Also heals manual blob deletion / disk cleanup.

Reproduced and verified in the compose dev env: serve a corrupt deb → install fails, blob evicted → device loops on "does not exist locally"; with this fix it logs "release cache exists but blobs are missing; re-fetching", re-downloads, and converges once the served file is fixed.