### PR TITLE
fix: Remove flashing stack trace when loading a new device

### DIFF
--- a/dashboard/app/(private)/devices/[serial]/WifiPanel.tsx
+++ b/dashboard/app/(private)/devices/[serial]/WifiPanel.tsx
@@ -197,22 +197,28 @@ const WifiPanel = ({ serial, device }: WifiPanelProps) => {
 	const [securityFilter, setSecurityFilter] = useState("all");
 
 	const {
-		data: profiles,
+		data: profilesRaw,
 		isLoading,
 		isError,
 	} = useGetConfiguredNetworksForDevice(serial, {
 		query: { refetchInterval: syncing ? 3000 : 30000 },
 	});
+	// Guard against a non-array body (e.g. an axios "success" resolved from a
+	// terminated request with an empty response): `?? []`/`?.` only catch
+	// null/undefined, so a stray "" or object would make .map/.filter/spread
+	// below throw and surface react-router's error page for a frame.
+	const profiles = Array.isArray(profilesRaw) ? profilesRaw : [];
 
-	const currentNetwork = profiles?.find((p) => p.is_active);
+	const currentNetwork = profiles.find((p) => p.is_active);
 
 	const {
-		data: scanResults,
+		data: scanResultsRaw,
 		isLoading: isScanLoading,
 		isError: isScanError,
 	} = useGetWifiScanForDevice(serial, {
 		query: { refetchInterval: scanSyncing ? 3000 : false },
 	});
+	const scanResults = Array.isArray(scanResultsRaw) ? scanResultsRaw : [];
 
 	const startProfileSync = useCommandSync(
 		syncing,
@@ -251,14 +257,13 @@ const WifiPanel = ({ serial, device }: WifiPanelProps) => {
 	});
 
 	const securityOptions = useMemo(
-		() =>
-			[...new Set((scanResults ?? []).map((r) => r.security ?? "Open"))].sort(),
+		() => [...new Set(scanResults.map((r) => r.security ?? "Open"))].sort(),
 		[scanResults],
 	);
 
 	const filteredResults = useMemo(() => {
 		const query = scanQuery.trim().toLowerCase();
-		return (scanResults ?? []).filter((r) => {
+		return scanResults.filter((r) => {
 			if (
 				query &&
 				!r.ssid?.toLowerCase().includes(query) &&
@@ -299,12 +304,15 @@ const WifiPanel = ({ serial, device }: WifiPanelProps) => {
 		prevSyncing.current = syncing;
 	}, [syncing, queryClient]);
 
-	const { data: intentList } = useGetDeviceIntent(deviceId, {
+	const { data: intentListRaw } = useGetDeviceIntent(deviceId, {
 		query: { refetchInterval: 30_000 },
 	});
 	const sortedIntent = useMemo(
-		() => [...(intentList ?? [])].sort((a, b) => a.priority - b.priority),
-		[intentList],
+		() =>
+			(Array.isArray(intentListRaw) ? [...intentListRaw] : []).sort(
+				(a, b) => a.priority - b.priority,
+			),
+		[intentListRaw],
 	);
 
 	const [applying, setApplying] = useState(false);
@@ -526,9 +534,9 @@ const WifiPanel = ({ serial, device }: WifiPanelProps) => {
 
 	// useGetNetworks returns void in the generated client (missing utoipa response annotation); cast is safe at runtime
 	const { data: catalogRaw } = useGetNetworks();
-	const wifiCatalog = ((catalogRaw ?? []) as CatalogNetwork[]).filter(
-		(n) => n.network_type === "wifi" && n.ssid != null,
-	);
+	const wifiCatalog = (
+		Array.isArray(catalogRaw) ? (catalogRaw as CatalogNetwork[]) : []
+	).filter((n) => n.network_type === "wifi" && n.ssid != null);
 
 	async function swapPriority(indexA: number, indexB: number) {
 		const a = sortedIntent[indexA];


### PR DESCRIPTION
The device detail page briefly flashed react-router's default error page (`Unexpected Application Error!` + a raw stack trace) before rendering correctly. I could only reproduce it on production on Firefox; it didn't happen on local or in any other browser.

Before this patch, there were some requests that were returned status code 0 on a cold cache, but succeeded after a refetch. Return code 0 is treated differently in Firefox from Chrome and other browsers, which explains all behaviour.

AI explanation of what happened:

<details>
On the broken loads, every API call fired on mount (wifi-scan, configured-networks, intent, networks, etc.) briefly came back with status: 0 and an empty body, followed ~700ms later by a normal retry that succeeded — so the flash always cleared itself, which is why it was easy to miss.

Traced it to how axios handles that: settle() treats status === 0 as a success, not an error (!response.status || ... short-circuits the validation), and its default transformResponse skips JSON-parsing an empty string entirely. So instead of rejecting, axios resolves with data: "".

WifiPanel.tsx consumed that data with scanResults ?? [] / intentList ?? [] / profiles?.find(...). ?? and ?. only substitute on null/undefined — an empty string is neither, so it sailed straight through as scanResults, and "".map(...) inside a useMemo threw TypeError: (intermediate value).map is not a function, crashing the render until the retry resolved.

This lines up with page-D7Y9oVxA.js/index-BggxfnXL.js in the reported stack trace — confirmed by matching those exact chunk hashes against a local build and tracing the source map back to this file's securityOptions memo.
</details>