### PR TITLE
chore: add network table deduplication tooling

### DIFF
--- a/scripts/dedupe-network/README.md
+++ b/scripts/dedupe-network/README.md
@@ -24,7 +24,7 @@ already there.
 Phases 2, 3 and 4 all group on the same tuple, under **strict** equality (NULL
 equal to NULL). It is defined once as `NETWORK_CONTENT_KEY` in `_common.sh`:
 
-```
+```sql
 (ssid, is_network_hidden, credentials->>'psk', network_type, security_type, identity)
 ```
 
@@ -60,6 +60,14 @@ Two consequences worth knowing:
 Phases 2 and 3 both remap the four device-side FKs (`device.network_id`,
 `device.current_network_id`, `device_configured_network.network_id`,
 `device_network_intent.network_id`) with a plain `UPDATE` before deleting.
+
+`device_network_intent` is `UNIQUE (device_id, network_id)`, so the plain
+`UPDATE` aborts where one device holds intents on several rows of the same group.
+Both scripts delete the losing intents first. Only rows being remapped are
+eligible for deletion, so an intent already sitting on the canonical row keeps
+its priority; among remapped ones the oldest survives. `device_configured_network`
+needs no such handling: its primary key is `(device_id, profile_name)` and does
+not involve `network_id`.
 
 `network_reference` needs different handling. Its FK is `ON DELETE RESTRICT`, so
 it must be repointed before the delete or the whole transaction aborts, and its
@@ -114,7 +122,13 @@ Two details in the delete condition:
   how long the run takes.
 - Empty-string passwords are normalized to NULL first, so open networks compare
   consistently across every phase. `network.password` is still written by the API
-  alongside `credentials`, so this is live, not legacy cleanup.
+  alongside `credentials`, so this is live, not legacy cleanup. This is scoped to
+  the same watermark, so the phase never writes to a row it would not delete, and
+  the report prints how many rows it touched.
+- The delete is driven from the staged `_to_delete` table rather than
+  re-evaluating the condition, so the printed plan is exactly what is deleted.
+  Under `READ COMMITTED` each statement takes its own snapshot, so re-evaluating
+  could delete a row the report never showed.
 - The `dup_group` column in the report uses the same content key as phases 2 to
   4, so a group shown here is the group those phases will act on.
 
@@ -218,7 +232,14 @@ This matters because the two commits cannot be atomic:
    points at a row the next step deletes. The assertion `RAISE`s rather than
    printing a count, so a partial update aborts the run instead of letting the
    Smith step strand the bridges it missed.
-4. Remap Smith FKs, fold credentials, delete non-canonical Smith rows.
+4. Re-fetch the refs, then remap Smith FKs, fold credentials, and delete
+   non-canonical Smith rows.
+
+The step 4 re-fetch is a guard, not a refresh: step 3 moved every bridge this run
+knew about off its old row, so a ref still sitting on an old row is one the sync
+job created in between. Deleting that row would strand it, so the whole remap for
+that row is dropped and reported under `HELD BACK`. Re-running converges. Phase 4
+guards its own delete the same way.
 
 App API goes first so a failure fails recoverably: the bridge points at the
 canonical row, which still exists, and re-running converges. The reverse order
@@ -231,6 +252,15 @@ Every payload is streamed into psql from a **quoted** heredoc. Device serial
 numbers are free text and real values contain spaces, commas, `+` and `/`, so an
 unquoted heredoc would let bash expand a serial containing `$` or a backtick.
 Values reach the server as `COPY` data and never become SQL program text.
+
+The quoting stops bash, not psql. psql ends COPY data at a line holding only
+`\.`, before the server sees any of it, and reads whatever follows as psql input.
+CSV quoting is no defence: a free-text value containing a newline can put such a
+line into the stream, and everything after it then runs as meta-commands, `\!`
+included, with the permissions of whoever is running the script. `copy_block`
+therefore refuses any payload containing that line rather than trying to escape
+it. Writing the payload to a file instead would only half fix it: it stops the
+meta-commands but still truncates the data at the same point.
 
 ```bash
 ./scripts/dedupe-network/phase3-dedupe-skipped-groups.sh <app-api-db-url> [<smith-db-url>] [--commit]
@@ -299,7 +329,10 @@ play and the choice falls to Smith references, then `min(id)`.
 
 Reads the same four App API tables as phase 3, plus `network_wifis.ssid`,
 `hidden` and `password`. **That payload carries live WiFi passwords**: it is
-streamed as `COPY` data, never echoed, and never interpolated into SQL text.
+streamed as `COPY` data, never echoed, never interpolated into SQL text, and
+never written to disk. It goes through the same `copy_block` check as every other
+payload, which matters most here: a password is the field an outside user
+controls most directly.
 
 ## Shared helpers
 
@@ -310,7 +343,8 @@ streamed as `COPY` data, never echoed, and never interpolated into SQL text.
   are validated as such; the device and wifi-content payloads are free text and
   are streamed instead.
 - `copy_block`, which emits a `\copy` command, its payload and its terminator
-  between quoted heredocs.
+  between quoted heredocs, after rejecting any payload that carries a `\.` line
+  of its own. See "Payload handling" for why that check is the whole defence.
 - `NETWORK_CONTENT_KEY` and `emit_referenced`. The content key is written **once**
   here and used by phases 2, 3 and 4, so the invariant the whole toolchain rests
   on cannot drift between scripts. `emit_referenced` builds `_referenced`, every
@@ -327,15 +361,35 @@ dedupe run in that window can delete a row the App API is about to point at.
 
 Two windows:
 
-- A row created **after** the run started. Closed deterministically by an id
-  watermark (`network.id` is `generated always as identity`, so it is monotonic;
-  the table has no `created_at`).
+- A row created **after** the run started. Bounded, but not closed, by an id
+  watermark (`network.id` is `generated always as identity`; the table has no
+  `created_at`).
 - A row that already existed and is bridged **after** the ref fetch. Narrowed by
   fetching refs twice and taking the union.
 
-Window B stays open for the duration of the transaction itself, which no
-client-side scheme can close. What closes it in practice is the precondition
-below, not timing.
+The watermark is weaker than it looks, and deliberately so. Sequences are
+non-transactional, so a row can be allocated a low id, commit late, and land
+below a watermark read in between. It is therefore a bound on which rows are in
+**scope**, not a guarantee that a new row is safe.
+
+Locking `network` does not fix this, which is why it is not done. Whether the
+lock is held across the whole transaction or only around the watermark read, the
+late-committing row is still below the watermark and still unbridged, so it is
+deleted either way. All the lock adds is blocking: lock requests are granted
+FIFO, so ordinary inserts queue behind a waiting request even though they do not
+conflict with whatever it is waiting for. Measured at 6.1s for one unrelated
+insert while a single writer held an open transaction.
+
+Pinning a `REPEATABLE READ` snapshot **before** the App API ref fetch would be
+correct, since a row committing afterwards is invisible and cannot be deleted.
+It needs the psql connection held open across the App API round-trip, which the
+current one-shot pipe cannot do. Deferred on cost, not rejected on merit.
+
+What actually defends this is the ref refresh, the precondition below, and an
+operational freeze. The real window is "the row exists and its bridge is not
+written yet", and only reading the bridges addresses that. If a hard fix is ever wanted, it is
+`track_commit_timestamp = on` plus `pg_xact_commit_timestamp(xmin)`, which
+supplies the `created_at` this table lacks.
 
 ## When to run
 
@@ -370,5 +424,5 @@ Two smaller points:
   so a gap between them is a gap in which the fleet moves under the plan you
   just read.
 - Device reports create new `network` rows at a low rate (3 rows in the 21 hours
-  between two consecutive prod dumps). Those are already covered by the id
-  watermark, so they constrain nothing.
+  between two consecutive prod dumps). Nothing prevents those, and nothing needs
+  to: a row a device report creates is re-reported on the next cycle.

--- a/scripts/dedupe-network/README.md
+++ b/scripts/dedupe-network/README.md
@@ -1,7 +1,7 @@
 # Network Table Deduplication
 
 One-off tooling to collapse duplicate `network` rows. Read this before running
-anything: phase 3 writes to a database Smith does not own.
+anything: phases 3 and 4 write to a database Smith does not own.
 
 ## Background
 
@@ -21,7 +21,7 @@ already there.
 
 ## The content key
 
-Phases 2 and 3 both group on the same tuple, under **strict** equality (NULL
+Phases 2, 3 and 4 all group on the same tuple, under **strict** equality (NULL
 equal to NULL). It is defined once as `NETWORK_CONTENT_KEY` in `_common.sh`:
 
 ```
@@ -115,8 +115,8 @@ Two details in the delete condition:
 - Empty-string passwords are normalized to NULL first, so open networks compare
   consistently across every phase. `network.password` is still written by the API
   alongside `credentials`, so this is live, not legacy cleanup.
-- The `dup_group` column in the report uses the same content key as phases 2
-  and 3, so a group shown here is the group those phases will act on.
+- The `dup_group` column in the report uses the same content key as phases 2 to
+  4, so a group shown here is the group those phases will act on.
 
 ```bash
 ./scripts/dedupe-network/phase1-delete-unreferenced.sh <app-api-db-url> [<smith-db-url>] [--commit]
@@ -242,9 +242,68 @@ Phase 3 reads four App API tables: `network_smith` (the bridge it rewrites),
 
 Pause `departmentNetworkSmithSync` for this run if you can.
 
+### Phase 4: repair stale bridges (writes to the App API)
+
+`phase4-repair-stale-bridges.sh`
+
+Picks up what phases 1 to 3 could not deal with: the bridges phase 3 classified
+`UNSUPPORTED` and held back. Repoints the ones with a computable destination,
+then deletes the Smith rows that repair leaves unreferenced.
+
+#### The resolution test
+
+A destination is only defensible when two independent things agree:
+
+1. The App API record's **own** content (`ssid`, `hidden`, `password`) matches a
+   content group, and
+2. that group is one the owning department's devices are actually on.
+
+Content alone is what went stale in the first place. Device evidence alone
+cannot say which of several networks a record meant. Requiring both, and
+requiring **exactly one** candidate group, is what makes this a repair rather
+than a guess. Open networks store `password = ''` on the App API side and a NULL
+psk in Smith, so the fetch normalizes with `NULLIF`.
+
+Bridges with zero candidate groups are contradictory, not ambiguous: the record
+describes a network that exists nowhere its devices are, sometimes nowhere in
+Smith at all. Those are printed with the evidence and left untouched.
+
+`security` is deliberately not part of the match. It adds nothing here, since
+ssid plus password plus the device constraint already pin the group, and Smith
+rows may carry a NULL `security_type` that no App API value equals.
+
+#### The delete
+
+Scoped to the rows this run freed. A general sweep is phase 1's job. A row is
+deleted only when it falls to zero references across all six sources and sits
+below the id watermark, which is taken before the first fetch.
+
+The guard excludes the bridges being repaired rather than reading them back from
+the App API, so a dry run reports exactly what a commit would do. Refs are
+re-fetched immediately before the delete to narrow the sync-job race.
+
+#### Order of operations
+
+Same reasoning as phase 3: App API first, so a later failure leaves a bridge
+pointing at a row that still exists, and the same post-update assertion aborts
+the run rather than deleting rows whose bridges did not move.
+
+The canonical rule here is deliberately **not** phase 3's. Phase 3 picks only
+among bridged rows, because in a skipped group every candidate holds a bridge. A
+phase 4 destination group may hold no bridge at all, so the whole group is in
+play and the choice falls to Smith references, then `min(id)`.
+
+```bash
+./scripts/dedupe-network/phase4-repair-stale-bridges.sh <app-api-db-url> [<smith-db-url>] [--commit]
+```
+
+Reads the same four App API tables as phase 3, plus `network_wifis.ssid`,
+`hidden` and `password`. **That payload carries live WiFi passwords**: it is
+streamed as `COPY` data, never echoed, and never interpolated into SQL text.
+
 ## Shared helpers
 
-`_common.sh` is sourced by all three phase scripts, never executed. It provides:
+`_common.sh` is sourced by all four phase scripts, never executed. It provides:
 
 - `db_psql`, the `docker://` handling described above.
 - The App API fetchers. `network_smith_id` is a TEXT column, so integer payloads
@@ -253,7 +312,7 @@ Pause `departmentNetworkSmithSync` for this run if you can.
 - `copy_block`, which emits a `\copy` command, its payload and its terminator
   between quoted heredocs.
 - `NETWORK_CONTENT_KEY` and `emit_referenced`. The content key is written **once**
-  here and used by phases 2 and 3, so the invariant the whole toolchain rests
+  here and used by phases 2, 3 and 4, so the invariant the whole toolchain rests
   on cannot drift between scripts. `emit_referenced` builds `_referenced`, every
   row anything points at with its group and reference counts. It is a temp table
   rather than a view because callers scan it repeatedly and every count is a

--- a/scripts/dedupe-network/README.md
+++ b/scripts/dedupe-network/README.md
@@ -351,6 +351,8 @@ controls most directly.
   row anything points at with its group and reference counts. It is a temp table
   rather than a view because callers scan it repeatedly and every count is a
   correlated subquery.
+- `dangling_bridges` and `verify_no_new_dangling`, the post-run check described
+  under "Verification".
 - The race mitigations below.
 
 ## Races against the sync job
@@ -385,9 +387,10 @@ correct, since a row committing afterwards is invisible and cannot be deleted.
 It needs the psql connection held open across the App API round-trip, which the
 current one-shot pipe cannot do. Deferred on cost, not rejected on merit.
 
-What actually defends this is the ref refresh, the precondition below, and an
-operational freeze. The real window is "the row exists and its bridge is not
-written yet", and only reading the bridges addresses that. If a hard fix is ever wanted, it is
+What actually defends this is the ref refresh, the precondition below, an
+operational freeze, and the post-run check under "Verification". The real window
+is "the row exists and its bridge is not written yet", and only reading the
+bridges addresses that. If a hard fix is ever wanted, it is
 `track_commit_timestamp = on` plus `pg_xact_commit_timestamp(xmin)`, which
 supplies the `created_at` this table lacks.
 
@@ -426,3 +429,35 @@ Two smaller points:
 - Device reports create new `network` rows at a low rate (3 rows in the 21 hours
   between two consecutive prod dumps). Nothing prevents those, and nothing needs
   to: a row a device report creates is re-reported on the next cycle.
+
+Only three people create `network` rows through the dashboard or CLI, so asking
+them to hold off for the length of a run is a real freeze rather than a hope.
+Combined with an empty retry set, that leaves device reports as the only writer,
+which is the case the verification below covers.
+
+## Verification
+
+Every phase checks itself. Before touching anything it records which App API
+bridges already point at a missing Smith row, and after committing it re-reads
+the bridges and compares. Anything newly stranded is reported and the script
+exits non-zero.
+
+This is the only failure mode these scripts can produce that the plan output
+cannot show you, because it depends on what the App API did while the run was in
+flight. It is also the cheapest one to recover from, so the check matters more
+than any of the races above.
+
+The repair is deliberately **not** automated. Nulling a bridge is a write to a
+fleet-facing database that makes the sync job recreate a network, so the script
+prints the statement and stops:
+
+```sql
+UPDATE network_smith SET network_smith_id = NULL WHERE network_wifi_id IN (...);
+```
+
+The record re-enters the sync job's retry set (`getUnsyncedNetworkWifis` selects
+on `network_smith_id IS NULL`) and the next pass recreates the network and
+rewrites the bridge. Check the rows are what you expect before running it.
+
+Pre-existing stranded bridges are counted and reported but never treated as a
+failure, since the run did not cause them.

--- a/scripts/dedupe-network/README.md
+++ b/scripts/dedupe-network/README.md
@@ -240,7 +240,7 @@ Phase 3 reads four App API tables: `network_smith` (the bridge it rewrites),
 `network_wifis` and `network_surveys` (which department owns each bridge), and
 `device` (the evidence). It writes only `network_smith.network_smith_id`.
 
-Pause `departmentNetworkSmithSync` for this run if you can.
+See "When to run" for the precondition to check first.
 
 ### Phase 4: repair stale bridges (writes to the App API)
 
@@ -333,5 +333,42 @@ Two windows:
 - A row that already existed and is bridged **after** the ref fetch. Narrowed by
   fetching refs twice and taking the union.
 
-Neither substitutes for pausing the job. Window B stays open for the duration of
-the transaction itself, which no client-side scheme can close.
+Window B stays open for the duration of the transaction itself, which no
+client-side scheme can close. What closes it in practice is the precondition
+below, not timing.
+
+## When to run
+
+The dangerous window only exists while the sync job has work to do, and it
+almost never does. It acts on the retry set, `network_wifis` rows whose
+`network_smith` bridge is still NULL, which is only non-empty after someone adds
+a wifi record in the App API. Measured over the bridge table: 85 bridges total,
+4 written in the last 30 days, 1 in the last 7, scattered across four months.
+
+So the precondition is not a time of day, it is that the retry set is empty:
+
+```bash
+psql "$APP_API_URL" -c "
+SELECT count(*) AS unsynced_wifis
+FROM network_wifis w
+LEFT JOIN network_smith ns ON ns.network_wifi_id = w.id
+WHERE ns.network_smith_id IS NULL;"
+```
+
+If that is `0`, the next sync pass will do nothing, and window B cannot open
+while the run is in progress. Check it immediately before starting and again
+after finishing; if it moved, a wifi record was added mid-run and the phase 1
+plan should be re-read before trusting it.
+
+If it is **not** 0, either wait for the job's next pass to drain it, or hold off
+until whoever is adding records is done. Running against a non-empty retry set is
+the one case where pausing the job is worth the trouble.
+
+Two smaller points:
+
+- Run the four phases back to back in one sitting. Each takes its inputs fresh,
+  so a gap between them is a gap in which the fleet moves under the plan you
+  just read.
+- Device reports create new `network` rows at a low rate (3 rows in the 21 hours
+  between two consecutive prod dumps). Those are already covered by the id
+  watermark, so they constrain nothing.

--- a/scripts/dedupe-network/README.md
+++ b/scripts/dedupe-network/README.md
@@ -117,9 +117,10 @@ of the key questions are settled.
 
 Two details in the delete condition:
 
-- The id watermark is taken **before** the ref fetch, not after, so any row
-  created while the run is in progress is out of scope for the delete no matter
-  how long the run takes.
+- The id watermark is taken **before** the ref fetch, not after, so the delete is
+  bounded to ids that existed at that point. It is a bound on the id range, not a
+  guarantee that every row created during the run is excluded; see "Races against
+  the sync job" for what it does and does not cover.
 - Empty-string passwords are normalized to NULL first, so open networks compare
   consistently across every phase. `network.password` is still written by the API
   alongside `credentials`, so this is live, not legacy cleanup. This is scoped to

--- a/scripts/dedupe-network/README.md
+++ b/scripts/dedupe-network/README.md
@@ -121,11 +121,15 @@ Two details in the delete condition:
   bounded to ids that existed at that point. It is a bound on the id range, not a
   guarantee that every row created during the run is excluded; see "Races against
   the sync job" for what it does and does not cover.
-- Empty-string passwords are normalized to NULL first, so open networks compare
-  consistently across every phase. `network.password` is still written by the API
-  alongside `credentials`, so this is live, not legacy cleanup. This is scoped to
-  the same watermark, so the phase never writes to a row it would not delete, and
-  the report prints how many rows it touched.
+- Empty-string passwords are normalized to NULL first, and `credentials`'s `psk`
+  key is dropped alongside it, since grouping compares `credentials ->> 'psk'`
+  (`NETWORK_CONTENT_KEY`), not `password`; touching only `password` would leave
+  the actual comparison untouched. `network.password` is still written by the API
+  alongside `credentials`, so this is live, not legacy cleanup. Scoped to rows
+  under the watermark rather than just `_to_delete`, because a kept row left
+  unnormalized would still fail to merge in phases 2 to 4, which re-read
+  `credentials` fresh and have no normalization step of their own. The report
+  prints how many rows it touched.
 - The delete is driven from the staged `_to_delete` table rather than
   re-evaluating the condition, so the printed plan is exactly what is deleted.
   Under `READ COMMITTED` each statement takes its own snapshot, so re-evaluating
@@ -406,7 +410,7 @@ a wifi record in the App API. Measured over the bridge table: 85 bridges total,
 So the precondition is not a time of day, it is that the retry set is empty:
 
 ```bash
-psql "$APP_API_URL" -c "
+psql "<app-api-db-url>" -c "
 SELECT count(*) AS unsynced_wifis
 FROM network_wifis w
 LEFT JOIN network_smith ns ON ns.network_wifi_id = w.id
@@ -433,8 +437,18 @@ Two smaller points:
 
 Only three people create `network` rows through the dashboard or CLI, so asking
 them to hold off for the length of a run is a real freeze rather than a hope.
-Combined with an empty retry set, that leaves device reports as the only writer,
-which is the case the verification below covers.
+Combined with an empty retry set, that leaves device reports as the only writer.
+
+Device reports are a race the verification below does **not** cover: it only
+re-reads the App API bridge, and a device report never touches that table. The
+same allocation-before-commit ordering can strand a race-created row's device
+side instead, and two of its four FKs fail silently rather than raising:
+`device_configured_network.network_id` is `ON DELETE CASCADE`, so the profile
+row is deleted along with it, and `device.current_network_id` is `ON DELETE SET
+NULL`. Neither leaves anything to detect afterwards. It is tolerated rather than
+guarded because it is self-healing: the same device re-reports on its next
+cycle and recreates both. `device.network_id` and `device_network_intent` are
+`ON DELETE RESTRICT`, so those abort the delete outright instead.
 
 ## Verification
 
@@ -443,10 +457,10 @@ bridges already point at a missing Smith row, and after committing it re-reads
 the bridges and compares. Anything newly stranded is reported and the script
 exits non-zero.
 
-This is the only failure mode these scripts can produce that the plan output
-cannot show you, because it depends on what the App API did while the run was in
-flight. It is also the cheapest one to recover from, so the check matters more
-than any of the races above.
+This is the failure mode most likely to matter: an App API bridge stranding is
+easy to cause (the sync job runs every 15 minutes) and easy to fix by hand once
+seen. The device-report race under "When to run" is rarer and self-healing, so
+it is accepted rather than checked.
 
 The repair is deliberately **not** automated. Nulling a bridge is a write to a
 fleet-facing database that makes the sync job recreate a network, so the script

--- a/scripts/dedupe-network/README.md
+++ b/scripts/dedupe-network/README.md
@@ -1,0 +1,278 @@
+# Network Table Deduplication
+
+One-off tooling to collapse duplicate `network` rows. Read this before running
+anything: phase 3 writes to a database Smith does not own.
+
+## Background
+
+The `network` table accumulated duplicates because `POST /networks` used to
+insert unconditionally, with no uniqueness constraint on the content.
+
+The App API `departmentNetworkSmithSync` job calls `POST /networks` to register
+a WiFi credential, then writes the returned `id` to its `network_smith` bridge
+table. If the bridge write failed after Smith had created the row, the wifi
+entry stayed in the retry set (`network_smith_id IS NULL`) and the job inserted
+another row on the next pass, every 15 minutes. The table reached 725 rows for
+roughly 130 distinct networks.
+
+`POST /networks` and `ReportNMProfiles` are now content-addressed and converge on
+one row, so the table no longer grows this way. This tooling cleans up what is
+already there.
+
+## The content key
+
+Phases 2 and 3 both group on the same tuple, under **strict** equality (NULL
+equal to NULL). It is defined once as `NETWORK_CONTENT_KEY` in `_common.sh`:
+
+```
+(ssid, is_network_hidden, credentials->>'psk', network_type, security_type, identity)
+```
+
+This is deliberately stricter than the API's own match. `network_find_by_content`
+relaxes `security_type` and `identity` bidirectionally, so a NULL matches
+anything. That relation is **not transitive**: `open ~ NULL ~ wpa-eap`, but
+`open !~ wpa-eap`. It therefore cannot be expressed as a `GROUP BY` at all.
+
+Grouping strictly means rows that differ only by a relaxable NULL are left alone
+rather than merged on a rule the scripts cannot express. That residue is small
+and is meant to be handled by hand.
+
+Two consequences worth knowing:
+
+- `name` and `description` are **not** in the key. The survivor keeps its own and
+  the other is dropped. App-API-created rows always carry `name = ssid` and
+  `description = 'Network for <ssid>'`, so merging tends to replace hand-written
+  Smith labels with that boilerplate.
+- `credentials` is keyed on `->>'psk'` only. Its other keys (`pmf`, `eap`,
+  `phase2_auth`, `anonymous_identity`) are unprotected and would be dropped with
+  the row, so phases 2 and 3 fold them into the survivor before deleting. None of
+  them affect matching, so the next device report would restore them anyway; the
+  fold matters when a merged network's devices have gone quiet.
+
+  Only `psk` is guaranteed equal across a group, so the other keys can conflict.
+  Two rules resolve it: `merged || k.credentials` puts the survivor last, so its
+  own values always win, and `jsonb_object_agg(... ORDER BY o.id)` lets later
+  keys overwrite earlier ones, so among the dropped rows the newest wins
+  deterministically.
+
+## Repointing foreign keys
+
+Phases 2 and 3 both remap the four device-side FKs (`device.network_id`,
+`device.current_network_id`, `device_configured_network.network_id`,
+`device_network_intent.network_id`) with a plain `UPDATE` before deleting.
+
+`network_reference` needs different handling. Its FK is `ON DELETE RESTRICT`, so
+it must be repointed before the delete or the whole transaction aborts, and its
+primary key is `(holder, external_key, network_id)`, so a reference that already
+exists for the canonical id would collide on the way over. Both scripts therefore
+insert what is missing with `ON CONFLICT DO NOTHING` and then drop the old rows
+outright, rather than updating in place.
+
+## Connecting
+
+Every script takes an optional Smith URL as its last positional argument and
+accepts two forms:
+
+- `postgres://...` an ordinary TCP connection
+- `docker://<container>[/<database>]` runs psql inside the container
+
+The `docker://` form exists because a full-tunnel VPN (Cisco Secure Client)
+installs routes for the Docker bridge subnets pointing at the tunnel, so host
+connections to a published port hang with no RST. Reaching the prod App API and
+the local Smith DB at the same time requires it. Default is
+`docker://smith-postgres`.
+
+Every phase script fetches the App API refs live. Their delete guard is "the App
+API references this row", and the sync job bridges new rows continuously, so a
+stale copy of the refs would put real rows at risk.
+
+## Phases
+
+Run them in order. Every script dry-runs by default and needs `--commit` to
+apply. Always read the plan first.
+
+### Phase 1: delete unreferenced rows
+
+`phase1-delete-unreferenced.sh`
+
+Deletes every `network` row with no reference in any of `device.network_id`,
+`device.current_network_id`, `device_configured_network.network_id`,
+`device_network_intent.network_id`, `network_reference.network_id`, or the App
+API `network_smith` bridge.
+
+`network_reference` matters out of proportion to its size: its FK is
+`ON DELETE RESTRICT`, so a row holding one cannot be deleted even when every
+other reference count is zero. It is empty in prod today.
+
+No grouping and no canonical rule are involved, so it is safe to run before any
+of the key questions are settled.
+
+Two details in the delete condition:
+
+- The id watermark is taken **before** the ref fetch, not after, so any row
+  created while the run is in progress is out of scope for the delete no matter
+  how long the run takes.
+- Empty-string passwords are normalized to NULL first, so open networks compare
+  consistently across every phase. `network.password` is still written by the API
+  alongside `credentials`, so this is live, not legacy cleanup.
+- The `dup_group` column in the report uses the same content key as phases 2
+  and 3, so a group shown here is the group those phases will act on.
+
+```bash
+./scripts/dedupe-network/phase1-delete-unreferenced.sh <app-api-db-url> [<smith-db-url>] [--commit]
+```
+
+### Phase 2: deduplicate referenced rows
+
+`phase2-dedupe-referenced.sh`
+
+Groups the survivors on the content key above and merges each group onto one
+canonical row, remapping FKs and folding credentials before deleting the rest.
+
+Canonical selection, for groups the phase can fully merge:
+
+1. The row referenced by App API `network_smith.network_smith_id`.
+2. Then the row with the most Smith-side FK references.
+3. Then `min(id)`.
+
+Groups where **more than one** row holds an App API ref cannot be fully merged,
+because collapsing them needs App API writes. Those are skipped and left to
+phase 3, except for the safe part: any row in them with no App API ref is folded
+into a bridged row of the same group and deleted.
+
+That fold is not the canonical rule above. Phase 2 is not choosing a survivor
+there, since every bridged row in a skipped group is staying put regardless; it
+is parking device-only rows somewhere valid until phase 3 does the real merge,
+and any bridged row in the group is equally correct. It picks by
+`smith_refs DESC, id ASC`, the same order phase 3 uses for its canonical, for two
+reasons: the parked references land on the row phase 3 will keep, so they are not
+rewritten twice, and parking cannot inflate an arbitrary row past the group's
+real leader and steer phase 3 onto it.
+
+```bash
+./scripts/dedupe-network/phase2-dedupe-referenced.sh <app-api-db-url> [<smith-db-url>] [--commit]
+```
+
+### Phase 3: deduplicate skipped groups (writes to the App API)
+
+`phase3-dedupe-skipped-groups.sh`
+
+Handles the groups phase 2 skipped, by repointing the App API bridge rows at one
+canonical Smith id.
+
+#### Bridge classification
+
+Phase 3 only ever repoints a bridge **within one content group**, so the plan is
+only correct if the bridge belongs to that group at all. The App API record's own
+fields cannot answer that. The sync job is create-only (`getUnsyncedNetworkWifis`
+selects `WHERE ns.network_smith_id IS NULL`), so a record edited after it was
+first synced keeps its old bridge, and its ssid, password and security drift away
+from the Smith row it points at. Comparing those fields tells you the record
+changed, not where its devices are.
+
+Device evidence does answer it. Each bridge is tested against the devices its
+owning department actually has, joining App API `device.serial_number` to Smith
+`device.serial_number`. A device counts as being on a content group through
+`device.network_id`, `device.current_network_id`, or
+`device_configured_network.network_id`. `device_network_intent` is deliberately
+excluded: it is operator intent, not evidence of where the device is.
+
+| class | meaning | action |
+|---|---|---|
+| `CONFIRMED` | the department has devices on this content group | repoint to canonical, delete the emptied row |
+| `UNKNOWN` | the department yields no evidence at all: no devices in Smith, or none of its devices reference any network row | repoint, and report. Nothing contradicts the bridge, and refusing to act on absent evidence would strand the group forever |
+| `UNSUPPORTED` | the department has devices on some content group, and it is not this one | **held back.** The row keeps its bridge and is not deleted |
+
+An `UNSUPPORTED` bridge points at a group its department is not on, so every
+destination inside that group is equally wrong and repointing would relocate a
+bad link rather than fix it. It cannot be repaired here at all: the repair has to
+leave the content group, and no Smith-side write can express that. Phase 3
+reports these and moves on.
+
+A row is held back if **any** of its bridges is `UNSUPPORTED`, because the remap
+deletes the row and would carry the bad bridge to the canonical with it. A
+held-back row may still be chosen as canonical; that only means it survives,
+which it does either way.
+
+The report prints the classification per row, plus an `UNSUPPORTED BRIDGES`
+section covering the whole bridge set. Its `blocks_merge` column marks the ones
+that also stop a phase 3 group from collapsing; the rest are bridges in
+single-row groups, detected but not in phase 3's way.
+
+#### Canonical selection
+
+Most Smith-side references, then `min(id)`. Every candidate holds an App API ref
+here, so phase 2's first tiebreak is dead weight. Choosing `min(id)` alone is
+valid but repoints far more FK rows for no benefit, since the rows are
+content-identical by construction. The `min(id)` tiebreak only breaks ties in the
+reference count; in the current data the count is decisive in every group and it
+never fires.
+
+#### Order of operations
+
+This matters because the two commits cannot be atomic:
+
+1. Classify the bridges (read-only).
+2. Print the plan (read-only, rolls back).
+3. Update App API `network_smith.network_smith_id`, then assert no bridge still
+   points at a row the next step deletes. The assertion `RAISE`s rather than
+   printing a count, so a partial update aborts the run instead of letting the
+   Smith step strand the bridges it missed.
+4. Remap Smith FKs, fold credentials, delete non-canonical Smith rows.
+
+App API goes first so a failure fails recoverably: the bridge points at the
+canonical row, which still exists, and re-running converges. The reverse order
+fails toward dangling bridges, App API rows pointing at deleted Smith ids, which
+nothing here can detect afterwards.
+
+#### Payload handling
+
+Every payload is streamed into psql from a **quoted** heredoc. Device serial
+numbers are free text and real values contain spaces, commas, `+` and `/`, so an
+unquoted heredoc would let bash expand a serial containing `$` or a backtick.
+Values reach the server as `COPY` data and never become SQL program text.
+
+```bash
+./scripts/dedupe-network/phase3-dedupe-skipped-groups.sh <app-api-db-url> [<smith-db-url>] [--commit]
+```
+
+Phase 3 reads four App API tables: `network_smith` (the bridge it rewrites),
+`network_wifis` and `network_surveys` (which department owns each bridge), and
+`device` (the evidence). It writes only `network_smith.network_smith_id`.
+
+Pause `departmentNetworkSmithSync` for this run if you can.
+
+## Shared helpers
+
+`_common.sh` is sourced by all three phase scripts, never executed. It provides:
+
+- `db_psql`, the `docker://` handling described above.
+- The App API fetchers. `network_smith_id` is a TEXT column, so integer payloads
+  are validated as such; the device and wifi-content payloads are free text and
+  are streamed instead.
+- `copy_block`, which emits a `\copy` command, its payload and its terminator
+  between quoted heredocs.
+- `NETWORK_CONTENT_KEY` and `emit_referenced`. The content key is written **once**
+  here and used by phases 2 and 3, so the invariant the whole toolchain rests
+  on cannot drift between scripts. `emit_referenced` builds `_referenced`, every
+  row anything points at with its group and reference counts. It is a temp table
+  rather than a view because callers scan it repeatedly and every count is a
+  correlated subquery.
+- The race mitigations below.
+
+## Races against the sync job
+
+`departmentNetworkSmithSync` calls `POST /networks` and then writes the bridge
+row. Between those two steps the Smith row exists and is unreferenced, so a
+dedupe run in that window can delete a row the App API is about to point at.
+
+Two windows:
+
+- A row created **after** the run started. Closed deterministically by an id
+  watermark (`network.id` is `generated always as identity`, so it is monotonic;
+  the table has no `created_at`).
+- A row that already existed and is bridged **after** the ref fetch. Narrowed by
+  fetching refs twice and taking the union.
+
+Neither substitutes for pausing the job. Window B stays open for the duration of
+the transaction itself, which no client-side scheme can close.

--- a/scripts/dedupe-network/README.md
+++ b/scripts/dedupe-network/README.md
@@ -445,7 +445,7 @@ same allocation-before-commit ordering can strand a race-created row's device
 side instead, and two of its four FKs fail silently rather than raising:
 `device_configured_network.network_id` is `ON DELETE CASCADE`, so the profile
 row is deleted along with it, and `device.current_network_id` is `ON DELETE SET
-NULL`. Neither leaves anything to detect afterwards. It is tolerated rather than
+NULL`. Neither leaves anything to detect afterward. It is tolerated rather than
 guarded because it is self-healing: the same device re-reports on its next
 cycle and recreates both. `device.network_id` and `device_network_intent` are
 `ON DELETE RESTRICT`, so those abort the delete outright instead.

--- a/scripts/dedupe-network/_common.sh
+++ b/scripts/dedupe-network/_common.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Shared helpers for the dedupe-network scripts. Sourced, not executed.
+# shellcheck shell=bash
+
+# psql against a connection string or docker://<container>[/<database>].
+# See README.md for why the docker form exists.
+db_psql() {
+    local url="$1"
+    shift
+    if [[ "$url" == docker://* ]]; then
+        local rest="${url#docker://}"
+        local container="${rest%%/*}"
+        local dbname="postgres"
+        [[ "$rest" == */* ]] && dbname="${rest#*/}"
+        [[ -z "$dbname" ]] && dbname="postgres"
+        docker exec -i "$container" psql -U postgres -d "$dbname" "$@"
+    else
+        psql "$url" "$@"
+    fi
+}
+
+# Sets APP_API_REF_CSV and APP_API_REF_COUNT. network_smith_id is TEXT, hence
+# the integer validation.
+fetch_app_api_refs() {
+    local url="$1"
+    local rows
+    rows=$(db_psql "$url" -t -A -F $'\t' -c \
+        "SELECT network_wifi_id, network_smith_id FROM network_smith WHERE network_smith_id IS NOT NULL ORDER BY network_wifi_id;")
+
+    if [[ -z "$rows" ]]; then
+        echo "ERROR: no rows returned from App API network_smith table" >&2
+        return 1
+    fi
+
+    if printf '%s\n' "$rows" | grep -qvE '^[0-9]+'$'\t''[0-9]+$'; then
+        echo "ERROR: network_smith returned a non-integer id pair; refusing to continue." >&2
+        echo "       network_smith_id is TEXT, so inspect it before re-running." >&2
+        return 1
+    fi
+
+    APP_API_REF_CSV=$(printf '%s\n' "$rows" | tr '\t' ',')
+    APP_API_REF_COUNT=$(printf '%s\n' "$rows" | wc -l | tr -d ' ')
+}
+
+# Which department owns each bridge. Sets APP_API_WIFI_DEPT_CSV.
+fetch_app_api_wifi_depts() {
+    local url="$1"
+    local rows
+    rows=$(db_psql "$url" -t -A -F $'\t' -c \
+        "SELECT ns.network_wifi_id, s.department_id
+         FROM network_smith ns
+         JOIN network_wifis w ON w.id = ns.network_wifi_id
+         JOIN network_surveys s ON s.id = w.survey_id
+         WHERE ns.network_smith_id IS NOT NULL AND s.department_id IS NOT NULL
+         ORDER BY ns.network_wifi_id;")
+
+    if [[ -z "$(printf '%s' "$rows" | tr -d '[:space:]')" ]]; then
+        echo "ERROR: no wifi/department rows returned from the App API" >&2
+        return 1
+    fi
+
+    if printf '%s\n' "$rows" | sed '/^$/d' | grep -qvE '^[0-9]+'$'\t''[0-9]+$'; then
+        echo "ERROR: wifi/department fetch returned a non-integer pair; refusing to continue." >&2
+        return 1
+    fi
+
+    APP_API_WIFI_DEPT_CSV=$(printf '%s\n' "$rows" | sed '/^$/d' | tr '\t' ',')
+}
+
+# Sets APP_API_DEV_DEPT_CSV and APP_API_DEV_DEPT_COUNT. serial_number is free
+# text, so this is RFC-4180 CSV and MUST be streamed into a quoted heredoc.
+fetch_app_api_device_depts() {
+    local url="$1"
+    APP_API_DEV_DEPT_CSV=$(db_psql "$url" -q -t -A -c \
+        "\copy (SELECT serial_number, department FROM public.device
+                WHERE serial_number IS NOT NULL ORDER BY 1) TO STDOUT WITH (FORMAT csv)")
+
+    if [[ -z "$APP_API_DEV_DEPT_CSV" ]]; then
+        echo "ERROR: no rows returned from App API device table" >&2
+        return 1
+    fi
+
+    APP_API_DEV_DEPT_COUNT=$(printf '%s\n' "$APP_API_DEV_DEPT_CSV" | sed '/^$/d' | wc -l | tr -d ' ')
+}
+
+# Emitted between QUOTED heredocs so bash never expands a payload.
+copy_block() {
+    printf '\\copy %s FROM STDIN WITH (FORMAT csv)\n' "$1"
+    printf '%s\n' "$2"
+    printf '\\.\n'
+}
+
+# The one content key. Every phase groups on this; see README.md.
+NETWORK_CONTENT_KEY="n.ssid, n.is_network_hidden, n.credentials ->> 'psk', n.network_type::text, n.security_type, n.identity"
+
+# Emits _referenced: every row anything points at, with its content group and
+# reference counts. Requires a _refs table to already exist. Materialized rather
+# than a view because callers scan it repeatedly and the counts are subqueries.
+emit_referenced() {
+    cat <<SQL
+CREATE TEMP TABLE _referenced AS
+SELECT n.id,
+       n.ssid,
+       n.is_network_hidden AS hidden,
+       n.credentials ->> 'psk' AS psk,
+       n.network_type::text AS type,
+       n.security_type AS sec,
+       n.identity ->> 'username' AS ident,
+       dense_rank() OVER (ORDER BY $NETWORK_CONTENT_KEY) AS grp,
+       count(*)     OVER (PARTITION BY $NETWORK_CONTENT_KEY) AS grp_size,
+       (SELECT COUNT(*) FROM _refs a WHERE a.network_smith_id = n.id) AS app_refs,
+       (SELECT COUNT(*) FROM device WHERE network_id = n.id) +
+       (SELECT COUNT(*) FROM device WHERE current_network_id = n.id) +
+       (SELECT COUNT(*) FROM device_configured_network WHERE network_id = n.id) +
+       (SELECT COUNT(*) FROM device_network_intent WHERE network_id = n.id) +
+       (SELECT COUNT(*) FROM network_reference WHERE network_id = n.id) AS smith_refs
+FROM network n
+WHERE EXISTS (SELECT 1 FROM _refs a WHERE a.network_smith_id = n.id)
+   OR EXISTS (SELECT 1 FROM device WHERE network_id = n.id)
+   OR EXISTS (SELECT 1 FROM device WHERE current_network_id = n.id)
+   OR EXISTS (SELECT 1 FROM device_configured_network WHERE network_id = n.id)
+   OR EXISTS (SELECT 1 FROM device_network_intent WHERE network_id = n.id)
+   OR EXISTS (SELECT 1 FROM network_reference WHERE network_id = n.id);
+SQL
+}
+
+# Same validation for the remap pairs phase 3 writes back to both databases.
+validate_int_pairs() {
+    if printf '%s\n' "$1" | grep -qvE '^[0-9]+'$'\t''[0-9]+$'; then
+        echo "ERROR: computed remap contains a non-integer pair; refusing to continue." >&2
+        return 1
+    fi
+}
+
+# ── Race mitigation against the App API sync job. See README.md. ─────────────
+
+# network has no created_at; id is `generated always as identity`, so monotonic.
+smith_watermark() {
+    db_psql "$1" -tAc "SELECT coalesce(max(id), 0) FROM network;" | tr -d '[:space:]'
+}
+
+# Call immediately before the mutating transaction.
+refresh_app_api_refs() {
+    local url="$1"
+    local first="$APP_API_REF_CSV"
+    fetch_app_api_refs "$url" || return 1
+    APP_API_REF_CSV=$(printf '%s\n%s\n' "$first" "$APP_API_REF_CSV" | sort -u | sed '/^$/d')
+    APP_API_REF_COUNT=$(printf '%s\n' "$APP_API_REF_CSV" | sed '/^$/d' | wc -l | tr -d ' ')
+}

--- a/scripts/dedupe-network/_common.sh
+++ b/scripts/dedupe-network/_common.sh
@@ -100,7 +100,18 @@ fetch_app_api_wifi_content() {
 }
 
 # Emitted between QUOTED heredocs so bash never expands a payload.
+#
+# psql ends COPY data at a line holding only \., before the server sees it, and
+# resumes reading the rest as psql input. CSV quoting does not protect against
+# this: ssids, passwords and serials are free text and a value containing a
+# newline can put such a line into the stream, after which the remainder runs as
+# meta-commands (\! included) with the operator's permissions. Refuse instead.
 copy_block() {
+    if printf '%s\n' "$2" | grep -qE '^\\\.[[:space:]]*$'; then
+        echo "ERROR: payload for $1 contains a COPY terminator line; refusing to continue." >&2
+        echo "       Inspect the source rows before re-running; this is not valid data." >&2
+        return 1
+    fi
     printf '\\copy %s FROM STDIN WITH (FORMAT csv)\n' "$1"
     printf '%s\n' "$2"
     printf '\\.\n'

--- a/scripts/dedupe-network/_common.sh
+++ b/scripts/dedupe-network/_common.sh
@@ -166,6 +166,59 @@ smith_watermark() {
     db_psql "$1" -tAc "SELECT coalesce(max(id), 0) FROM network;" | tr -d '[:space:]'
 }
 
+# ── Post-run verification ────────────────────────────────────────────────────
+
+# Bridges pointing at a Smith row that no longer exists, one "wifi_id,smith_id"
+# per line. Read-only against both databases.
+dangling_bridges() {
+    local smith_url="$1" refs_csv="$2"
+    {
+        printf 'CREATE TEMP TABLE _dang (network_wifi_id int, network_smith_id int);\n'
+        copy_block "_dang (network_wifi_id, network_smith_id)" "$refs_csv"
+        cat <<'SQL'
+SELECT a.network_wifi_id || ',' || a.network_smith_id
+FROM _dang a
+WHERE NOT EXISTS (SELECT 1 FROM network n WHERE n.id = a.network_smith_id)
+ORDER BY a.network_wifi_id;
+SQL
+    } | db_psql "$smith_url" -q -t -A -v ON_ERROR_STOP=1 | sed '/^$/d'
+}
+
+# Re-reads the bridges and fails if this run stranded any that were not already
+# stranded. Repair is left to the operator: nulling a bridge makes the sync job
+# recreate the network, which is a write to a fleet-facing database.
+verify_no_new_dangling() {
+    local app_url="$1" smith_url="$2" before="$3" after new
+    fetch_app_api_refs "$app_url" || return 1
+    after=$(dangling_bridges "$smith_url" "$APP_API_REF_CSV") || return 1
+
+    # LC_ALL=C throughout: comm requires the exact collation sort produced.
+    new=$(LC_ALL=C comm -13 \
+        <(printf '%s\n' "$before" | sed '/^$/d' | LC_ALL=C sort) \
+        <(printf '%s\n' "$after"  | sed '/^$/d' | LC_ALL=C sort))
+
+    if [[ -z "$new" ]]; then
+        echo "==> Verified: no bridge was stranded by this run."
+        [[ -n "$(printf '%s' "$before" | tr -d '[:space:]')" ]] &&
+            echo "    ($(printf '%s\n' "$before" | sed '/^$/d' | wc -l | tr -d ' ') were already stranded beforehand, unchanged.)"
+        return 0
+    fi
+
+    echo "" >&2
+    echo "!!! $(printf '%s\n' "$new" | wc -l | tr -d ' ') bridge(s) were stranded by this run." >&2
+    echo "    The Smith rows below were deleted while the App API still pointed at them." >&2
+    printf '%s\n' "$new" | sed 's/^/      network_wifi_id,network_smith_id = /' >&2
+    echo "" >&2
+    echo "    This is recoverable. Nulling the bridge puts the record back in the" >&2
+    echo "    sync job's retry set, and the next pass recreates the network:" >&2
+    echo "" >&2
+    echo "      UPDATE network_smith SET network_smith_id = NULL" >&2
+    echo "      WHERE network_wifi_id IN ($(printf '%s\n' "$new" | cut -d, -f1 | paste -sd, -));" >&2
+    echo "" >&2
+    echo "    Run it against the App API only after checking the rows are what you expect." >&2
+    return 1
+}
+
 # Call immediately before the mutating transaction.
 refresh_app_api_refs() {
     local url="$1"

--- a/scripts/dedupe-network/_common.sh
+++ b/scripts/dedupe-network/_common.sh
@@ -83,6 +83,22 @@ fetch_app_api_device_depts() {
     APP_API_DEV_DEPT_COUNT=$(printf '%s\n' "$APP_API_DEV_DEPT_CSV" | sed '/^$/d' | wc -l | tr -d ' ')
 }
 
+# Sets APP_API_WIFI_CONTENT_CSV. Carries live WiFi passwords, so this is
+# RFC-4180 CSV and MUST be streamed into a quoted heredoc. Never echo it.
+fetch_app_api_wifi_content() {
+    local url="$1"
+    APP_API_WIFI_CONTENT_CSV=$(db_psql "$url" -q -t -A -c \
+        "\copy (SELECT ns.network_wifi_id, w.ssid, w.hidden, NULLIF(w.password, '')
+                FROM network_smith ns JOIN network_wifis w ON w.id = ns.network_wifi_id
+                WHERE ns.network_smith_id IS NOT NULL
+                ORDER BY ns.network_wifi_id) TO STDOUT WITH (FORMAT csv)")
+
+    if [[ -z "$APP_API_WIFI_CONTENT_CSV" ]]; then
+        echo "ERROR: no rows returned from App API network_wifis" >&2
+        return 1
+    fi
+}
+
 # Emitted between QUOTED heredocs so bash never expands a payload.
 copy_block() {
     printf '\\copy %s FROM STDIN WITH (FORMAT csv)\n' "$1"

--- a/scripts/dedupe-network/_common.sh
+++ b/scripts/dedupe-network/_common.sh
@@ -107,7 +107,11 @@ fetch_app_api_wifi_content() {
 # newline can put such a line into the stream, after which the remainder runs as
 # meta-commands (\! included) with the operator's permissions. Refuse instead.
 copy_block() {
-    if printf '%s\n' "$2" | grep -qE '^\\\.[[:space:]]*$'; then
+    # grep -c, not -q: -q exits on the first match, which SIGPIPEs the writer and
+    # fails the pipeline under pipefail, silently skipping the check.
+    local terminators
+    terminators=$(printf '%s\n' "$2" | grep -cE '^\\\.[[:space:]]*$' || true)
+    if [[ "$terminators" != 0 ]]; then
         echo "ERROR: payload for $1 contains a COPY terminator line; refusing to continue." >&2
         echo "       Inspect the source rows before re-running; this is not valid data." >&2
         return 1

--- a/scripts/dedupe-network/phase1-delete-unreferenced.sh
+++ b/scripts/dedupe-network/phase1-delete-unreferenced.sh
@@ -51,6 +51,8 @@ echo "==> Re-fetching refs to narrow the bridge-write race..."
 refresh_app_api_refs "$APP_API_DB_URL"
 echo "==> $APP_API_REF_COUNT refs after union."
 
+DANGLING_BEFORE=$(dangling_bridges "$SMITH_DB_URL" "$APP_API_REF_CSV")
+
 if [[ "$COMMIT" == "--commit" ]]; then
     FINAL_STATEMENT="COMMIT;"
     echo "==> Running in COMMIT mode."
@@ -139,5 +141,7 @@ SELECT COUNT(*) AS remaining_rows FROM network;
 
 $FINAL_STATEMENT
 SQL
+
+verify_no_new_dangling "$APP_API_DB_URL" "$SMITH_DB_URL" "$DANGLING_BEFORE"
 
 echo "==> Done."

--- a/scripts/dedupe-network/phase1-delete-unreferenced.sh
+++ b/scripts/dedupe-network/phase1-delete-unreferenced.sh
@@ -68,7 +68,14 @@ BEGIN;
 \echo '=== EMPTY PASSWORDS NORMALIZED TO NULL ==='
 SELECT COUNT(*) AS rows_normalized FROM network WHERE password = '' AND id <= $WATERMARK;
 
-UPDATE network SET password = NULL WHERE password = '' AND id <= $WATERMARK;
+-- Grouping compares credentials->>'psk', not password (see NETWORK_CONTENT_KEY
+-- in _common.sh), so both have to move together or an old empty-string row
+-- never merges with a NULL row of the same content, in this phase or any later
+-- one. content_credentials() in route.rs never writes psk = '' for a fresh
+-- row, only {} or a real value, so dropping the key here (not nulling it)
+-- matches what a current writer would have produced.
+UPDATE network SET password = NULL, credentials = credentials - 'psk'
+WHERE password = '' AND id <= $WATERMARK;
 
 CREATE TEMP TABLE _app_api_refs (network_wifi_id int, network_smith_id int);
 \copy _app_api_refs (network_wifi_id, network_smith_id) FROM STDIN WITH (FORMAT csv)

--- a/scripts/dedupe-network/phase1-delete-unreferenced.sh
+++ b/scripts/dedupe-network/phase1-delete-unreferenced.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Phase 1: Delete network rows with zero references anywhere.
+# See README.md for the delete condition, the watermark, and the race notes.
+#
+# Usage: ./phase1-delete-unreferenced.sh <app-api-db-url> [<smith-db-url>] [--commit]
+#
+#   <app-api-db-url>  Connection string for the App API postgres DB
+#                     e.g. postgres://user:pass@host:5432/dbname
+#
+#   <smith-db-url>    Smith postgres DB. Connection string or docker://<container>.
+#                     Defaults to docker://smith-postgres.
+#
+#   --commit          Apply. Without it the script dry-runs (ROLLBACK).
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
+
+DEV_SMITH_DB_URL="docker://smith-postgres"
+
+APP_API_DB_URL="${1:-}"
+if [[ -z "$APP_API_DB_URL" ]]; then
+    echo "Usage: $0 <app-api-db-url> [<smith-db-url>] [--commit]" >&2
+    exit 1
+fi
+
+if [[ "${2:-}" == "--commit" ]]; then
+    SMITH_DB_URL="$DEV_SMITH_DB_URL"
+    COMMIT="--commit"
+elif [[ -n "${2:-}" ]]; then
+    SMITH_DB_URL="${2}"
+    COMMIT="${3:-}"
+else
+    SMITH_DB_URL="$DEV_SMITH_DB_URL"
+    COMMIT=""
+fi
+
+smith_psql() { db_psql "$SMITH_DB_URL" "$@"; }
+
+echo "==> Smith DB: $SMITH_DB_URL"
+
+# Before the ref fetch, deliberately.
+WATERMARK=$(smith_watermark "$SMITH_DB_URL")
+echo "==> Watermark: network.id <= $WATERMARK (rows created after this are never deleted)"
+
+echo "==> Fetching App API network_smith refs..."
+fetch_app_api_refs "$APP_API_DB_URL"
+echo "==> Got $APP_API_REF_COUNT App API refs."
+
+echo "==> Re-fetching refs to narrow the bridge-write race..."
+refresh_app_api_refs "$APP_API_DB_URL"
+echo "==> $APP_API_REF_COUNT refs after union."
+
+if [[ "$COMMIT" == "--commit" ]]; then
+    FINAL_STATEMENT="COMMIT;"
+    echo "==> Running in COMMIT mode."
+else
+    FINAL_STATEMENT="ROLLBACK;"
+    echo "==> Running in DRY-RUN mode (ROLLBACK). Pass --commit to apply."
+fi
+
+echo "==> Running phase 1 cleanup on Smith DB..."
+smith_psql -v ON_ERROR_STOP=1 <<SQL
+BEGIN;
+
+UPDATE network SET password = NULL WHERE password = '';
+
+CREATE TEMP TABLE _app_api_refs (network_wifi_id int, network_smith_id int);
+\copy _app_api_refs (network_wifi_id, network_smith_id) FROM STDIN WITH (FORMAT csv)
+$APP_API_REF_CSV
+\.
+
+CREATE TEMP TABLE _to_delete AS
+SELECT n.id, n.ssid, n.is_network_hidden AS hidden, n.password IS NOT NULL AS has_pwd,
+       n.credentials ->> 'psk' AS psk, n.network_type::text AS type,
+       n.security_type AS sec, n.identity AS identval
+FROM network n
+WHERE NOT EXISTS (SELECT 1 FROM _app_api_refs a WHERE a.network_smith_id = n.id)
+  AND NOT EXISTS (SELECT 1 FROM device WHERE network_id = n.id)
+  AND NOT EXISTS (SELECT 1 FROM device WHERE current_network_id = n.id)
+  AND NOT EXISTS (SELECT 1 FROM device_configured_network WHERE network_id = n.id)
+  AND NOT EXISTS (SELECT 1 FROM device_network_intent WHERE network_id = n.id)
+  AND NOT EXISTS (SELECT 1 FROM network_reference WHERE network_id = n.id)
+  AND n.id <= $WATERMARK;
+
+CREATE TEMP TABLE _to_keep AS
+SELECT n.id, n.ssid, n.is_network_hidden AS hidden, n.password IS NOT NULL AS has_pwd,
+    n.credentials ->> 'psk' AS psk, n.network_type::text AS type,
+    n.security_type AS sec, n.identity AS identval,
+    (SELECT string_agg(DISTINCT a.network_wifi_id::text, ',' ORDER BY a.network_wifi_id::text)
+     FROM _app_api_refs a WHERE a.network_smith_id = n.id) AS app_wifi_ids,
+    (SELECT count(*) FROM device WHERE network_id = n.id) AS d_network_id_count,
+    (SELECT count(*) FROM device WHERE current_network_id = n.id) AS d_current_network_count,
+    (SELECT count(*) FROM device_configured_network WHERE network_id = n.id) AS dcn_count,
+    (SELECT count(*) FROM device_network_intent WHERE network_id = n.id) AS dni_count
+FROM network n
+WHERE EXISTS (SELECT 1 FROM _app_api_refs a WHERE a.network_smith_id = n.id)
+   OR EXISTS (SELECT 1 FROM device WHERE network_id = n.id)
+   OR EXISTS (SELECT 1 FROM device WHERE current_network_id = n.id)
+   OR EXISTS (SELECT 1 FROM device_configured_network WHERE network_id = n.id)
+   OR EXISTS (SELECT 1 FROM device_network_intent WHERE network_id = n.id)
+   OR EXISTS (SELECT 1 FROM network_reference WHERE network_id = n.id);
+
+-- dup_group uses the same content key as phases 2 to 4, so a group shown here
+-- is the group those phases will act on.
+CREATE TEMP TABLE _groups AS
+SELECT ssid, hidden, psk, type, sec, identval,
+    dense_rank() OVER (ORDER BY ssid, hidden, psk, type, sec, identval) AS grp
+FROM (SELECT ssid, hidden, psk, type, sec, identval FROM _to_delete
+      UNION ALL SELECT ssid, hidden, psk, type, sec, identval FROM _to_keep) combined
+GROUP BY ssid, hidden, psk, type, sec, identval
+HAVING COUNT(*) > 1;
+
+\echo '=== ROWS TO DELETE ==='
+SELECT d.id, d.ssid, d.hidden, d.has_pwd, COALESCE(g.grp::text, '') AS dup_group
+FROM _to_delete d
+LEFT JOIN _groups g ON g.ssid IS NOT DISTINCT FROM d.ssid AND g.hidden = d.hidden
+     AND g.psk IS NOT DISTINCT FROM d.psk AND g.type = d.type
+     AND g.sec IS NOT DISTINCT FROM d.sec AND g.identval IS NOT DISTINCT FROM d.identval
+ORDER BY dup_group, d.ssid, d.id;
+
+\echo '=== ROWS TO KEEP ==='
+SELECT k.id, k.ssid, k.hidden, k.has_pwd, k.app_wifi_ids,
+    k.d_network_id_count, k.d_current_network_count, k.dcn_count, k.dni_count,
+    COALESCE(g.grp::text, '') AS dup_group
+FROM _to_keep k
+LEFT JOIN _groups g ON g.ssid IS NOT DISTINCT FROM k.ssid AND g.hidden = k.hidden
+     AND g.psk IS NOT DISTINCT FROM k.psk AND g.type = k.type
+     AND g.sec IS NOT DISTINCT FROM k.sec AND g.identval IS NOT DISTINCT FROM k.identval
+ORDER BY dup_group, k.ssid, k.id;
+
+DELETE FROM network n
+WHERE NOT EXISTS (SELECT 1 FROM _app_api_refs a WHERE a.network_smith_id = n.id)
+  AND NOT EXISTS (SELECT 1 FROM device WHERE network_id = n.id)
+  AND NOT EXISTS (SELECT 1 FROM device WHERE current_network_id = n.id)
+  AND NOT EXISTS (SELECT 1 FROM device_configured_network WHERE network_id = n.id)
+  AND NOT EXISTS (SELECT 1 FROM device_network_intent WHERE network_id = n.id)
+  AND NOT EXISTS (SELECT 1 FROM network_reference WHERE network_id = n.id)
+  AND n.id <= $WATERMARK;
+
+SELECT COUNT(*) AS remaining_rows FROM network;
+
+$FINAL_STATEMENT
+SQL
+
+echo "==> Done."

--- a/scripts/dedupe-network/phase1-delete-unreferenced.sh
+++ b/scripts/dedupe-network/phase1-delete-unreferenced.sh
@@ -63,7 +63,10 @@ echo "==> Running phase 1 cleanup on Smith DB..."
 smith_psql -v ON_ERROR_STOP=1 <<SQL
 BEGIN;
 
-UPDATE network SET password = NULL WHERE password = '';
+\echo '=== EMPTY PASSWORDS NORMALIZED TO NULL ==='
+SELECT COUNT(*) AS rows_normalized FROM network WHERE password = '' AND id <= $WATERMARK;
+
+UPDATE network SET password = NULL WHERE password = '' AND id <= $WATERMARK;
 
 CREATE TEMP TABLE _app_api_refs (network_wifi_id int, network_smith_id int);
 \copy _app_api_refs (network_wifi_id, network_smith_id) FROM STDIN WITH (FORMAT csv)
@@ -129,14 +132,8 @@ LEFT JOIN _groups g ON g.ssid IS NOT DISTINCT FROM k.ssid AND g.hidden = k.hidde
      AND g.sec IS NOT DISTINCT FROM k.sec AND g.identval IS NOT DISTINCT FROM k.identval
 ORDER BY dup_group, k.ssid, k.id;
 
-DELETE FROM network n
-WHERE NOT EXISTS (SELECT 1 FROM _app_api_refs a WHERE a.network_smith_id = n.id)
-  AND NOT EXISTS (SELECT 1 FROM device WHERE network_id = n.id)
-  AND NOT EXISTS (SELECT 1 FROM device WHERE current_network_id = n.id)
-  AND NOT EXISTS (SELECT 1 FROM device_configured_network WHERE network_id = n.id)
-  AND NOT EXISTS (SELECT 1 FROM device_network_intent WHERE network_id = n.id)
-  AND NOT EXISTS (SELECT 1 FROM network_reference WHERE network_id = n.id)
-  AND n.id <= $WATERMARK;
+-- Driven from the staged set so the report above is exactly what gets deleted.
+DELETE FROM network n WHERE EXISTS (SELECT 1 FROM _to_delete d WHERE d.id = n.id);
 
 SELECT COUNT(*) AS remaining_rows FROM network;
 

--- a/scripts/dedupe-network/phase2-dedupe-referenced.sh
+++ b/scripts/dedupe-network/phase2-dedupe-referenced.sh
@@ -164,6 +164,37 @@ ORDER BY c.canonical_id;
 
 -- ── Mutations ────────────────────────────────────────────────────────────────
 
+CREATE TEMP TABLE _all_remap AS
+SELECT old_id, canonical_id FROM _to_remap
+UNION ALL
+SELECT old_id, canonical_id FROM _skipped_device_remap;
+
+-- device_network_intent is UNIQUE (device_id, network_id), so remapping would
+-- abort where a device holds intents on several rows of one group. Only rows
+-- being remapped are dropped, so an intent already on the canonical row keeps
+-- its priority; among remapped ones the oldest survives.
+CREATE TEMP TABLE _intent_conflicts AS
+SELECT i.id
+FROM device_network_intent i
+JOIN _all_remap r ON i.network_id = r.old_id
+WHERE EXISTS (
+    SELECT 1
+    FROM device_network_intent j
+    LEFT JOIN _all_remap r2 ON j.network_id = r2.old_id
+    WHERE j.device_id = i.device_id
+      AND coalesce(r2.canonical_id, j.network_id) = r.canonical_id
+      AND (j.network_id = r.canonical_id OR j.id < i.id));
+
+\echo ''
+\echo '=== DUPLICATE INTENTS DROPPED (device already has one for the canonical row) ==='
+SELECT i.id, i.device_id, i.network_id AS points_at, r.canonical_id AS would_become
+FROM device_network_intent i
+JOIN _intent_conflicts c ON c.id = i.id
+JOIN _all_remap r ON r.old_id = i.network_id
+ORDER BY i.device_id, i.id;
+
+DELETE FROM device_network_intent WHERE id IN (SELECT id FROM _intent_conflicts);
+
 UPDATE device SET network_id = r.canonical_id
 FROM _to_remap r WHERE device.network_id = r.old_id;
 

--- a/scripts/dedupe-network/phase2-dedupe-referenced.sh
+++ b/scripts/dedupe-network/phase2-dedupe-referenced.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Phase 2: Merge duplicate referenced network rows onto one canonical row.
+# See README.md for the content key, canonical selection, and skipped groups.
+#
+# Usage: ./phase2-dedupe-referenced.sh <app-api-db-url> [<smith-db-url>] [--commit]
+#
+#   <app-api-db-url>  Connection string for the App API postgres DB (read-only)
+#                     e.g. postgres://user:pass@host:5432/dbname
+#
+#   <smith-db-url>    Smith postgres DB. Connection string or docker://<container>.
+#                     Defaults to docker://smith-postgres.
+#
+#   --commit          Apply. Without it the script dry-runs (ROLLBACK).
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
+
+DEV_SMITH_DB_URL="docker://smith-postgres"
+
+APP_API_DB_URL="${1:-}"
+if [[ -z "$APP_API_DB_URL" ]]; then
+    echo "Usage: $0 <app-api-db-url> [<smith-db-url>] [--commit]" >&2
+    exit 1
+fi
+
+if [[ "${2:-}" == "--commit" ]]; then
+    SMITH_DB_URL="$DEV_SMITH_DB_URL"
+    COMMIT="--commit"
+elif [[ -n "${2:-}" ]]; then
+    SMITH_DB_URL="${2}"
+    COMMIT="${3:-}"
+else
+    SMITH_DB_URL="$DEV_SMITH_DB_URL"
+    COMMIT=""
+fi
+
+smith_psql() { db_psql "$SMITH_DB_URL" "$@"; }
+
+echo "==> Smith DB: $SMITH_DB_URL"
+echo "==> Fetching App API network_smith refs..."
+fetch_app_api_refs "$APP_API_DB_URL"
+echo "==> Got $APP_API_REF_COUNT App API refs."
+
+if [[ "$COMMIT" == "--commit" ]]; then
+    FINAL_STATEMENT="COMMIT;"
+    echo "==> Running in COMMIT mode."
+else
+    FINAL_STATEMENT="ROLLBACK;"
+    echo "==> Running in DRY-RUN mode (ROLLBACK). Pass --commit to apply."
+fi
+
+echo "==> Running phase 2 deduplication on Smith DB..."
+
+{
+    cat <<'SQL'
+BEGIN;
+
+CREATE TEMP TABLE _refs (network_wifi_id int, network_smith_id int);
+SQL
+    copy_block "_refs (network_wifi_id, network_smith_id)" "$APP_API_REF_CSV"
+    emit_referenced
+    cat <<'SQL'
+
+-- Left to phase 3: collapsing these needs App API writes.
+CREATE TEMP TABLE _skip_grps AS
+SELECT grp
+FROM _referenced
+WHERE grp_size > 1
+GROUP BY grp
+HAVING SUM(CASE WHEN app_refs > 0 THEN 1 ELSE 0 END) > 1;
+
+CREATE TEMP TABLE _canonical AS
+SELECT DISTINCT ON (grp)
+    grp,
+    id AS canonical_id
+FROM _referenced
+WHERE grp_size > 1
+  AND grp NOT IN (SELECT grp FROM _skip_grps)
+ORDER BY
+    grp,
+    app_refs DESC,
+    smith_refs DESC,
+    id ASC;
+
+CREATE TEMP TABLE _to_remap AS
+SELECT r.id AS old_id, c.canonical_id
+FROM _referenced r
+JOIN _canonical c ON c.grp = r.grp
+WHERE r.id != c.canonical_id;
+
+-- Device-only rows inside skipped groups: no App API writes required. Any
+-- bridged row in the group is equally valid, so the target is ordered the way
+-- phase 3 orders its canonical. Parking on the lowest id instead would inflate
+-- an arbitrary row, and once that row outweighed the group's real leader phase 3
+-- would canonicalize on it.
+CREATE TEMP TABLE _skipped_device_remap AS
+SELECT
+    r.id AS old_id,
+    (SELECT a.id FROM _referenced a WHERE a.grp = r.grp AND a.app_refs > 0
+     ORDER BY a.smith_refs DESC, a.id ASC LIMIT 1) AS canonical_id
+FROM _referenced r
+WHERE r.grp IN (SELECT grp FROM _skip_grps)
+  AND r.app_refs = 0;
+
+-- ── Report ───────────────────────────────────────────────────────────────────
+
+\echo ''
+\echo '=== SKIPPED GROUPS (App API rows kept as-is; device-only rows remapped) ==='
+SELECT
+    r.grp,
+    r.id,
+    r.ssid,
+    r.hidden,
+    r.type,
+    r.sec,
+    r.ident,
+    (r.psk IS NOT NULL) AS psk,
+    r.app_refs,
+    r.smith_refs,
+    CASE
+        WHEN m.canonical_id IS NOT NULL THEN 'remap → ' || m.canonical_id::text
+        ELSE 'keep (App API ref)'
+    END AS action
+FROM _referenced r
+LEFT JOIN _skipped_device_remap m ON m.old_id = r.id
+WHERE r.grp IN (SELECT grp FROM _skip_grps)
+ORDER BY r.grp, r.app_refs DESC, r.id;
+
+\echo ''
+\echo '=== REMAPPING PLAN (old_id → canonical_id) ==='
+SELECT
+    m.old_id,
+    m.canonical_id,
+    r.ssid,
+    r.hidden,
+    r.type,
+    r.sec,
+    r.ident,
+    (r.psk IS NOT NULL) AS psk,
+    r.app_refs AS old_app_refs,
+    r.smith_refs AS old_smith_refs
+FROM _to_remap m
+JOIN _referenced r ON r.id = m.old_id
+ORDER BY m.canonical_id, m.old_id;
+
+\echo ''
+\echo '=== CANONICAL ROWS (kept, with incoming merges) ==='
+SELECT
+    c.canonical_id AS id,
+    r.ssid,
+    r.hidden,
+    r.type,
+    r.sec,
+    r.ident,
+    (r.psk IS NOT NULL) AS psk,
+    r.app_refs,
+    r.smith_refs,
+    (SELECT string_agg(old_id::text, ',' ORDER BY old_id)
+     FROM _to_remap WHERE canonical_id = c.canonical_id) AS merging_ids
+FROM _canonical c
+JOIN _referenced r ON r.id = c.canonical_id
+ORDER BY c.canonical_id;
+
+-- ── Mutations ────────────────────────────────────────────────────────────────
+
+UPDATE device SET network_id = r.canonical_id
+FROM _to_remap r WHERE device.network_id = r.old_id;
+
+UPDATE device SET current_network_id = r.canonical_id
+FROM _to_remap r WHERE device.current_network_id = r.old_id;
+
+UPDATE device_configured_network SET network_id = r.canonical_id
+FROM _to_remap r WHERE device_configured_network.network_id = r.old_id;
+
+UPDATE device_network_intent SET network_id = r.canonical_id
+FROM _to_remap r WHERE device_network_intent.network_id = r.old_id;
+
+UPDATE device SET network_id = m.canonical_id
+FROM _skipped_device_remap m WHERE device.network_id = m.old_id;
+
+UPDATE device SET current_network_id = m.canonical_id
+FROM _skipped_device_remap m WHERE device.current_network_id = m.old_id;
+
+UPDATE device_configured_network SET network_id = m.canonical_id
+FROM _skipped_device_remap m WHERE device_configured_network.network_id = m.old_id;
+
+UPDATE device_network_intent SET network_id = m.canonical_id
+FROM _skipped_device_remap m WHERE device_network_intent.network_id = m.old_id;
+
+-- ON DELETE RESTRICT, and the PK can collide. See README.md.
+INSERT INTO network_reference (holder, external_key, network_id)
+SELECT nr.holder, nr.external_key, r.canonical_id
+FROM network_reference nr JOIN _to_remap r ON nr.network_id = r.old_id
+ON CONFLICT DO NOTHING;
+
+DELETE FROM network_reference nr USING _to_remap r WHERE nr.network_id = r.old_id;
+
+INSERT INTO network_reference (holder, external_key, network_id)
+SELECT nr.holder, nr.external_key, m.canonical_id
+FROM network_reference nr JOIN _skipped_device_remap m ON nr.network_id = m.old_id
+ON CONFLICT DO NOTHING;
+
+DELETE FROM network_reference nr USING _skipped_device_remap m WHERE nr.network_id = m.old_id;
+
+-- Keys outside psk would be dropped with the row. See README.md.
+CREATE TEMP TABLE _creds_fold AS
+SELECT canonical_id, jsonb_object_agg(e.key, e.value ORDER BY o.id) AS merged
+FROM (
+    SELECT old_id, canonical_id FROM _to_remap
+    UNION ALL
+    SELECT old_id, canonical_id FROM _skipped_device_remap
+) r
+JOIN network o ON o.id = r.old_id
+CROSS JOIN LATERAL jsonb_each(o.credentials) e
+GROUP BY canonical_id;
+
+\echo ''
+\echo '=== CREDENTIALS FOLDED INTO SURVIVORS (keys gained) ==='
+SELECT f.canonical_id AS id, n.ssid,
+       (SELECT string_agg(k, ',' ORDER BY k)
+        FROM jsonb_object_keys(f.merged) k
+        WHERE NOT n.credentials ? k) AS gained
+FROM _creds_fold f JOIN network n ON n.id = f.canonical_id
+WHERE EXISTS (SELECT 1 FROM jsonb_object_keys(f.merged) k WHERE NOT n.credentials ? k)
+ORDER BY f.canonical_id;
+
+UPDATE network k SET credentials = f.merged || k.credentials
+FROM _creds_fold f WHERE k.id = f.canonical_id;
+
+DELETE FROM network WHERE id IN (SELECT old_id FROM _to_remap)
+   OR id IN (SELECT old_id FROM _skipped_device_remap);
+
+\echo ''
+SELECT COUNT(*) AS remaining_rows FROM network;
+
+SQL
+    printf '%s\n' "$FINAL_STATEMENT"
+} | smith_psql -v ON_ERROR_STOP=1
+
+echo "==> Done."

--- a/scripts/dedupe-network/phase2-dedupe-referenced.sh
+++ b/scripts/dedupe-network/phase2-dedupe-referenced.sh
@@ -42,6 +42,8 @@ echo "==> Fetching App API network_smith refs..."
 fetch_app_api_refs "$APP_API_DB_URL"
 echo "==> Got $APP_API_REF_COUNT App API refs."
 
+DANGLING_BEFORE=$(dangling_bridges "$SMITH_DB_URL" "$APP_API_REF_CSV")
+
 if [[ "$COMMIT" == "--commit" ]]; then
     FINAL_STATEMENT="COMMIT;"
     echo "==> Running in COMMIT mode."
@@ -268,5 +270,7 @@ SELECT COUNT(*) AS remaining_rows FROM network;
 SQL
     printf '%s\n' "$FINAL_STATEMENT"
 } | smith_psql -v ON_ERROR_STOP=1
+
+verify_no_new_dangling "$APP_API_DB_URL" "$SMITH_DB_URL" "$DANGLING_BEFORE"
 
 echo "==> Done."

--- a/scripts/dedupe-network/phase3-dedupe-skipped-groups.sh
+++ b/scripts/dedupe-network/phase3-dedupe-skipped-groups.sh
@@ -52,6 +52,8 @@ echo "==> Fetching App API network_smith refs..."
 fetch_app_api_refs "$APP_API_DB_URL"
 echo "==> Got $APP_API_REF_COUNT App API refs."
 
+DANGLING_BEFORE=$(dangling_bridges "$SMITH_DB_URL" "$APP_API_REF_CSV")
+
 echo "==> Fetching App API wifi/department ownership..."
 fetch_app_api_wifi_depts "$APP_API_DB_URL"
 
@@ -413,5 +415,7 @@ SELECT COUNT(*) AS remaining_rows FROM network;
 SQL
     printf '%s\n' "$FINAL_STATEMENT"
 } | smith_psql -v ON_ERROR_STOP=1
+
+verify_no_new_dangling "$APP_API_DB_URL" "$SMITH_DB_URL" "$DANGLING_BEFORE"
 
 echo "==> Done."

--- a/scripts/dedupe-network/phase3-dedupe-skipped-groups.sh
+++ b/scripts/dedupe-network/phase3-dedupe-skipped-groups.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+# Phase 3: Collapse the groups phase 2 skipped, by repointing the App API bridge
+# rows at one canonical Smith id. This writes to a database Smith does not own.
+#
+# See README.md for the bridge classification, canonical selection, the ordering
+# of the two non-atomic commits, and why every payload is streamed.
+#
+# Run phases 1 and 2 before this script.
+#
+# Usage: ./phase3-dedupe-skipped-groups.sh [<app-api-db-url>] [<smith-db-url>] [--commit]
+#
+#   <app-api-db-url>  Connection string for the App API postgres DB (read + write).
+#                     Defaults to local dev: postgres://postgres:postgres@localhost:5433/postgres
+#                     (the DB spun up by setup-test-app-api-db.sh)
+#
+#   <smith-db-url>    Smith postgres DB. Connection string or docker://<container>.
+#                     Defaults to docker://smith-postgres.
+#
+#   --commit          Apply. Without it the script dry-runs (ROLLBACK on both).
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
+
+DEV_APP_API_DB_URL="postgres://postgres:postgres@localhost:5433/postgres"
+DEV_SMITH_DB_URL="docker://smith-postgres"
+
+# Parse args: both DBs are optional and default to dev; --commit can appear anywhere
+APP_API_DB_URL="$DEV_APP_API_DB_URL"
+SMITH_DB_URL="$DEV_SMITH_DB_URL"
+COMMIT=""
+
+for arg in "$@"; do
+    if [[ "$arg" == "--commit" ]]; then
+        COMMIT="--commit"
+    elif [[ -z "${_APP_API_SET:-}" ]]; then
+        APP_API_DB_URL="$arg"
+        _APP_API_SET=1
+    else
+        SMITH_DB_URL="$arg"
+    fi
+done
+
+smith_psql() { db_psql "$SMITH_DB_URL" "$@"; }
+app_api_psql() { db_psql "$APP_API_DB_URL" "$@"; }
+
+echo "==> Smith DB:   $SMITH_DB_URL"
+echo "==> App API DB: $APP_API_DB_URL"
+
+echo "==> Fetching App API network_smith refs..."
+fetch_app_api_refs "$APP_API_DB_URL"
+echo "==> Got $APP_API_REF_COUNT App API refs."
+
+echo "==> Fetching App API wifi/department ownership..."
+fetch_app_api_wifi_depts "$APP_API_DB_URL"
+
+echo "==> Fetching App API device/department ownership..."
+fetch_app_api_device_depts "$APP_API_DB_URL"
+echo "==> Got $APP_API_DEV_DEPT_COUNT App API devices."
+
+# Emitted as a unit so every query sees the same inputs.
+emit_inputs() {
+    cat <<'SQL'
+CREATE TEMP TABLE _refs (network_wifi_id int, network_smith_id int);
+SQL
+    copy_block "_refs (network_wifi_id, network_smith_id)" "$APP_API_REF_CSV"
+    cat <<'SQL'
+CREATE TEMP TABLE _wifi_dept (network_wifi_id int, department_id int);
+SQL
+    copy_block "_wifi_dept (network_wifi_id, department_id)" "$APP_API_WIFI_DEPT_CSV"
+    cat <<'SQL'
+CREATE TEMP TABLE _dev_dept (serial_number text, department_id int);
+SQL
+    copy_block "_dev_dept (serial_number, department_id)" "$APP_API_DEV_DEPT_CSV"
+}
+
+# ── Bridge classification ───────────────────────────────────────────────────
+
+echo "==> Classifying App API bridges against device evidence..."
+CLASS_TSV=$(
+    {
+        emit_inputs
+        emit_referenced
+        cat <<'SQL'
+-- device_network_intent is excluded: intent, not evidence.
+CREATE TEMP VIEW _dept_grp AS
+SELECT DISTINCT dd.department_id, g.grp
+FROM _dev_dept dd
+JOIN device d ON d.serial_number = dd.serial_number
+JOIN _referenced g ON g.id IN (d.network_id, d.current_network_id)
+UNION
+SELECT DISTINCT dd.department_id, g.grp
+FROM _dev_dept dd
+JOIN device d ON d.serial_number = dd.serial_number
+JOIN device_configured_network c ON c.device_id = d.id
+JOIN _referenced g ON g.id = c.network_id;
+
+SELECT b.network_wifi_id, b.network_smith_id, g.grp,
+       CASE
+           WHEN wd.department_id IS NULL THEN 'UNKNOWN'
+           WHEN NOT EXISTS (SELECT 1 FROM _dept_grp x
+                            WHERE x.department_id = wd.department_id) THEN 'UNKNOWN'
+           WHEN EXISTS (SELECT 1 FROM _dept_grp x
+                        WHERE x.department_id = wd.department_id AND x.grp = g.grp) THEN 'CONFIRMED'
+           ELSE 'UNSUPPORTED'
+       END
+FROM _refs b
+JOIN _referenced g ON g.id = b.network_smith_id
+LEFT JOIN _wifi_dept wd ON wd.network_wifi_id = b.network_wifi_id
+ORDER BY g.grp, b.network_wifi_id;
+SQL
+    } | smith_psql -q -t -A -F $'\t' -v ON_ERROR_STOP=1
+)
+
+if [[ -z "$CLASS_TSV" ]]; then
+    echo "ERROR: classification returned no rows; refusing to continue." >&2
+    exit 1
+fi
+
+if printf '%s\n' "$CLASS_TSV" | grep -qvE '^[0-9]+'$'\t''[0-9]+'$'\t''[0-9]+'$'\t''(CONFIRMED|UNKNOWN|UNSUPPORTED)$'; then
+    echo "ERROR: classification produced an unexpected row shape; refusing to continue." >&2
+    exit 1
+fi
+
+CLASS_CSV=$(printf '%s\n' "$CLASS_TSV" | tr '\t' ',')
+
+for c in CONFIRMED UNKNOWN UNSUPPORTED; do
+    printf '==> %-12s %s bridges\n' "$c" \
+        "$(printf '%s\n' "$CLASS_TSV" | grep -cE $'\t'"$c\$" || true)"
+done
+
+# ── Remap ───────────────────────────────────────────────────────────────────
+
+echo "==> Computing skipped group remapping from Smith DB..."
+REMAP_TSV=$(
+    {
+        emit_inputs
+        emit_referenced
+        cat <<'SQL'
+CREATE TEMP TABLE _class (network_wifi_id int, network_smith_id int, grp int, class text);
+SQL
+        copy_block "_class (network_wifi_id, network_smith_id, grp, class)" "$CLASS_CSV"
+        cat <<'SQL'
+WITH
+skip_grps AS (
+    SELECT grp
+    FROM _referenced
+    WHERE grp_size > 1
+    GROUP BY grp
+    HAVING SUM(CASE WHEN app_refs > 0 THEN 1 ELSE 0 END) > 1
+),
+-- Rows carrying an UNSUPPORTED bridge stay. See README.md.
+blocked AS (
+    SELECT DISTINCT network_smith_id AS id FROM _class WHERE class = 'UNSUPPORTED'
+),
+canonical AS (
+    SELECT DISTINCT ON (grp) grp, id AS canonical_id
+    FROM _referenced
+    WHERE grp IN (SELECT grp FROM skip_grps) AND app_refs > 0
+    ORDER BY grp, smith_refs DESC, id ASC
+)
+SELECT r.id::text, c.canonical_id::text
+FROM _referenced r
+JOIN canonical c ON c.grp = r.grp
+WHERE r.grp IN (SELECT grp FROM skip_grps)
+  AND r.app_refs > 0
+  AND r.id != c.canonical_id
+  AND r.id NOT IN (SELECT id FROM blocked);
+SQL
+    } | smith_psql -q -t -A -F $'\t' -v ON_ERROR_STOP=1
+)
+
+if [[ -z "$REMAP_TSV" ]]; then
+    echo "==> Nothing to remap. Every skipped group is either already collapsed"
+    echo "    or held back by an UNSUPPORTED bridge."
+    exit 0
+fi
+
+validate_int_pairs "$REMAP_TSV"
+
+REMAP_COUNT=$(printf '%s\n' "$REMAP_TSV" | wc -l | tr -d ' ')
+echo "==> $REMAP_COUNT non-canonical Smith rows to remap."
+
+REMAP_CSV=$(printf '%s\n' "$REMAP_TSV" | tr '\t' ',')
+
+if [[ "$COMMIT" == "--commit" ]]; then
+    FINAL_STATEMENT="COMMIT;"
+    echo "==> Running in COMMIT mode."
+else
+    FINAL_STATEMENT="ROLLBACK;"
+    echo "==> Running in DRY-RUN mode (ROLLBACK). Pass --commit to apply."
+fi
+
+# ── Report. Printed before either database is touched. ─────────────────────
+
+echo "==> Phase 3 plan:"
+{
+    cat <<'SQL'
+BEGIN;
+SQL
+    emit_inputs
+    emit_referenced
+    cat <<'SQL'
+CREATE TEMP TABLE _class (network_wifi_id int, network_smith_id int, grp int, class text);
+SQL
+    copy_block "_class (network_wifi_id, network_smith_id, grp, class)" "$CLASS_CSV"
+    cat <<'SQL'
+CREATE TEMP TABLE _to_remap (old_id int, canonical_id int);
+SQL
+    copy_block "_to_remap (old_id, canonical_id)" "$REMAP_CSV"
+    cat <<'SQL'
+
+CREATE TEMP VIEW _skip_grps AS
+SELECT grp FROM _referenced
+WHERE grp_size > 1
+GROUP BY grp
+HAVING SUM(CASE WHEN app_refs > 0 THEN 1 ELSE 0 END) > 1;
+
+CREATE TEMP VIEW _plan AS
+SELECT g.id, g.grp, g.ssid, g.hidden, g.type, g.sec, g.ident,
+       (g.psk IS NOT NULL) AS psk, g.app_refs, g.smith_refs,
+       (SELECT string_agg(DISTINCT c.class, '+' ORDER BY c.class)
+        FROM _class c WHERE c.network_smith_id = g.id) AS bridge_class
+FROM _referenced g
+WHERE g.grp IN (SELECT grp FROM _skip_grps) AND g.app_refs > 0;
+
+\echo ''
+\echo '=== SKIPPED GROUPS: full remap plan ==='
+SELECT p.grp, p.id, p.ssid, p.hidden, p.type, p.sec, p.ident, p.psk,
+       p.app_refs, p.smith_refs, p.bridge_class,
+       CASE WHEN m.canonical_id IS NOT NULL THEN 'remap -> ' || m.canonical_id::text
+            WHEN p.bridge_class LIKE '%UNSUPPORTED%' THEN 'HELD BACK (unsupported bridge)'
+            ELSE 'keep (canonical)'
+       END AS action
+FROM _plan p
+LEFT JOIN _to_remap m ON m.old_id = p.id
+ORDER BY p.grp, CASE WHEN m.canonical_id IS NULL THEN 0 ELSE 1 END, p.smith_refs DESC, p.id;
+
+\echo ''
+\echo '=== UNSUPPORTED BRIDGES: the owning department has devices, none on this group ==='
+\echo '(none of these can be fixed here; the repair has to leave the content group,'
+\echo ' which no Smith-side write can express. blocks_merge marks the ones that also'
+\echo ' stop a phase 3 group from collapsing)'
+SELECT * FROM (
+    SELECT c.grp, c.network_wifi_id, c.network_smith_id AS points_at, wd.department_id,
+           (SELECT n.ssid FROM network n WHERE n.id = c.network_smith_id) AS smith_ssid,
+           (c.grp IN (SELECT grp FROM _skip_grps)) AS blocks_merge
+    FROM _class c
+    LEFT JOIN _wifi_dept wd ON wd.network_wifi_id = c.network_wifi_id
+    WHERE c.class = 'UNSUPPORTED'
+) u ORDER BY u.blocks_merge DESC, u.grp, u.network_wifi_id;
+
+\echo ''
+\echo '=== FK rows this plan will repoint ==='
+SELECT
+    (SELECT COUNT(*) FROM device d JOIN _to_remap r ON d.network_id = r.old_id) AS assigned,
+    (SELECT COUNT(*) FROM device d JOIN _to_remap r ON d.current_network_id = r.old_id) AS current,
+    (SELECT COUNT(*) FROM device_configured_network x JOIN _to_remap r ON x.network_id = r.old_id) AS profiles,
+    (SELECT COUNT(*) FROM device_network_intent x JOIN _to_remap r ON x.network_id = r.old_id) AS intents,
+    (SELECT COUNT(*) FROM network_reference x JOIN _to_remap r ON x.network_id = r.old_id) AS refs;
+
+ROLLBACK;
+SQL
+} | smith_psql -v ON_ERROR_STOP=1
+
+# ── App API update. Goes FIRST on purpose; see README.md. ───────────────────
+
+echo "==> Running phase 3 on App API DB..."
+{
+    cat <<'SQL'
+BEGIN;
+
+CREATE TEMP TABLE _to_remap (old_id int, canonical_id int);
+SQL
+    copy_block "_to_remap (old_id, canonical_id)" "$REMAP_CSV"
+    cat <<'SQL'
+
+\echo ''
+\echo '=== App API network_smith rows to update ==='
+SELECT
+    ns.id AS network_smith_row_id,
+    ns.network_wifi_id,
+    ns.network_smith_id AS old_smith_id,
+    m.canonical_id AS new_smith_id
+FROM network_smith ns
+JOIN _to_remap m ON ns.network_smith_id = m.old_id::text
+ORDER BY ns.network_wifi_id;
+
+UPDATE network_smith
+SET network_smith_id = m.canonical_id::text
+FROM _to_remap m
+WHERE network_smith.network_smith_id = m.old_id::text;
+
+-- Abort rather than report: the Smith step deletes these rows next.
+DO $$
+DECLARE stale int;
+BEGIN
+    SELECT COUNT(*) INTO stale FROM network_smith ns
+    JOIN _to_remap m ON ns.network_smith_id = m.old_id::text;
+    IF stale > 0 THEN
+        RAISE EXCEPTION 'aborting: % bridges still point at rows the Smith step deletes', stale;
+    END IF;
+END $$;
+SQL
+    printf '%s\n' "$FINAL_STATEMENT"
+} | app_api_psql -v ON_ERROR_STOP=1
+
+# ── Smith mutations ─────────────────────────────────────────────────────────
+
+echo "==> Running phase 3 on Smith DB..."
+{
+    cat <<'SQL'
+BEGIN;
+
+CREATE TEMP TABLE _to_remap (old_id int, canonical_id int);
+SQL
+    copy_block "_to_remap (old_id, canonical_id)" "$REMAP_CSV"
+    cat <<'SQL'
+
+UPDATE device SET network_id = r.canonical_id
+FROM _to_remap r WHERE device.network_id = r.old_id;
+
+UPDATE device SET current_network_id = r.canonical_id
+FROM _to_remap r WHERE device.current_network_id = r.old_id;
+
+UPDATE device_configured_network SET network_id = r.canonical_id
+FROM _to_remap r WHERE device_configured_network.network_id = r.old_id;
+
+UPDATE device_network_intent SET network_id = r.canonical_id
+FROM _to_remap r WHERE device_network_intent.network_id = r.old_id;
+
+-- ON DELETE RESTRICT, and the PK can collide. See README.md.
+INSERT INTO network_reference (holder, external_key, network_id)
+SELECT nr.holder, nr.external_key, r.canonical_id
+FROM network_reference nr JOIN _to_remap r ON nr.network_id = r.old_id
+ON CONFLICT DO NOTHING;
+
+DELETE FROM network_reference nr USING _to_remap r WHERE nr.network_id = r.old_id;
+
+-- Keys outside psk would be dropped with the row. See README.md.
+CREATE TEMP TABLE _creds_fold AS
+SELECT r.canonical_id, jsonb_object_agg(e.key, e.value ORDER BY o.id) AS merged
+FROM _to_remap r
+JOIN network o ON o.id = r.old_id
+CROSS JOIN LATERAL jsonb_each(o.credentials) e
+GROUP BY r.canonical_id;
+
+\echo ''
+\echo '=== CREDENTIALS FOLDED INTO SURVIVORS (keys gained) ==='
+SELECT f.canonical_id AS id, n.ssid,
+       (SELECT string_agg(k, ',' ORDER BY k)
+        FROM jsonb_object_keys(f.merged) k
+        WHERE NOT n.credentials ? k) AS gained
+FROM _creds_fold f JOIN network n ON n.id = f.canonical_id
+WHERE EXISTS (SELECT 1 FROM jsonb_object_keys(f.merged) k WHERE NOT n.credentials ? k)
+ORDER BY f.canonical_id;
+
+UPDATE network k SET credentials = f.merged || k.credentials
+FROM _creds_fold f WHERE k.id = f.canonical_id;
+
+DELETE FROM network WHERE id IN (SELECT old_id FROM _to_remap);
+
+\echo ''
+SELECT COUNT(*) AS remaining_rows FROM network;
+SQL
+    printf '%s\n' "$FINAL_STATEMENT"
+} | smith_psql -v ON_ERROR_STOP=1
+
+echo "==> Done."

--- a/scripts/dedupe-network/phase3-dedupe-skipped-groups.sh
+++ b/scripts/dedupe-network/phase3-dedupe-skipped-groups.sh
@@ -29,11 +29,12 @@ DEV_SMITH_DB_URL="docker://smith-postgres"
 APP_API_DB_URL="$DEV_APP_API_DB_URL"
 SMITH_DB_URL="$DEV_SMITH_DB_URL"
 COMMIT=""
+_APP_API_SET=""
 
 for arg in "$@"; do
     if [[ "$arg" == "--commit" ]]; then
         COMMIT="--commit"
-    elif [[ -z "${_APP_API_SET:-}" ]]; then
+    elif [[ -z "$_APP_API_SET" ]]; then
         APP_API_DB_URL="$arg"
         _APP_API_SET=1
     else
@@ -306,6 +307,12 @@ SQL
 } | app_api_psql -v ON_ERROR_STOP=1
 
 # ── Smith mutations ─────────────────────────────────────────────────────────
+# Refs re-fetched after the App API commit so the guard below sees anything the
+# sync job bridged since the run started, as phase 4 does before its delete.
+
+ORIG_REF_CSV="$APP_API_REF_CSV"
+echo "==> Re-fetching refs before the Smith step..."
+refresh_app_api_refs "$APP_API_DB_URL"
 
 echo "==> Running phase 3 on Smith DB..."
 {
@@ -316,6 +323,47 @@ CREATE TEMP TABLE _to_remap (old_id int, canonical_id int);
 SQL
     copy_block "_to_remap (old_id, canonical_id)" "$REMAP_CSV"
     cat <<'SQL'
+CREATE TEMP TABLE _refs (network_wifi_id int, network_smith_id int);
+SQL
+    copy_block "_refs (network_wifi_id, network_smith_id)" "$APP_API_REF_CSV"
+    cat <<'SQL'
+CREATE TEMP TABLE _orig_refs (network_wifi_id int, network_smith_id int);
+SQL
+    copy_block "_orig_refs (network_wifi_id, network_smith_id)" "$ORIG_REF_CSV"
+    cat <<'SQL'
+
+-- The App API UPDATE moved every bridge this run knew about off its old row, so
+-- a ref still on an old row that the run never saw is one the sync job created
+-- in between. Deleting that row would strand it, so drop the whole remap for it.
+CREATE TEMP TABLE _blocked AS
+SELECT DISTINCT r.old_id
+FROM _to_remap r
+WHERE EXISTS (
+    SELECT 1 FROM _refs a
+    WHERE a.network_smith_id = r.old_id
+      AND a.network_wifi_id NOT IN (SELECT o.network_wifi_id FROM _orig_refs o
+                                    WHERE o.network_smith_id = r.old_id));
+
+\echo ''
+\echo '=== HELD BACK: a new bridge landed on these rows after the App API commit ==='
+SELECT b.old_id, n.ssid FROM _blocked b JOIN network n ON n.id = b.old_id ORDER BY b.old_id;
+
+DELETE FROM _to_remap WHERE old_id IN (SELECT old_id FROM _blocked);
+
+-- device_network_intent is UNIQUE (device_id, network_id), so remapping would
+-- abort where a device holds intents on several rows of one group. Only rows
+-- being remapped are dropped, so an intent already on the canonical row keeps
+-- its priority; among remapped ones the oldest survives.
+DELETE FROM device_network_intent i
+USING _to_remap r
+WHERE i.network_id = r.old_id
+  AND EXISTS (
+      SELECT 1
+      FROM device_network_intent j
+      LEFT JOIN _to_remap r2 ON j.network_id = r2.old_id
+      WHERE j.device_id = i.device_id
+        AND coalesce(r2.canonical_id, j.network_id) = r.canonical_id
+        AND (j.network_id = r.canonical_id OR j.id < i.id));
 
 UPDATE device SET network_id = r.canonical_id
 FROM _to_remap r WHERE device.network_id = r.old_id;

--- a/scripts/dedupe-network/phase4-repair-stale-bridges.sh
+++ b/scripts/dedupe-network/phase4-repair-stale-bridges.sh
@@ -57,6 +57,8 @@ fetch_app_api_device_depts "$APP_API_DB_URL"
 fetch_app_api_wifi_content "$APP_API_DB_URL"
 echo "==> $APP_API_REF_COUNT bridges, $APP_API_DEV_DEPT_COUNT devices."
 
+DANGLING_BEFORE=$(dangling_bridges "$SMITH_DB_URL" "$APP_API_REF_CSV")
+
 emit_inputs() {
     cat <<'SQL'
 CREATE TEMP TABLE _refs (network_wifi_id int, network_smith_id int);
@@ -306,5 +308,7 @@ SELECT COUNT(*) AS remaining_rows FROM network;
 SQL
     printf '%s\n' "$FINAL_STATEMENT"
 } | smith_psql -v ON_ERROR_STOP=1
+
+verify_no_new_dangling "$APP_API_DB_URL" "$SMITH_DB_URL" "$DANGLING_BEFORE"
 
 echo "==> Done."

--- a/scripts/dedupe-network/phase4-repair-stale-bridges.sh
+++ b/scripts/dedupe-network/phase4-repair-stale-bridges.sh
@@ -27,11 +27,12 @@ DEV_SMITH_DB_URL="docker://smith-postgres"
 APP_API_DB_URL="$DEV_APP_API_DB_URL"
 SMITH_DB_URL="$DEV_SMITH_DB_URL"
 COMMIT=""
+_APP_API_SET=""
 
 for arg in "$@"; do
     if [[ "$arg" == "--commit" ]]; then
         COMMIT="--commit"
-    elif [[ -z "${_APP_API_SET:-}" ]]; then
+    elif [[ -z "$_APP_API_SET" ]]; then
         APP_API_DB_URL="$arg"
         _APP_API_SET=1
     else

--- a/scripts/dedupe-network/phase4-repair-stale-bridges.sh
+++ b/scripts/dedupe-network/phase4-repair-stale-bridges.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# Phase 4: Repair the App API bridges phase 3 held back as UNSUPPORTED, then
+# delete the Smith rows that repair leaves unreferenced.
+#
+# See README.md for the resolution test, why unresolvable bridges are left
+# alone, and the ordering of the two non-atomic commits.
+#
+# Run phases 1, 2 and 3 before this script.
+#
+# Usage: ./phase4-repair-stale-bridges.sh [<app-api-db-url>] [<smith-db-url>] [--commit]
+#
+#   <app-api-db-url>  Connection string for the App API postgres DB (read + write).
+#                     Defaults to local dev: postgres://postgres:postgres@localhost:5433/postgres
+#
+#   <smith-db-url>    Smith postgres DB. Connection string or docker://<container>.
+#                     Defaults to docker://smith-postgres.
+#
+#   --commit          Apply. Without it the script dry-runs (ROLLBACK on both).
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
+
+DEV_APP_API_DB_URL="postgres://postgres:postgres@localhost:5433/postgres"
+DEV_SMITH_DB_URL="docker://smith-postgres"
+
+APP_API_DB_URL="$DEV_APP_API_DB_URL"
+SMITH_DB_URL="$DEV_SMITH_DB_URL"
+COMMIT=""
+
+for arg in "$@"; do
+    if [[ "$arg" == "--commit" ]]; then
+        COMMIT="--commit"
+    elif [[ -z "${_APP_API_SET:-}" ]]; then
+        APP_API_DB_URL="$arg"
+        _APP_API_SET=1
+    else
+        SMITH_DB_URL="$arg"
+    fi
+done
+
+smith_psql() { db_psql "$SMITH_DB_URL" "$@"; }
+app_api_psql() { db_psql "$APP_API_DB_URL" "$@"; }
+
+echo "==> Smith DB:   $SMITH_DB_URL"
+echo "==> App API DB: $APP_API_DB_URL"
+
+# Before the ref fetch, deliberately.
+WATERMARK=$(smith_watermark "$SMITH_DB_URL")
+echo "==> Watermark: network.id <= $WATERMARK"
+
+echo "==> Fetching App API bridge, ownership and content..."
+fetch_app_api_refs "$APP_API_DB_URL"
+fetch_app_api_wifi_depts "$APP_API_DB_URL"
+fetch_app_api_device_depts "$APP_API_DB_URL"
+fetch_app_api_wifi_content "$APP_API_DB_URL"
+echo "==> $APP_API_REF_COUNT bridges, $APP_API_DEV_DEPT_COUNT devices."
+
+emit_inputs() {
+    cat <<'SQL'
+CREATE TEMP TABLE _refs (network_wifi_id int, network_smith_id int);
+SQL
+    copy_block "_refs (network_wifi_id, network_smith_id)" "$APP_API_REF_CSV"
+    cat <<'SQL'
+CREATE TEMP TABLE _wifi_dept (network_wifi_id int, department_id int);
+SQL
+    copy_block "_wifi_dept (network_wifi_id, department_id)" "$APP_API_WIFI_DEPT_CSV"
+    cat <<'SQL'
+CREATE TEMP TABLE _dev_dept (serial_number text, department_id int);
+SQL
+    copy_block "_dev_dept (serial_number, department_id)" "$APP_API_DEV_DEPT_CSV"
+    cat <<'SQL'
+CREATE TEMP TABLE _wifi (network_wifi_id int, ssid text, hidden boolean, psk text);
+SQL
+    copy_block "_wifi (network_wifi_id, ssid, hidden, psk)" "$APP_API_WIFI_CONTENT_CSV"
+}
+
+# Phase-4-specific views. Requires _referenced from _common.sh.
+emit_model() {
+    cat <<'SQL'
+-- device_network_intent is excluded: intent, not evidence.
+CREATE TEMP VIEW _dept_grp AS
+SELECT DISTINCT dd.department_id, g.grp
+FROM _dev_dept dd
+JOIN device d ON d.serial_number = dd.serial_number
+JOIN _referenced g ON g.id IN (d.network_id, d.current_network_id)
+UNION
+SELECT DISTINCT dd.department_id, g.grp
+FROM _dev_dept dd
+JOIN device d ON d.serial_number = dd.serial_number
+JOIN device_configured_network c ON c.device_id = d.id
+JOIN _referenced g ON g.id = c.network_id;
+
+CREATE TEMP VIEW _unsupported AS
+SELECT b.network_wifi_id AS wid, b.network_smith_id AS sid, wd.department_id AS dept
+FROM _refs b
+JOIN _referenced g ON g.id = b.network_smith_id
+JOIN _wifi_dept wd ON wd.network_wifi_id = b.network_wifi_id
+WHERE EXISTS (SELECT 1 FROM _dept_grp x WHERE x.department_id = wd.department_id)
+  AND NOT EXISTS (SELECT 1 FROM _dept_grp x
+                  WHERE x.department_id = wd.department_id AND x.grp = g.grp);
+
+-- A destination needs two independent things to agree: the App API record's own
+-- content matches the group, AND the department's devices are on it.
+CREATE TEMP VIEW _candidate AS
+SELECT DISTINCT u.wid, u.sid, x.grp
+FROM _unsupported u
+JOIN _wifi w ON w.network_wifi_id = u.wid
+JOIN _dept_grp x ON x.department_id = u.dept
+WHERE EXISTS (SELECT 1 FROM _referenced g
+              WHERE g.grp = x.grp AND g.ssid = w.ssid AND g.hidden = w.hidden
+                AND g.psk IS NOT DISTINCT FROM w.psk);
+
+-- Not phase 3's canonical rule: that one picks only among bridged rows because
+-- every candidate there holds a bridge. A phase 4 destination group may hold no
+-- bridge at all, so the whole group is in play.
+CREATE TEMP VIEW _repair AS
+SELECT c.wid, c.sid AS old_id,
+       (SELECT id FROM _referenced x WHERE x.grp = c.grp
+        ORDER BY x.smith_refs DESC, x.id LIMIT 1) AS new_id
+FROM _candidate c
+WHERE c.wid IN (SELECT wid FROM _candidate GROUP BY wid HAVING count(*) = 1);
+SQL
+}
+
+# Read-only, and emitted from _repair rather than _to_repair so it works before
+# the repair plan exists. These bridges are what phase 4 exists to surface;
+# going silent once everything resolvable is done would hide them entirely.
+emit_unresolvable_report() {
+    cat <<'SQL'
+
+\echo ''
+\echo '=== UNRESOLVABLE: left as-is, no computable destination ==='
+SELECT u.wid AS network_wifi_id, w.ssid AS record_says, u.sid AS points_at,
+       (SELECT string_agg(DISTINCT gg.ssid, ' | ')
+        FROM _dept_grp x JOIN _referenced gg ON gg.grp = x.grp
+        WHERE x.department_id = u.dept) AS devices_actually_on,
+       (SELECT COUNT(*) FROM _candidate c WHERE c.wid = u.wid) AS candidate_groups
+FROM _unsupported u
+JOIN _wifi w ON w.network_wifi_id = u.wid
+WHERE u.wid NOT IN (SELECT wid FROM _repair WHERE old_id <> new_id)
+ORDER BY u.wid;
+SQL
+}
+
+echo "==> Resolving unsupported bridges..."
+REPAIR_TSV=$(
+    {
+        emit_inputs
+        emit_referenced
+        emit_model
+        cat <<'SQL'
+SELECT wid::text, old_id::text, new_id::text FROM _repair WHERE old_id <> new_id ORDER BY wid;
+SQL
+    } | smith_psql -q -t -A -F $'\t' -v ON_ERROR_STOP=1
+)
+
+if [[ -z "$REPAIR_TSV" ]]; then
+    echo "==> Nothing resolvable. The unsupported bridges that remain:"
+    {
+        emit_inputs
+        emit_referenced
+        emit_model
+        emit_unresolvable_report
+    } | smith_psql -v ON_ERROR_STOP=1
+    exit 0
+fi
+
+if printf '%s\n' "$REPAIR_TSV" | grep -qvE '^[0-9]+'$'\t''[0-9]+'$'\t''[0-9]+$'; then
+    echo "ERROR: repair plan has an unexpected row shape; refusing to continue." >&2
+    exit 1
+fi
+
+REPAIR_CSV=$(printf '%s\n' "$REPAIR_TSV" | tr '\t' ',')
+REPAIR_BRIDGE_COUNT=$(printf '%s\n' "$REPAIR_TSV" | wc -l | tr -d ' ')
+echo "==> $REPAIR_BRIDGE_COUNT bridges to repoint."
+
+if [[ "$COMMIT" == "--commit" ]]; then
+    FINAL_STATEMENT="COMMIT;"
+    echo "==> Running in COMMIT mode."
+else
+    FINAL_STATEMENT="ROLLBACK;"
+    echo "==> Running in DRY-RUN mode (ROLLBACK). Pass --commit to apply."
+fi
+
+# ── Report. Printed before either database is touched. ─────────────────────
+
+echo "==> Phase 4 plan:"
+{
+    cat <<'SQL'
+BEGIN;
+SQL
+    emit_inputs
+    emit_referenced
+    emit_model
+    cat <<'SQL'
+CREATE TEMP TABLE _to_repair (wid int, old_id int, new_id int);
+SQL
+    copy_block "_to_repair (wid, old_id, new_id)" "$REPAIR_CSV"
+    cat <<'SQL'
+
+\echo ''
+\echo '=== BRIDGES TO REPOINT ==='
+SELECT r.wid AS network_wifi_id, w.ssid AS record_says, r.old_id AS points_at,
+       (SELECT ssid FROM network n WHERE n.id = r.old_id) AS old_ssid,
+       r.new_id AS repoint_to
+FROM _to_repair r JOIN _wifi w ON w.network_wifi_id = r.wid
+ORDER BY r.wid;
+
+\echo ''
+\echo '=== SMITH ROWS THIS FREES (deleted below if nothing else points at them) ==='
+SELECT g.id, g.ssid, g.smith_refs,
+       (SELECT COUNT(*) FROM _refs a WHERE a.network_smith_id = g.id) -
+       (SELECT COUNT(*) FROM _to_repair r WHERE r.old_id = g.id) AS bridges_after
+FROM _referenced g
+WHERE g.id IN (SELECT old_id FROM _to_repair)
+ORDER BY g.id;
+SQL
+    emit_unresolvable_report
+    cat <<'SQL'
+
+ROLLBACK;
+SQL
+} | smith_psql -v ON_ERROR_STOP=1
+
+# ── App API update. Goes FIRST on purpose; see README.md. ───────────────────
+
+echo "==> Repointing bridges on App API DB..."
+{
+    cat <<'SQL'
+BEGIN;
+
+CREATE TEMP TABLE _to_repair (wid int, old_id int, new_id int);
+SQL
+    copy_block "_to_repair (wid, old_id, new_id)" "$REPAIR_CSV"
+    cat <<'SQL'
+
+UPDATE network_smith ns
+SET network_smith_id = r.new_id::text
+FROM _to_repair r
+WHERE ns.network_wifi_id = r.wid AND ns.network_smith_id = r.old_id::text;
+
+-- Abort rather than report: the Smith step deletes these rows next, so a bridge
+-- left on an old id would be stranded by that delete.
+DO $$
+DECLARE stale int;
+BEGIN
+    SELECT COUNT(*) INTO stale FROM network_smith ns
+    JOIN _to_repair r ON r.wid = ns.network_wifi_id AND ns.network_smith_id = r.old_id::text;
+    IF stale > 0 THEN
+        RAISE EXCEPTION 'aborting: % bridges did not move off their old row', stale;
+    END IF;
+END $$;
+SQL
+    printf '%s\n' "$FINAL_STATEMENT"
+} | app_api_psql -v ON_ERROR_STOP=1
+
+# ── Smith delete ───────────────────────────────────────────────────────────
+# Refs re-fetched after the App API commit so the guard sees the repointing and
+# anything the sync job bridged since the run started.
+
+echo "==> Re-fetching refs before the delete..."
+refresh_app_api_refs "$APP_API_DB_URL"
+
+echo "==> Deleting rows the repair left unreferenced..."
+{
+    cat <<'SQL'
+BEGIN;
+
+CREATE TEMP TABLE _refs (network_wifi_id int, network_smith_id int);
+SQL
+    copy_block "_refs (network_wifi_id, network_smith_id)" "$APP_API_REF_CSV"
+    cat <<'SQL'
+CREATE TEMP TABLE _to_repair (wid int, old_id int, new_id int);
+SQL
+    copy_block "_to_repair (wid, old_id, new_id)" "$REPAIR_CSV"
+    cat <<SQL
+
+-- Scoped to the rows this run freed; a general sweep is phase 1's job. Only the
+-- bridge leaving this row is excluded from the guard, never every repaired
+-- bridge: a row that simultaneously receives one must still count as referenced.
+-- Excluding rather than reading back keeps the dry run identical to a commit.
+CREATE TEMP TABLE _dead AS
+SELECT DISTINCT r.old_id AS id
+FROM _to_repair r
+WHERE r.old_id <= $WATERMARK
+  AND NOT EXISTS (SELECT 1 FROM _refs a WHERE a.network_smith_id = r.old_id
+                    AND a.network_wifi_id <> r.wid)
+  AND NOT EXISTS (SELECT 1 FROM device WHERE network_id = r.old_id)
+  AND NOT EXISTS (SELECT 1 FROM device WHERE current_network_id = r.old_id)
+  AND NOT EXISTS (SELECT 1 FROM device_configured_network WHERE network_id = r.old_id)
+  AND NOT EXISTS (SELECT 1 FROM device_network_intent WHERE network_id = r.old_id)
+  AND NOT EXISTS (SELECT 1 FROM network_reference WHERE network_id = r.old_id);
+SQL
+    cat <<'SQL'
+
+\echo ''
+\echo '=== ROWS DELETED ==='
+SELECT d.id, n.ssid FROM _dead d JOIN network n ON n.id = d.id ORDER BY d.id;
+
+DELETE FROM network WHERE id IN (SELECT id FROM _dead);
+
+\echo ''
+SELECT COUNT(*) AS remaining_rows FROM network;
+SQL
+    printf '%s\n' "$FINAL_STATEMENT"
+} | smith_psql -v ON_ERROR_STOP=1
+
+echo "==> Done."


### PR DESCRIPTION
## What

Four-phase, dry-run-by-default tooling to collapse duplicate rows in the
`network` table. Reasoning for every rule is in
`scripts/dedupe-network/README.md`.

## Why

Three duplication sources, all since fixed in the API: unconditional inserts on
`POST /networks` combined with a sync job that re-posted every 15 minutes when
its bridge write failed; one Smith row per department for a shared SSID; and a
backfill that guessed `security_type` from the password. Writes are
content-addressed now (#524, #528), so this only cleans up what is already
there. 805 rows down to 101 on the current prod snapshot.

## Approach

Phases 1 and 2 delete unreferenced rows and merge duplicate groups. Phase 3
handles groups holding more than one App API bridge, which need App API writes.
Phase 4 repairs the bridges phase 3 refuses to move.

Three decisions a reviewer should know, all expanded in the README:

- **The content key is stricter than the API's own matcher.** The API relaxes
  `security_type` and `identity`, which makes that relation non-transitive
  (`open ~ NULL ~ wpa-eap` but `open !~ wpa-eap`) and therefore not expressible
  as a `GROUP BY`. The residue is left for hand-checking.
- **Phase 3 classifies each bridge against device evidence**, not against the
  App API record's own fields, which drift because the sync job is create-only.
  A bridge whose department has devices on some other group is held back rather
  than repointed inside a group it doesn't belong to.
- **The App API commit goes first** in phases 3 and 4, and both assert no bridge
  was left behind, raising rather than printing. The reverse order fails toward
  dangling bridges that nothing here can detect afterwards.

Rejected: relaxing `is_network_hidden` in the API matcher (40 devices genuinely
hold two NetworkManager profiles per SSID, so the fork is real), and pausing the
sync job for a run (its retry set is empty almost always, so a precondition
check replaces it).

## Testing

- [x] All four phases run end to end against a same-day prod dump restored
      locally, plus a stand-in App API carrying `network_smith`'s real
      constraints.
- [x] Manual smoke test: `805 -> 151 -> 140 -> 108 -> 101`. Verified
      independently afterwards: 0 strict duplicate groups remain, 0 dangling
      bridges, 0 orphaned profiles or intents, and profiles (4956) and intents
      (69) unchanged. No device reference or operator intent lost across 704
      deleted rows.
- [x] Phase 1's split recomputed outside the script; the 11 SSIDs that disappear
      entirely were inspected individually.
- [x] Adversarial rows (non-integer `network_smith_id`, unbridged retry-set row)
      and each review fix proven to fire, not merely to not break.

**Not tested against prod:** role permissions and scale.

## Checklist

- [x] No unintended side effects. No application code changes; standalone
      scripts, not wired into any build or service, nothing imports them.
- [x] Breaking change? No. Dry-run by default, `--commit` to apply.
- [x] Docs: README covers the content key, canonical rules, bridge
      classification, FK repointing, payload handling, and when to run. Nothing
      user-facing.