### PR TITLE
fix: match network identity so EAP credentials stay separate

### DIFF
--- a/api/.sqlx/query-b92c629ffc20975d1ba64b3ba7f01c03c6a18f5dd8204828d982c253b65b2182.json
+++ b/api/.sqlx/query-b92c629ffc20975d1ba64b3ba7f01c03c6a18f5dd8204828d982c253b65b2182.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT network_find_by_content($1, $2, $3, $4, 'wifi')",
+  "query": "SELECT network_find_by_content($1, $2, $3, $4, 'wifi', $5)",
   "describe": {
     "columns": [
       {
@@ -14,12 +14,13 @@
         "Text",
         "Bool",
         "Jsonb",
-        "Text"
+        "Text",
+        "Jsonb"
       ]
     },
     "nullable": [
       null
     ]
   },
-  "hash": "0137af42633aa3582555660ce4c5c937b6cb295107b231b620406de3b349d198"
+  "hash": "b92c629ffc20975d1ba64b3ba7f01c03c6a18f5dd8204828d982c253b65b2182"
 }

--- a/api/migrations/20260803000000_network_eap_identity_match.sql
+++ b/api/migrations/20260803000000_network_eap_identity_match.sql
@@ -1,0 +1,35 @@
+-- wpa-eap has no shared psk, so every field the Stage 3 match compared was equal
+-- for any two EAP rows on one SSID: the second device landed on the first
+-- device's row and its own credential was dropped. Add identity to the match.
+--
+-- The lock key stays as it is. Coarsening a lock only merges buckets, so two EAP
+-- rows sharing an SSID serializing against each other is correct.
+
+-- DEFAULT NULL rather than an overload: a 5-argument call cannot be resolved
+-- between a 5-argument and a 6-argument-with-default candidate, so the old
+-- signature has to go. Existing 5-argument callers land here with p_identity
+-- NULL, the relaxed case, so their behaviour is unchanged.
+DROP FUNCTION IF EXISTS public.network_find_by_content(text, boolean, jsonb, text, text);
+
+-- The identity clause is relaxed in both directions like the security_type one
+-- above it, so a writer that knows no identity converges instead of forking, and
+-- an identified writer still heals a row that has none. ORDER BY keeps
+-- security_type primary to leave the existing ordering guarantees untouched.
+CREATE OR REPLACE FUNCTION public.network_find_by_content(
+    p_ssid text, p_is_network_hidden boolean, p_credentials jsonb,
+    p_security_type text, p_network_type text, p_identity jsonb DEFAULT NULL
+) RETURNS integer LANGUAGE sql STABLE
+SET search_path = pg_catalog, public
+AS $$
+    SELECT id FROM public.network
+    WHERE ssid IS NOT DISTINCT FROM p_ssid
+      AND is_network_hidden = p_is_network_hidden
+      AND network_type::text = p_network_type
+      AND (credentials->>'psk') IS NOT DISTINCT FROM (p_credentials->>'psk')
+      AND (p_security_type IS NULL OR security_type = p_security_type OR security_type IS NULL)
+      AND (p_identity IS NULL OR identity = p_identity OR identity IS NULL)
+    ORDER BY (security_type IS NOT DISTINCT FROM p_security_type) DESC,
+             (identity IS NOT DISTINCT FROM p_identity) DESC,
+             id DESC
+    LIMIT 1;
+$$;

--- a/api/src/home.rs
+++ b/api/src/home.rs
@@ -204,12 +204,15 @@ pub async fn save_responses(
                     // Shared with create_network (api/src/network/route.rs) so the match
                     // cannot drift between writers; see network_find_by_content (arch.md).
                     // ReportNMProfiles only ever describes wifi.
+                    // Only writer that knows an identity. Without it, two devices holding
+                    // different EAP credentials for one SSID match each other's row.
                     let existing_id: Option<i32> = sqlx::query_scalar!(
-                        r#"SELECT network_find_by_content($1, $2, $3, $4, 'wifi')"#,
+                        r#"SELECT network_find_by_content($1, $2, $3, $4, 'wifi', $5)"#,
                         ssid,
                         hidden,
                         &identity_credentials,
                         mapped_security_type as Option<&str>,
+                        identity_val.as_ref() as Option<&serde_json::Value>,
                     )
                     .fetch_one(&mut *tx)
                     .await?;

--- a/api/src/network/route.rs
+++ b/api/src/network/route.rs
@@ -306,6 +306,8 @@ pub async fn create_network(
     .await
     .map_err(internal_error("Failed to take network content lock"))?;
 
+    // NewNetwork carries no identity, so p_identity takes its DEFAULT NULL and
+    // stays relaxed: matches an identified row rather than forking a copy of it.
     let existing_id: Option<i32> = sqlx::query_scalar!(
         r#"SELECT network_find_by_content($1, $2, $3, $4, $5)"#,
         new_network.ssid,

--- a/e2e/tests/daemon_api.rs
+++ b/e2e/tests/daemon_api.rs
@@ -401,6 +401,148 @@ async fn repeated_untyped_profile_report_does_not_duplicate() -> Result<()> {
     Ok(())
 }
 
+/// Regression guard for the EAP blind spot: with no shared psk, every field the
+/// pre-identity match compared was equal for two EAP rows on one SSID. Distinct
+/// identities must not match each other, and an unknown identity must still reach
+/// an identified row, since POST /networks and old smithd never send one.
+#[tokio::test]
+#[ignore = "requires running compose stack; use make test.e2e"]
+async fn distinct_eap_identities_on_one_ssid_do_not_match() -> Result<()> {
+    let ctx = Ctx::connect().await?;
+    wait_for_api(&ctx).await?;
+
+    if !has_stage3_content_addressing(&ctx).await? {
+        println!(
+            "skipping distinct_eap_identities_on_one_ssid_do_not_match: \
+             network_content_lock_key not present (released-api version-skew job)"
+        );
+        return Ok(());
+    }
+
+    let ssid = format!("e2e-eap-{}", uuid::Uuid::new_v4());
+    // No psk: the psk clause matches trivially, leaving identity as the only field
+    // that can tell the two rows apart.
+    let credentials = serde_json::json!({ "eap": "peap", "phase2_auth": "mschapv2" });
+    let identity_a = serde_json::json!({ "username": "e2e-box-a" });
+    let identity_b = serde_json::json!({ "username": "e2e-box-b" });
+
+    let insert = |identity: Option<serde_json::Value>| {
+        let (ssid, credentials) = (ssid.clone(), credentials.clone());
+        let pool = ctx.db.clone();
+        async move {
+            sqlx::query_scalar::<_, i32>(
+                "INSERT INTO network
+                     (ssid, name, network_type, is_network_hidden,
+                      security_type, credentials, identity)
+                 VALUES ($1, $1, 'wifi', false, 'wpa-eap', $2, $3)
+                 RETURNING id",
+            )
+            .bind(&ssid)
+            .bind(&credentials)
+            .bind(identity)
+            .fetch_one(&pool)
+            .await
+        }
+    };
+
+    let find = |identity: Option<serde_json::Value>| {
+        let (ssid, credentials) = (ssid.clone(), credentials.clone());
+        let pool = ctx.db.clone();
+        async move {
+            sqlx::query_scalar::<_, Option<i32>>(
+                "SELECT network_find_by_content($1, false, $2, 'wpa-eap', 'wifi', $3)",
+            )
+            .bind(&ssid)
+            .bind(&credentials)
+            .bind(identity)
+            .fetch_one(&pool)
+            .await
+        }
+    };
+
+    struct Outcome {
+        a_id: i32,
+        matched_a: Option<i32>,
+        matched_b_before_insert: Option<i32>,
+        matched_b_after_insert: Option<i32>,
+        matched_unknown: Option<i32>,
+        b_id: i32,
+    }
+
+    // Wrapped so a failed insert or match still reaches the cleanup below rather
+    // than leaking the rows inserted up to that point.
+    let outcome: Result<Outcome> = async {
+        let a_id = insert(Some(identity_a.clone()))
+            .await
+            .context("inserting EAP row A")?;
+
+        let matched_a = find(Some(identity_a.clone()))
+            .await
+            .context("matching identity A")?;
+
+        // The bug: with only A present, identity B used to be handed A's id.
+        let matched_b_before_insert = find(Some(identity_b.clone()))
+            .await
+            .context("matching identity B against row A alone")?;
+
+        let b_id = insert(Some(identity_b.clone()))
+            .await
+            .context("inserting EAP row B")?;
+
+        let matched_b_after_insert = find(Some(identity_b.clone()))
+            .await
+            .context("matching identity B with both rows present")?;
+
+        let matched_unknown = find(None).await.context("matching without an identity")?;
+
+        Ok(Outcome {
+            a_id,
+            matched_a,
+            matched_b_before_insert,
+            matched_b_after_insert,
+            matched_unknown,
+            b_id,
+        })
+    }
+    .await;
+
+    sqlx::query("DELETE FROM network WHERE ssid = $1")
+        .bind(&ssid)
+        .execute(&ctx.db)
+        .await
+        .context("cleaning up eap ssid")?;
+
+    let Outcome {
+        a_id,
+        matched_a,
+        matched_b_before_insert,
+        matched_b_after_insert,
+        matched_unknown,
+        b_id,
+    } = outcome?;
+
+    ensure!(
+        matched_a == Some(a_id),
+        "identity A must match its own row {a_id}, got {matched_a:?}"
+    );
+    ensure!(
+        matched_b_before_insert.is_none(),
+        "identity B must not match row {a_id}, which holds identity A; got \
+         {matched_b_before_insert:?}"
+    );
+    ensure!(
+        matched_b_after_insert == Some(b_id),
+        "identity B must match its own row {b_id}, got {matched_b_after_insert:?}"
+    );
+    ensure!(
+        matched_unknown == Some(b_id),
+        "a writer with no identity must stay relaxed and reach the newest row {b_id} \
+         (id DESC tiebreak among equally-relaxed matches), got {matched_unknown:?}"
+    );
+
+    Ok(())
+}
+
 /// Regression guard for the healing half of F4 and for the match ordering that
 /// makes it safe. A typed writer must reach an existing NULL-`security_type` row
 /// (rather than inserting a second one) and fill the type in, but when an exact

--- a/e2e/tests/daemon_api.rs
+++ b/e2e/tests/daemon_api.rs
@@ -425,6 +425,7 @@ async fn distinct_eap_identities_on_one_ssid_do_not_match() -> Result<()> {
     let credentials = serde_json::json!({ "eap": "peap", "phase2_auth": "mschapv2" });
     let identity_a = serde_json::json!({ "username": "e2e-box-a" });
     let identity_b = serde_json::json!({ "username": "e2e-box-b" });
+    let identity_c = serde_json::json!({ "username": "e2e-box-c" });
 
     let insert = |identity: Option<serde_json::Value>| {
         let (ssid, credentials) = (ssid.clone(), credentials.clone());
@@ -466,7 +467,9 @@ async fn distinct_eap_identities_on_one_ssid_do_not_match() -> Result<()> {
         matched_b_before_insert: Option<i32>,
         matched_b_after_insert: Option<i32>,
         matched_unknown: Option<i32>,
+        matched_healable: Option<i32>,
         b_id: i32,
+        null_ident_id: i32,
     }
 
     // Wrapped so a failed insert or match still reaches the cleanup below rather
@@ -495,13 +498,25 @@ async fn distinct_eap_identities_on_one_ssid_do_not_match() -> Result<()> {
 
         let matched_unknown = find(None).await.context("matching without an identity")?;
 
+        // Inserted last on purpose: an identity-NULL row is relaxed against every
+        // p_identity, so it would win the ordering tiebreak and change every
+        // assertion above. Identity C matches neither A nor B exactly, leaving the
+        // NULL row as the only candidate, which is the healing direction.
+        let null_ident_id = insert(None).await.context("inserting identity-NULL row")?;
+
+        let matched_healable = find(Some(identity_c.clone()))
+            .await
+            .context("matching a third identity against the identity-NULL row")?;
+
         Ok(Outcome {
             a_id,
             matched_a,
             matched_b_before_insert,
             matched_b_after_insert,
             matched_unknown,
+            matched_healable,
             b_id,
+            null_ident_id,
         })
     }
     .await;
@@ -518,7 +533,9 @@ async fn distinct_eap_identities_on_one_ssid_do_not_match() -> Result<()> {
         matched_b_before_insert,
         matched_b_after_insert,
         matched_unknown,
+        matched_healable,
         b_id,
+        null_ident_id,
     } = outcome?;
 
     ensure!(
@@ -538,6 +555,12 @@ async fn distinct_eap_identities_on_one_ssid_do_not_match() -> Result<()> {
         matched_unknown == Some(b_id),
         "a writer with no identity must stay relaxed and reach the newest row {b_id} \
          (id DESC tiebreak among equally-relaxed matches), got {matched_unknown:?}"
+    );
+    ensure!(
+        matched_healable == Some(null_ident_id),
+        "an identified writer must reach the identity-NULL row {null_ident_id} to heal it, \
+         and must not match rows {a_id} or {b_id} which hold other identities; got \
+         {matched_healable:?}"
     );
 
     Ok(())


### PR DESCRIPTION
## What
Add `identity` to the content-addressed identity match introduced in #524, so two devices holding
different wpa-eap credentials for the same SSID no longer resolve to each other's `network` row.

## Why
Closes #

`network_find_by_content` compares `(ssid, is_network_hidden, network_type, credentials->>'psk',
security_type)`. For wpa-eap there is no shared psk: every device authenticates with its own
credential, stored in `network.identity`, and the psk clause matches trivially on both sides because
both are NULL. So for two EAP rows on one SSID every compared field is equal and the match collapses
them: the second device is handed the first device's row, its own identity is never stored, and
pushing config back down from that row would push the wrong username. No error, no duplicate row,
nothing visible in a row count.

Found while auditing the `network` table for the dedupe work: the three EAP rows in prod each carry a
distinct identity (`DAC-E1CR7`, `teton.spital.lokal`, `tetonbox01`) that the match never looks at.
Not reachable today because those three sit on three different SSIDs, so the `ssid` clause keeps them
apart, but that is deployment luck rather than a property of the code: one site issuing per-device
EAP credentials produces it immediately.

## Approach
- **Migration `20260803000000_network_eap_identity_match.sql`** adds `p_identity jsonb DEFAULT NULL`
  to `network_find_by_content`. The clause mirrors the `security_type` one exactly, bidirectionally
  relaxed: a writer that does not know an identity still converges onto an identified row rather than
  forking, and an identified writer still heals a row that has none. Only two writers that both know
  an identity, and disagree, stop matching.
- **`DEFAULT NULL` rather than an overload.** Two candidates differing only by a defaulted trailing
  argument are ambiguous to the resolver, so the 5-argument version is dropped and recreated. Every
  existing 5-argument call site keeps resolving to the new function and gets `p_identity => NULL`,
  which is the relaxed case, so no caller changes behaviour and a rolling deploy is safe in both
  directions.
- **`ORDER BY`** keeps `security_type` as the primary preference, leaving the ordering already
  covered by `typed_match_prefers_exact_row_over_null_row` untouched. The identity preference breaks
  ties beneath it and ahead of `id DESC`, so an exact identity wins over a merely-relaxed row of the
  same `security_type`.
- **`ReportNMProfiles`** (`api/src/home.rs`) passes the identity it already computes. It is the only
  writer that knows one.
- **`create_network`** (`api/src/network/route.rs`) is unchanged apart from a comment: `NewNetwork`
  carries no identity, so it stays on the relaxed side by taking the default.
- **The lock key is deliberately not changed.** It already excludes `security_type`; coarsening a
  lock only merges buckets, never splits an identity group, so two EAP rows sharing an SSID
  serialize against each other, which is what we want.

### Rejected alternatives
- Adding `identity` to `network_content_lock_key` — splits the lock for rows the match may still
  merge, which is the one direction of lock change that is not safe.
- Keeping the 5-argument function as an overload alongside a 6-argument one — Postgres cannot resolve
  a 5-argument call between them.
- Leaving it as a known gap — the fix is a few lines in a function this PR series already owns, and
  the failure mode is silent credential loss rather than a duplicate row, so it would not show up in
  the row-count monitoring the rest of this work is built around.

## Testing
- [x] `cargo clippy -p api -p smith-e2e --all-features --all-targets -- -Dwarnings` clean;
      `cargo fmt --check` clean; `cargo test -p api` 33/33 passing.
- [x] `cargo sqlx prepare` regenerated: exactly one cached query replaced, the `ReportNMProfiles`
      match.
- [x] New e2e test `distinct_eap_identities_on_one_ssid_do_not_match`
      (`e2e/tests/daemon_api.rs`): identity B must not match a row holding identity A; each identity
      matches its own row once both exist; a writer with no identity stays relaxed and still reaches
      a row.
- [x] Verified directly against a dev DB restored from the July 31 prod dump: identity B against an
      A-only SSID returns NULL (previously returned A), each identity matches its own row, an
      identity-less writer still matches, and an identified writer still reaches an
      `identity IS NULL` row so the healing path is intact.
- [ ] Full `make test.e2e` run.

## Checklist
- [x] No unintended side effects on adjacent features — `create_network` behaviour is byte-identical
      (it passes no identity and every row it creates has `identity IS NULL`). `ReportNMProfiles`
      changes only for profiles that report an EAP identity.
- [x] Breaking change? No. The SQL signature gains a defaulted trailing argument, so 5-argument
      callers are unaffected; no HTTP contract changes.
- [ ] Docs / changelog updated if user-facing — no user-facing change; internal API/DB behaviour only.