### PR TITLE
fix: include all NMProfile fields in redacted command log

### DIFF
--- a/api/src/home.rs
+++ b/api/src/home.rs
@@ -468,15 +468,16 @@ pub async fn save_responses(
         }
         let mut response_json = match &response.command {
             SafeCommandRx::ReportNMProfiles { profiles } => {
+                // Serialize the whole profile so any future NMProfile field is kept
+                // automatically, then redact just the secret.
                 let redacted: Vec<_> = profiles
                     .iter()
                     .map(|p| {
-                        json!({
-                            "name": p.name,
-                            "ssid": p.ssid,
-                            "password": null,
-                            "is_active": p.is_active,
-                        })
+                        let mut v = json!(p);
+                        if let Some(obj) = v.as_object_mut() {
+                            obj.insert("password".to_string(), Value::Null);
+                        }
+                        v
                     })
                     .collect();
                 json!({ "ReportNMProfiles": { "profiles": redacted } })


### PR DESCRIPTION
## What

The `ReportNMProfiles` command's stored response (shown on the device's Commands page) was hardcoded to only include `name`, `ssid`, `password` (always null), and `is_active`. The 7 new fields added in #510 (`key_mgmt`, `hidden`, `pmf`, `eap`, `phase2_auth`, `anonymous_identity`, `eap_identity`) were silently dropped from this display log, even though they were correctly written to the `network` table.

## Why

Found while verifying #510 in production: a device's Commands page showed a `ReportNMProfiles` response with only the old 4 fields, which looked like the device was still running old smithd. Checking the `network` table directly showed the real data (`security_type`, `credentials.pmf`, etc.) was populated correctly — the bug was isolated to this display/audit log, not the actual write path.

## Approach

`api/src/home.rs`: the redaction step used to manually rebuild a JSON object field-by-field, which meant every future `NMProfile` field addition would need this code updated too (as just happened). Changed it to serialize the whole profile via `serde_json::json!(p)` and then null out just the `password` key on the resulting object, so any future field is included automatically without needing this redaction logic touched again.

Only `password` (the WPA-PSK) is redacted. Everything else (`key_mgmt`, `hidden`, `pmf`, `eap`, `phase2_auth`, `anonymous_identity`, `eap_identity`) is non-secret protocol metadata or, in `eap_identity`'s case, a username (not a credential) — same sensitivity class as `ssid`, which was already shown unredacted.

The separate `network.credentials` JSONB column (which legitimately needs to store the real PSK for the apply pipeline to work) is untouched — this fix only affects the command-log display path.

## Testing

- [x] `cargo clippy -p api --all-features -- -Dwarnings` clean
- [x] `cargo build -p api` (offline) clean
- [x] Manual smoke test: triggered `ReportNMProfiles` locally, confirmed the Commands page now shows `key_mgmt`, `hidden`, `pmf` etc. per profile, with `password` still `null`

## Checklist

- [x] No unintended side effects on adjacent features (`network.credentials` write path untouched)
- [x] Breaking change? No — purely additive to the displayed JSON shape
- [x] Docs / changelog updated if user-facing — not user-facing