### PR TITLE
feat: support typed commands in devices bulk-command modal

### DIFF
--- a/dashboard/app/(private)/commands/shared.tsx
+++ b/dashboard/app/(private)/commands/shared.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Badge } from "@teton/smith-ui";
 import { Check, Copy, X } from "lucide-react";
 import { type ReactNode, useState } from "react";
 import type { DeviceCommandResponse } from "@/app/api-client";
@@ -69,6 +70,9 @@ export const SIMPLE_COMMANDS = [
 	"CheckOTAStatus",
 	"StartOTA",
 	"TestNetwork",
+	"WifiScan",
+	"ReportNMProfiles",
+	"RunAudit",
 ] as const;
 
 // ---------------------------------------------------------------------------
@@ -87,6 +91,15 @@ export type CmdRxUpdatePackage = {
 export type CmdRxWifiConnect = {
 	WifiConnect: { stdout: string; stderr: string };
 };
+export type WifiNetwork = {
+	ssid: string | null;
+	bssid: string;
+	signal: number | null;
+	rate: number | null;
+	security: string | null;
+	channel: number | null;
+};
+export type CmdRxWifiScan = { WifiScan: { networks: WifiNetwork[] } };
 export type CmdRxCheckOTAStatus = { CheckOTAStatus: { status: string } };
 export type CmdRxTestNetwork = {
 	TestNetwork: {
@@ -442,6 +455,12 @@ export const getTxLabel = (
 			return { label: "Start OTA", mono: false };
 		case "TestNetwork":
 			return { label: "Test Network", mono: false };
+		case "WifiScan":
+			return { label: "WiFi Scan", mono: false };
+		case "ReportNMProfiles":
+			return { label: "Report NM Profiles", mono: false };
+		case "RunAudit":
+			return { label: "Run Audit", mono: false };
 		case "FreeForm": {
 			const p = (parsed.tx as CmdTxFreeForm).FreeForm;
 			return { label: p.cmd, mono: true };
@@ -732,6 +751,90 @@ export const renderRxDetail = (response: unknown) => {
 							labelClassName="text-red-400"
 						/>
 					)}
+				</div>
+			);
+		}
+		case "WifiScan": {
+			const { networks } = parsed.payload as CmdRxWifiScan["WifiScan"];
+			if (networks.length === 0) {
+				return (
+					<p className="text-sm text-gray-400 italic">No networks found.</p>
+				);
+			}
+			return (
+				<div className="overflow-x-auto">
+					<table className="min-w-full divide-y divide-gray-200">
+						<thead>
+							<tr>
+								<th
+									scope="col"
+									className="text-xs font-medium text-gray-500 uppercase tracking-wider text-left pb-2"
+								>
+									Network
+								</th>
+								<th
+									scope="col"
+									className="text-xs font-medium text-gray-500 uppercase tracking-wider px-2 pb-2"
+								>
+									Channel
+								</th>
+								<th
+									scope="col"
+									className="text-xs font-medium text-gray-500 uppercase tracking-wider px-2 pb-2 text-right"
+								>
+									Signal
+								</th>
+								<th
+									scope="col"
+									className="text-xs font-medium text-gray-500 uppercase tracking-wider px-2 pb-2 text-right"
+								>
+									Rate
+								</th>
+								<th
+									scope="col"
+									className="text-xs font-medium text-gray-500 uppercase tracking-wider pl-2 pb-2"
+								>
+									Security
+								</th>
+							</tr>
+						</thead>
+						<tbody className="divide-y divide-gray-100">
+							{networks.map((n) => (
+								<tr key={`${n.bssid}-${n.channel}`}>
+									<td className="py-2 pr-2 max-w-0 w-full">
+										<div className="flex flex-col min-w-0">
+											{n.ssid ? (
+												<span className="text-sm font-medium text-gray-900 truncate">
+													{n.ssid}
+												</span>
+											) : (
+												<span className="text-sm italic text-gray-400 truncate">
+													&lt;hidden&gt;
+												</span>
+											)}
+											<span className="text-xs text-gray-500 font-mono truncate">
+												{n.bssid}
+											</span>
+										</div>
+									</td>
+									<td className="px-2 py-2 text-xs text-gray-500 whitespace-nowrap">
+										{n.channel ?? "—"}
+									</td>
+									<td className="px-2 py-2 text-xs text-gray-500 text-right whitespace-nowrap">
+										{n.signal != null ? `${n.signal}%` : "—"}
+									</td>
+									<td className="px-2 py-2 text-xs text-gray-500 text-right whitespace-nowrap">
+										{n.rate != null ? `${n.rate} Mbps` : "—"}
+									</td>
+									<td className="pl-2 py-2 whitespace-nowrap">
+										<Badge variant="gray" pill>
+											{n.security ?? "Open"}
+										</Badge>
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
 				</div>
 			);
 		}

--- a/dashboard/app/(private)/commands/shared.tsx
+++ b/dashboard/app/(private)/commands/shared.tsx
@@ -86,10 +86,12 @@ export const SIMPLE_COMMANDS = [
 	"RunAudit",
 ] as const;
 
-// Curated subset of SIMPLE_COMMANDS/COMMAND_OPTIONS safe to dispatch in bulk to
-// many devices at once from the devices-page modal. Deliberately excludes
-// anything session-based, parameterized, or that can brick connectivity/flash
-// a device (UpdateNetwork, StartOTA, DownloadOTA, OpenTunnel, StreamLogs, ...).
+// Curated subset of SIMPLE_COMMANDS/COMMAND_OPTIONS offered in the devices-page
+// bulk-dispatch modal. A UI curation, not a safety boundary: ExtendedNetworkTest
+// and GetLogs take parameters, and FreeForm can run arbitrary shell commands
+// (gated server-side by the `freeform` permission, not by this list). Excludes
+// anything session-based or that can brick connectivity/flash a device
+// (UpdateNetwork, StartOTA, DownloadOTA, OpenTunnel, StreamLogs, ...).
 export const BULK_COMMAND_OPTIONS = [
 	"WifiScan",
 	"Ping",
@@ -166,6 +168,7 @@ export const COMMAND_OPTIONS = [
 	"OpenTunnel",
 	"DownloadOTA",
 	"ExtendedNetworkTest",
+	"GetLogs",
 ];
 
 export type EditableCommand = {
@@ -318,6 +321,7 @@ export function CommandFields({
 			<select
 				value={command.variant}
 				onChange={(e) => set({ variant: e.target.value })}
+				aria-label="Command variant"
 				className={fieldClass}
 			>
 				{[...options].sort().map((opt) => (
@@ -1007,7 +1011,9 @@ export const renderRxDetail = (response: unknown) => {
 			);
 		}
 		case "WifiScan": {
-			const { networks } = parsed.payload as CmdRxWifiScan["WifiScan"];
+			const networks =
+				(parsed.payload as CmdRxWifiScan["WifiScan"] | undefined)?.networks ??
+				[];
 			return <WifiScanRxTable networks={networks} />;
 		}
 		case "Restart": {

--- a/dashboard/app/(private)/commands/shared.tsx
+++ b/dashboard/app/(private)/commands/shared.tsx
@@ -43,6 +43,14 @@ export type CmdTxStreamLogs = {
 	StreamLogs: { session_id: string; service_name: string };
 };
 export type CmdTxStopLogStream = { StopLogStream: { session_id: string } };
+export type CmdTxGetLogs = {
+	GetLogs: {
+		unit?: string | null;
+		since?: string | null;
+		until?: string | null;
+		grep?: string | null;
+	};
+};
 
 export type SafeCommandTx =
 	| CmdTxPing
@@ -59,7 +67,8 @@ export type SafeCommandTx =
 	| CmdTxDownloadOTA
 	| CmdTxExtendedNetworkTest
 	| CmdTxStreamLogs
-	| CmdTxStopLogStream;
+	| CmdTxStopLogStream
+	| CmdTxGetLogs;
 
 // TX command variants that carry no parameters (unit variants).
 export const SIMPLE_COMMANDS = [
@@ -153,6 +162,10 @@ export type EditableCommand = {
 	payload: string;
 	rate: string;
 	duration_minutes: string;
+	unit: string;
+	since: string;
+	until: string;
+	grep: string;
 };
 
 export const emptyCommand = (variant = "Ping"): EditableCommand => ({
@@ -166,6 +179,10 @@ export const emptyCommand = (variant = "Ping"): EditableCommand => ({
 	payload: "",
 	rate: "",
 	duration_minutes: "",
+	unit: "",
+	since: "",
+	until: "",
+	grep: "",
 });
 
 // Build the SafeCommandTx shape that smithd expects from the editable form.
@@ -195,6 +212,15 @@ export function buildCommand(ec: EditableCommand): unknown {
 					duration_minutes: Number(ec.duration_minutes),
 				},
 			};
+		case "GetLogs":
+			return {
+				GetLogs: {
+					unit: ec.unit.trim() || null,
+					since: ec.since.trim() || null,
+					until: ec.until.trim() || null,
+					grep: ec.grep.trim() || null,
+				},
+			};
 		default:
 			return ec.variant;
 	}
@@ -221,6 +247,10 @@ export function parseCommand(
 		ec.rate = p.rate != null ? String(p.rate) : "";
 		ec.duration_minutes =
 			p.duration_minutes != null ? String(p.duration_minutes) : "";
+		ec.unit = (p.unit as string) ?? "";
+		ec.since = (p.since as string) ?? "";
+		ec.until = (p.until as string) ?? "";
+		ec.grep = (p.grep as string) ?? "";
 		return ec;
 	}
 	return emptyCommand();
@@ -351,6 +381,39 @@ export function CommandFields({
 					placeholder="duration (minutes)"
 					className={fieldClass}
 				/>
+			)}
+
+			{command.variant === "GetLogs" && (
+				<div className="grid grid-cols-2 gap-2">
+					<input
+						type="text"
+						value={command.unit}
+						onChange={(e) => set({ unit: e.target.value })}
+						placeholder="unit (optional, e.g. smithd)"
+						className={fieldClass}
+					/>
+					<input
+						type="text"
+						value={command.grep}
+						onChange={(e) => set({ grep: e.target.value })}
+						placeholder="grep (optional)"
+						className={fieldClass}
+					/>
+					<input
+						type="text"
+						value={command.since}
+						onChange={(e) => set({ since: e.target.value })}
+						placeholder="since (optional, e.g. 1h ago)"
+						className={fieldClass}
+					/>
+					<input
+						type="text"
+						value={command.until}
+						onChange={(e) => set({ until: e.target.value })}
+						placeholder="until (optional)"
+						className={fieldClass}
+					/>
+				</div>
 			)}
 
 			<label className="flex items-center gap-2 text-xs text-gray-600">
@@ -495,6 +558,10 @@ export const getTxLabel = (
 		}
 		case "StopLogStream":
 			return { label: "Stop Log Stream", mono: false };
+		case "GetLogs": {
+			const p = (parsed.tx as CmdTxGetLogs).GetLogs;
+			return { label: `Get Logs${p.unit ? `: ${p.unit}` : ""}`, mono: false };
+		}
 		default:
 			return { label: parsed.variant, mono: false };
 	}
@@ -688,6 +755,20 @@ export const renderTxDetail = (cmd_data: unknown) => {
 		case "StopLogStream": {
 			const p = (parsed.tx as CmdTxStopLogStream).StopLogStream;
 			return <KVTable rows={[{ key: "Session ID", value: p.session_id }]} />;
+		}
+		case "GetLogs": {
+			const p = (parsed.tx as CmdTxGetLogs).GetLogs;
+			const rows = [
+				p.unit ? { key: "Unit", value: p.unit } : null,
+				p.since ? { key: "Since", value: p.since } : null,
+				p.until ? { key: "Until", value: p.until } : null,
+				p.grep ? { key: "Grep", value: p.grep } : null,
+			].filter(Boolean) as { key: string; value: string }[];
+			return rows.length > 0 ? (
+				<KVTable rows={rows} />
+			) : (
+				<p className="text-sm text-gray-400 italic">No filters</p>
+			);
 		}
 		default:
 			return (

--- a/dashboard/app/(private)/commands/shared.tsx
+++ b/dashboard/app/(private)/commands/shared.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { Badge } from "@teton/smith-ui";
-import { Check, Copy, X } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import { Check, ChevronDown, ChevronRight, Copy, X } from "lucide-react";
+import { Fragment, type ReactNode, useMemo, useState } from "react";
 import type { DeviceCommandResponse } from "@/app/api-client";
+import { Tooltip } from "@/app/components/tooltip";
+import { deriveBand, groupScanResults, SignalBar } from "@/app/utils/wifiScan";
 
 // ---------------------------------------------------------------------------
 // SafeCommandTx types (mirrors smithd/src/utils/schema.rs)
@@ -685,6 +687,160 @@ export const KVTable = ({
 	</dl>
 );
 
+// Groups a WifiScan response the same way the device Network page groups its
+// persisted scan (dashboard/app/utils/wifiScan.ts): by SSID+security, best
+// signal first, hidden APs collapsed into one group last. No relationship
+// badges (Active/Configured/In intent) here — those need the device's
+// configured profiles and intent, which aren't available in this context and
+// a bundle response can cover many different devices at once.
+const WifiScanRxTable = ({ networks }: { networks: WifiNetwork[] }) => {
+	const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+
+	const groups = useMemo(
+		() =>
+			groupScanResults(
+				networks.map((n) => ({ ...n, band: deriveBand(n.channel) })),
+			),
+		[networks],
+	);
+
+	if (networks.length === 0) {
+		return <p className="text-sm text-gray-400 italic">No networks found.</p>;
+	}
+
+	const toggleGroup = (key: string) =>
+		setExpandedGroups((prev) => {
+			const next = new Set(prev);
+			if (next.has(key)) next.delete(key);
+			else next.add(key);
+			return next;
+		});
+
+	return (
+		<div className="overflow-x-auto">
+			<table className="min-w-full divide-y divide-gray-200">
+				<thead>
+					<tr>
+						<th
+							scope="col"
+							className="text-xs font-medium text-gray-500 uppercase tracking-wider text-left pb-2"
+						>
+							Network
+						</th>
+						<th
+							scope="col"
+							className="text-xs font-medium text-gray-500 uppercase tracking-wider px-2 pb-2"
+						>
+							Signal
+						</th>
+						<th
+							scope="col"
+							className="text-xs font-medium text-gray-500 uppercase tracking-wider px-2 pb-2 text-right"
+						>
+							APs
+						</th>
+						<th
+							scope="col"
+							className="text-xs font-medium text-gray-500 uppercase tracking-wider px-2 pb-2"
+						>
+							Bands
+						</th>
+						<th
+							scope="col"
+							className="text-xs font-medium text-gray-500 uppercase tracking-wider pl-2 pb-2"
+						>
+							Security
+						</th>
+					</tr>
+				</thead>
+				<tbody className="divide-y divide-gray-100">
+					{groups.map((group) => {
+						const hidden = group.ssid == null;
+						const expanded = expandedGroups.has(group.key);
+						return (
+							<Fragment key={group.key}>
+								<tr>
+									<td className="py-2 pr-2 max-w-0 w-full">
+										<button
+											type="button"
+											onClick={() => toggleGroup(group.key)}
+											aria-expanded={expanded}
+											aria-label={`${expanded ? "Collapse" : "Expand"} ${
+												hidden ? "hidden networks" : group.ssid
+											}`}
+											className="flex items-center gap-1.5 min-w-0 w-full text-left cursor-pointer"
+										>
+											{expanded ? (
+												<ChevronDown className="w-3.5 h-3.5 text-gray-400 flex-shrink-0" />
+											) : (
+												<ChevronRight className="w-3.5 h-3.5 text-gray-400 flex-shrink-0" />
+											)}
+											{hidden ? (
+												<span className="text-sm italic text-gray-500 truncate">
+													{group.aps.length} hidden AP
+													{group.aps.length === 1 ? "" : "s"} seen
+												</span>
+											) : (
+												<span className="text-sm font-medium text-gray-900 truncate">
+													{group.ssid}
+												</span>
+											)}
+										</button>
+									</td>
+									<td className="px-2 py-2 text-center whitespace-nowrap">
+										<SignalBar value={group.bestSignal} />
+									</td>
+									<td className="px-2 py-2 text-xs text-gray-500 text-right whitespace-nowrap tabular-nums">
+										×{group.aps.length}
+									</td>
+									<td className="px-2 py-2 whitespace-nowrap">
+										<span className="inline-flex gap-1">
+											{group.bands.map((band) => (
+												<Badge key={band} variant="gray">
+													{band}
+												</Badge>
+											))}
+										</span>
+									</td>
+									<td className="pl-2 py-2 whitespace-nowrap">
+										{!hidden && (
+											<Badge variant="gray" pill>
+												{group.security ?? "Open"}
+											</Badge>
+										)}
+									</td>
+								</tr>
+								{expanded &&
+									group.aps.map((ap) => (
+										<tr key={ap.bssid} className="bg-gray-50">
+											<td className="py-1.5 pr-2 pl-8 text-xs font-mono text-gray-500 whitespace-nowrap">
+												{ap.bssid}
+											</td>
+											<td className="px-2 py-1.5 text-center whitespace-nowrap">
+												<SignalBar value={ap.signal} />
+											</td>
+											<td />
+											<td className="px-2 py-1.5 text-xs text-gray-500 whitespace-nowrap">
+												<Tooltip content={`Channel ${ap.channel ?? "—"}`}>
+													<span className="border-b border-dotted border-gray-500 cursor-default">
+														{ap.band ?? "—"}
+													</span>
+												</Tooltip>
+											</td>
+											<td className="pl-2 py-1.5 text-right text-xs text-gray-500 tabular-nums whitespace-nowrap">
+												{ap.rate != null ? `${ap.rate} Mbps` : "—"}
+											</td>
+										</tr>
+									))}
+							</Fragment>
+						);
+					})}
+				</tbody>
+			</table>
+		</div>
+	);
+};
+
 // ---------------------------------------------------------------------------
 // TX detail renderer
 // ---------------------------------------------------------------------------
@@ -852,87 +1008,7 @@ export const renderRxDetail = (response: unknown) => {
 		}
 		case "WifiScan": {
 			const { networks } = parsed.payload as CmdRxWifiScan["WifiScan"];
-			if (networks.length === 0) {
-				return (
-					<p className="text-sm text-gray-400 italic">No networks found.</p>
-				);
-			}
-			return (
-				<div className="overflow-x-auto">
-					<table className="min-w-full divide-y divide-gray-200">
-						<thead>
-							<tr>
-								<th
-									scope="col"
-									className="text-xs font-medium text-gray-500 uppercase tracking-wider text-left pb-2"
-								>
-									Network
-								</th>
-								<th
-									scope="col"
-									className="text-xs font-medium text-gray-500 uppercase tracking-wider px-2 pb-2"
-								>
-									Channel
-								</th>
-								<th
-									scope="col"
-									className="text-xs font-medium text-gray-500 uppercase tracking-wider px-2 pb-2 text-right"
-								>
-									Signal
-								</th>
-								<th
-									scope="col"
-									className="text-xs font-medium text-gray-500 uppercase tracking-wider px-2 pb-2 text-right"
-								>
-									Rate
-								</th>
-								<th
-									scope="col"
-									className="text-xs font-medium text-gray-500 uppercase tracking-wider pl-2 pb-2"
-								>
-									Security
-								</th>
-							</tr>
-						</thead>
-						<tbody className="divide-y divide-gray-100">
-							{networks.map((n) => (
-								<tr key={`${n.bssid}-${n.channel}`}>
-									<td className="py-2 pr-2 max-w-0 w-full">
-										<div className="flex flex-col min-w-0">
-											{n.ssid ? (
-												<span className="text-sm font-medium text-gray-900 truncate">
-													{n.ssid}
-												</span>
-											) : (
-												<span className="text-sm italic text-gray-400 truncate">
-													&lt;hidden&gt;
-												</span>
-											)}
-											<span className="text-xs text-gray-500 font-mono truncate">
-												{n.bssid}
-											</span>
-										</div>
-									</td>
-									<td className="px-2 py-2 text-xs text-gray-500 whitespace-nowrap">
-										{n.channel ?? "—"}
-									</td>
-									<td className="px-2 py-2 text-xs text-gray-500 text-right whitespace-nowrap">
-										{n.signal != null ? `${n.signal}%` : "—"}
-									</td>
-									<td className="px-2 py-2 text-xs text-gray-500 text-right whitespace-nowrap">
-										{n.rate != null ? `${n.rate} Mbps` : "—"}
-									</td>
-									<td className="pl-2 py-2 whitespace-nowrap">
-										<Badge variant="gray" pill>
-											{n.security ?? "Open"}
-										</Badge>
-									</td>
-								</tr>
-							))}
-						</tbody>
-					</table>
-				</div>
-			);
+			return <WifiScanRxTable networks={networks} />;
 		}
 		case "Restart": {
 			const p = parsed.payload as CmdRxRestart["Restart"];

--- a/dashboard/app/(private)/commands/shared.tsx
+++ b/dashboard/app/(private)/commands/shared.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, Copy } from "lucide-react";
+import { Check, Copy, X } from "lucide-react";
 import { type ReactNode, useState } from "react";
 import type { DeviceCommandResponse } from "@/app/api-client";
 
@@ -114,6 +114,283 @@ export type CmdRxLogStreamStopped = {
 export type CmdRxLogStreamError = {
 	LogStreamError: { session_id: string; error: string };
 };
+
+// ---------------------------------------------------------------------------
+// Editable command builder (used by the recipes page and the devices bulk-
+// command modal to build a SafeCommandTx from a form)
+// ---------------------------------------------------------------------------
+
+// Full set of command variants a recipe can store.
+export const COMMAND_OPTIONS = [
+	...SIMPLE_COMMANDS,
+	"FreeForm",
+	"OpenTunnel",
+	"DownloadOTA",
+	"ExtendedNetworkTest",
+];
+
+export type EditableCommand = {
+	variant: string;
+	continue_on_error: boolean;
+	cmd: string;
+	port: string;
+	user: string;
+	pub_key: string;
+	tools: string;
+	payload: string;
+	rate: string;
+	duration_minutes: string;
+};
+
+export const emptyCommand = (variant = "Ping"): EditableCommand => ({
+	variant,
+	continue_on_error: false,
+	cmd: "",
+	port: "",
+	user: "",
+	pub_key: "",
+	tools: "",
+	payload: "",
+	rate: "",
+	duration_minutes: "",
+});
+
+// Build the SafeCommandTx shape that smithd expects from the editable form.
+export function buildCommand(ec: EditableCommand): unknown {
+	switch (ec.variant) {
+		case "FreeForm":
+			return { FreeForm: { cmd: ec.cmd } };
+		case "OpenTunnel":
+			return {
+				OpenTunnel: {
+					port: ec.port.trim() ? Number(ec.port) : null,
+					user: ec.user.trim() || null,
+					pub_key: ec.pub_key.trim() || null,
+				},
+			};
+		case "DownloadOTA":
+			return {
+				DownloadOTA: {
+					tools: ec.tools,
+					payload: ec.payload,
+					rate: Number(ec.rate),
+				},
+			};
+		case "ExtendedNetworkTest":
+			return {
+				ExtendedNetworkTest: {
+					duration_minutes: Number(ec.duration_minutes),
+				},
+			};
+		default:
+			return ec.variant;
+	}
+}
+
+// Parse a stored command back into the editable form (for editing a recipe).
+export function parseCommand(
+	cmd: unknown,
+	continue_on_error: boolean,
+): EditableCommand {
+	if (typeof cmd === "string")
+		return { ...emptyCommand(cmd), continue_on_error };
+	if (cmd && typeof cmd === "object") {
+		const variant = Object.keys(cmd)[0];
+		const p = (cmd as Record<string, Record<string, unknown>>)[variant] ?? {};
+		const ec = emptyCommand(variant);
+		ec.continue_on_error = continue_on_error;
+		ec.cmd = (p.cmd as string) ?? "";
+		ec.port = p.port != null ? String(p.port) : "";
+		ec.user = (p.user as string) ?? "";
+		ec.pub_key = (p.pub_key as string) ?? "";
+		ec.tools = (p.tools as string) ?? "";
+		ec.payload = (p.payload as string) ?? "";
+		ec.rate = p.rate != null ? String(p.rate) : "";
+		ec.duration_minutes =
+			p.duration_minutes != null ? String(p.duration_minutes) : "";
+		return ec;
+	}
+	return emptyCommand();
+}
+
+const isFiniteNumber = (v: string): boolean =>
+	v.trim().length > 0 && Number.isFinite(Number(v));
+
+export function commandIsValid(ec: EditableCommand): boolean {
+	switch (ec.variant) {
+		case "FreeForm":
+			return ec.cmd.trim().length > 0;
+		case "DownloadOTA":
+			return (
+				ec.tools.trim().length > 0 &&
+				ec.payload.trim().length > 0 &&
+				isFiniteNumber(ec.rate)
+			);
+		case "ExtendedNetworkTest":
+			return (
+				isFiniteNumber(ec.duration_minutes) && Number(ec.duration_minutes) > 0
+			);
+		default:
+			return true;
+	}
+}
+
+const fieldClass =
+	"w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900 placeholder-gray-400 text-sm";
+
+// Variant picker + variant-specific inputs + continue-on-error checkbox. No
+// list-row chrome (index, remove button) so it can be used standalone by
+// callers that only ever hold one command, like the devices bulk-command modal.
+export function CommandFields({
+	command,
+	options,
+	onChange,
+}: {
+	command: EditableCommand;
+	options: readonly string[];
+	onChange: (next: EditableCommand) => void;
+}) {
+	const set = (patch: Partial<EditableCommand>) =>
+		onChange({ ...command, ...patch });
+
+	return (
+		<div className="space-y-3">
+			<select
+				value={command.variant}
+				onChange={(e) => set({ variant: e.target.value })}
+				className={fieldClass}
+			>
+				{[...options].sort().map((opt) => (
+					<option key={opt} value={opt}>
+						{opt}
+					</option>
+				))}
+			</select>
+
+			{command.variant === "FreeForm" && (
+				<input
+					type="text"
+					value={command.cmd}
+					onChange={(e) => set({ cmd: e.target.value })}
+					placeholder="e.g., ls -la /var/log"
+					className={`${fieldClass} font-mono`}
+				/>
+			)}
+
+			{command.variant === "OpenTunnel" && (
+				<div className="grid grid-cols-3 gap-2">
+					<input
+						type="number"
+						value={command.port}
+						onChange={(e) => set({ port: e.target.value })}
+						placeholder="port (optional)"
+						className={fieldClass}
+					/>
+					<input
+						type="text"
+						value={command.user}
+						onChange={(e) => set({ user: e.target.value })}
+						placeholder="user (optional)"
+						className={fieldClass}
+					/>
+					<input
+						type="text"
+						value={command.pub_key}
+						onChange={(e) => set({ pub_key: e.target.value })}
+						placeholder="public key (optional)"
+						className={fieldClass}
+					/>
+				</div>
+			)}
+
+			{command.variant === "DownloadOTA" && (
+				<div className="grid grid-cols-3 gap-2">
+					<input
+						type="text"
+						value={command.tools}
+						onChange={(e) => set({ tools: e.target.value })}
+						placeholder="tools"
+						className={fieldClass}
+					/>
+					<input
+						type="text"
+						value={command.payload}
+						onChange={(e) => set({ payload: e.target.value })}
+						placeholder="payload"
+						className={fieldClass}
+					/>
+					<input
+						type="number"
+						step="any"
+						value={command.rate}
+						onChange={(e) => set({ rate: e.target.value })}
+						placeholder="rate"
+						className={fieldClass}
+					/>
+				</div>
+			)}
+
+			{command.variant === "ExtendedNetworkTest" && (
+				<input
+					type="number"
+					value={command.duration_minutes}
+					onChange={(e) => set({ duration_minutes: e.target.value })}
+					placeholder="duration (minutes)"
+					className={fieldClass}
+				/>
+			)}
+
+			<label className="flex items-center gap-2 text-xs text-gray-600">
+				<input
+					type="checkbox"
+					checked={command.continue_on_error}
+					onChange={(e) => set({ continue_on_error: e.target.checked })}
+				/>
+				Continue running the bundle if this command fails
+			</label>
+		</div>
+	);
+}
+
+// One editable command inside a repeatable list (recipes page): adds the
+// index label and a remove button around CommandFields.
+export function CommandRow({
+	command,
+	index,
+	onChange,
+	onRemove,
+}: {
+	command: EditableCommand;
+	index: number;
+	onChange: (next: EditableCommand) => void;
+	onRemove: () => void;
+}) {
+	return (
+		<div className="border border-gray-200/80 rounded-lg p-3 space-y-3">
+			<div className="flex items-start gap-2">
+				<span className="text-xs font-medium text-gray-400 w-5 mt-2">
+					{index + 1}.
+				</span>
+				<div className="flex-1">
+					<CommandFields
+						command={command}
+						options={COMMAND_OPTIONS}
+						onChange={onChange}
+					/>
+				</div>
+				<button
+					type="button"
+					onClick={onRemove}
+					aria-label="Remove command"
+					className="text-gray-400 hover:text-red-600 cursor-pointer p-1 mt-1"
+					title="Remove command"
+				>
+					<X className="w-4 h-4" />
+				</button>
+			</div>
+		</div>
+	);
+}
 
 // ---------------------------------------------------------------------------
 // Parsers

--- a/dashboard/app/(private)/commands/shared.tsx
+++ b/dashboard/app/(private)/commands/shared.tsx
@@ -84,6 +84,21 @@ export const SIMPLE_COMMANDS = [
 	"RunAudit",
 ] as const;
 
+// Curated subset of SIMPLE_COMMANDS/COMMAND_OPTIONS safe to dispatch in bulk to
+// many devices at once from the devices-page modal. Deliberately excludes
+// anything session-based, parameterized, or that can brick connectivity/flash
+// a device (UpdateNetwork, StartOTA, DownloadOTA, OpenTunnel, StreamLogs, ...).
+export const BULK_COMMAND_OPTIONS = [
+	"WifiScan",
+	"Ping",
+	"TestNetwork",
+	"ExtendedNetworkTest",
+	"RunAudit",
+	"ReportNMProfiles",
+	"GetLogs",
+	"FreeForm",
+] as const;
+
 // ---------------------------------------------------------------------------
 // SafeCommandRx types (mirrors smithd/src/utils/schema.rs)
 // ---------------------------------------------------------------------------

--- a/dashboard/app/(private)/devices/[serial]/WifiPanel.tsx
+++ b/dashboard/app/(private)/devices/[serial]/WifiPanel.tsx
@@ -51,6 +51,11 @@ import {
 	useClientMutatorWithStatus,
 } from "@/app/api-client-mutator";
 import { Tooltip } from "@/app/components/tooltip";
+import {
+	groupScanResults,
+	type ScanGroup,
+	SignalBar,
+} from "@/app/utils/wifiScan";
 
 const MASK = "••••••••••••";
 
@@ -59,60 +64,6 @@ const filterFieldClass =
 
 const getProfileTimestamp = (p: ConfiguredNetwork) => p.updated_at;
 const getScanTimestamp = (r: WifiScanResult) => r.scanned_at;
-
-/** One row per (SSID, security) pair the scan saw: APs sharing an SSID but
- *  differing in security are different networks, so they get separate rows.
- *  Hidden APs (no SSID) all collapse into a single group regardless of
- *  security, since there is nothing more specific to group them by. */
-interface ScanGroup {
-	key: string;
-	ssid: string | null;
-	/** Raw scan security string (e.g. "WPA1 WPA2"); null = open. Meaningless
-	 *  for the hidden group, which mixes securities. */
-	security: string | null;
-	bestSignal: number | null;
-	bands: string[];
-	aps: WifiScanResult[];
-}
-
-const HIDDEN_GROUP_KEY = "\0hidden";
-
-function groupScanResults(results: WifiScanResult[]): ScanGroup[] {
-	const groups = new Map<string, ScanGroup>();
-	for (const r of results) {
-		const key =
-			r.ssid == null ? HIDDEN_GROUP_KEY : `${r.ssid}\0${r.security ?? ""}`;
-		let group = groups.get(key);
-		if (!group) {
-			group = {
-				key,
-				ssid: r.ssid ?? null,
-				security: r.ssid == null ? null : (r.security ?? null),
-				bestSignal: null,
-				bands: [],
-				aps: [],
-			};
-			groups.set(key, group);
-		}
-		group.aps.push(r);
-	}
-
-	for (const group of groups.values()) {
-		group.aps.sort((a, b) => (b.signal ?? -1) - (a.signal ?? -1));
-		group.bestSignal = group.aps[0]?.signal ?? null;
-		group.bands = [
-			...new Set(
-				group.aps.map((ap) => ap.band).filter((b): b is string => !!b),
-			),
-		];
-	}
-
-	const visible = [...groups.values()]
-		.filter((g) => g.ssid != null)
-		.sort((a, b) => (b.bestSignal ?? -1) - (a.bestSignal ?? -1));
-	const hidden = groups.get(HIDDEN_GROUP_KEY);
-	return hidden ? [...visible, hidden] : visible;
-}
 
 type SecurityClass = "open" | "wep" | "psk" | "sae" | "owe" | "enterprise";
 
@@ -205,31 +156,6 @@ function RelationshipBadgePill({ badge }: { badge: RelationshipBadge }) {
 			</Badge>
 		);
 	return null;
-}
-
-function SignalBar({ value }: { value: number | null }) {
-	const pct = value ?? 0;
-	const color =
-		value == null
-			? "bg-gray-200"
-			: pct >= 60
-				? "bg-green-500"
-				: pct >= 35
-					? "bg-yellow-500"
-					: "bg-orange-500";
-	return (
-		<span className="inline-flex items-center gap-2 min-w-[110px]">
-			<span className="flex-1 h-1.5 min-w-[56px] rounded-full bg-gray-100 overflow-hidden">
-				<span
-					className={`block h-full rounded-full ${color}`}
-					style={{ width: `${Math.max(pct, value == null ? 0 : 2)}%` }}
-				/>
-			</span>
-			<span className="text-xs text-gray-500 tabular-nums w-9 text-right">
-				{value != null ? `${value}%` : "—"}
-			</span>
-		</span>
-	);
 }
 
 interface NetworkCondition {

--- a/dashboard/app/(private)/devices/page.tsx
+++ b/dashboard/app/(private)/devices/page.tsx
@@ -1,6 +1,7 @@
 import { useAuth0 } from "@auth0/auth0-react";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { Button, LabelChip, Toast } from "@teton/smith-ui";
+import { isAxiosError } from "axios";
 import {
 	AlertTriangle,
 	Calendar,
@@ -19,6 +20,14 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router";
+import {
+	BULK_COMMAND_OPTIONS,
+	buildCommand,
+	CommandFields,
+	commandIsValid,
+	type EditableCommand,
+	emptyCommand,
+} from "@/app/(private)/commands/shared";
 import LabelAutocomplete from "@/app/components/LabelAutocomplete";
 import { Modal } from "@/app/components/modal";
 import NetworkQualityIndicator from "@/app/components/NetworkQualityIndicator";
@@ -181,7 +190,10 @@ const DevicesPage = () => {
 	const [bulkDeployReleaseSearch, setBulkDeployReleaseSearch] = useState("");
 	// Bulk command state
 	const [showBulkCommandModal, setShowBulkCommandModal] = useState(false);
-	const [freeFormCommand, setFreeFormCommand] = useState("");
+	const [bulkCommand, setBulkCommand] = useState<EditableCommand>(() =>
+		emptyCommand("Ping"),
+	);
+	const [bulkCommandError, setBulkCommandError] = useState<string | null>(null);
 
 	// Approval state
 	const [approveModalDevice, setApproveModalDevice] = useState<Device | null>(
@@ -478,25 +490,41 @@ const DevicesPage = () => {
 				onSuccess: () => {
 					setShowBulkCommandModal(false);
 					setSelectedDeviceIds(new Set());
-					setFreeFormCommand("");
+					setBulkCommand(emptyCommand("Ping"));
+					setBulkCommandError(null);
+					navigate("/commands");
 				},
 				onError: (error) => {
 					console.error("Failed to issue commands:", error);
+					if (isAxiosError(error) && error.response?.status === 403) {
+						// The bulk modal only ever dispatches one command, so the variant
+						// still held in state is the one that got rejected. FreeForm is
+						// the only variant in BULK_COMMAND_OPTIONS gated behind the
+						// admin-only `freeform` permission, so it gets a specific message.
+						setBulkCommandError(
+							bulkCommand.variant === "FreeForm"
+								? "You don't have permission to run FreeForm commands"
+								: "You don't have permission to run this command",
+						);
+					} else {
+						setBulkCommandError("Failed to dispatch command");
+					}
 				},
 			},
 		});
 
 	const handleBulkCommand = () => {
-		if (!freeFormCommand.trim()) return;
+		if (!commandIsValid(bulkCommand)) return;
 
+		setBulkCommandError(null);
 		issueCommands({
 			data: {
 				devices: Array.from(selectedDeviceIds),
 				commands: [
 					{
 						id: -1,
-						command: { FreeForm: { cmd: freeFormCommand } },
-						continue_on_error: false,
+						command: buildCommand(bulkCommand),
+						continue_on_error: bulkCommand.continue_on_error,
 					},
 				],
 			},
@@ -1444,7 +1472,11 @@ const DevicesPage = () => {
 									variant="solid"
 									tone="purple"
 									icon={<Terminal className="w-4 h-4" />}
-									onClick={() => setShowBulkCommandModal(true)}
+									onClick={() => {
+										setBulkCommand(emptyCommand("Ping"));
+										setBulkCommandError(null);
+										setShowBulkCommandModal(true);
+									}}
 								>
 									Run Command
 								</Button>
@@ -1674,7 +1706,8 @@ const DevicesPage = () => {
 				open={showBulkCommandModal}
 				onClose={() => {
 					setShowBulkCommandModal(false);
-					setFreeFormCommand("");
+					setBulkCommand(emptyCommand("Ping"));
+					setBulkCommandError(null);
 				}}
 				title="Run Command on Selected Devices"
 				footer={
@@ -1685,7 +1718,8 @@ const DevicesPage = () => {
 							disabled={isIssuingCommands}
 							onClick={() => {
 								setShowBulkCommandModal(false);
-								setFreeFormCommand("");
+								setBulkCommand(emptyCommand("Ping"));
+								setBulkCommandError(null);
 							}}
 						>
 							Cancel
@@ -1694,7 +1728,7 @@ const DevicesPage = () => {
 							variant="solid"
 							tone="purple"
 							loading={isIssuingCommands}
-							disabled={!freeFormCommand.trim()}
+							disabled={!commandIsValid(bulkCommand)}
 							onClick={handleBulkCommand}
 						>
 							{isIssuingCommands ? "Sending..." : "Run Command"}
@@ -1719,20 +1753,24 @@ const DevicesPage = () => {
 					</div>
 				</div>
 
-				{/* Command Input */}
+				{bulkCommandError && (
+					<div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg p-3 mb-4">
+						{bulkCommandError}
+					</div>
+				)}
+
+				{/* Command */}
 				<div>
 					<label className="block text-sm font-medium text-gray-700 mb-2">
 						Command
 					</label>
-					<input
-						type="text"
-						value={freeFormCommand}
-						onChange={(e) => setFreeFormCommand(e.target.value)}
-						placeholder="e.g., ls -la /var/log"
-						className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-purple-500 focus:border-purple-500 text-gray-900 placeholder-gray-400"
+					<CommandFields
+						command={bulkCommand}
+						options={BULK_COMMAND_OPTIONS}
+						onChange={setBulkCommand}
 					/>
 					<p className="mt-1 text-xs text-gray-500">
-						Enter a shell command to execute on the selected devices
+						Runs on all selected devices
 					</p>
 				</div>
 			</Modal>

--- a/dashboard/app/(private)/recipes/page.tsx
+++ b/dashboard/app/(private)/recipes/page.tsx
@@ -97,15 +97,21 @@ function RecipeEditor({
 
 	const isPending = createMut.isPending || updateMut.isPending;
 
-	const builtCommands = commands.map((ec) => ({
-		command: buildCommand(ec),
-		continue_on_error: ec.continue_on_error,
-	}));
-
 	const isValid =
 		name.trim().length > 0 &&
 		commands.length > 0 &&
 		commands.every(commandIsValid);
+
+	// Only build once every row is valid: buildCommand's Number() conversions on
+	// an in-progress, not-yet-valid row (e.g. empty duration_minutes) would
+	// otherwise produce NaN, which JSON.stringify silently turns into null in
+	// the isDirty comparison below.
+	const builtCommands = isValid
+		? commands.map((ec) => ({
+				command: buildCommand(ec),
+				continue_on_error: ec.continue_on_error,
+			}))
+		: [];
 
 	// Whether the form differs from the saved recipe. A new (unsaved) recipe is
 	// always considered dirty so it can be created.

--- a/dashboard/app/(private)/recipes/page.tsx
+++ b/dashboard/app/(private)/recipes/page.tsx
@@ -2,9 +2,16 @@
 
 import { useQueryClient } from "@tanstack/react-query";
 import { Button, Card, SearchInput } from "@teton/smith-ui";
-import { Plus, ScrollText, Send, Trash2, X } from "lucide-react";
+import { Plus, ScrollText, Send, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import { SIMPLE_COMMANDS } from "@/app/(private)/commands/shared";
+import {
+	buildCommand,
+	CommandRow,
+	commandIsValid,
+	type EditableCommand,
+	emptyCommand,
+	parseCommand,
+} from "@/app/(private)/commands/shared";
 import {
 	type CommandRecipe,
 	type Device,
@@ -30,98 +37,6 @@ function asArray<T>(data: unknown): T[] {
 	return Array.isArray(data) ? (data as T[]) : [];
 }
 
-const COMMAND_OPTIONS = [
-	...SIMPLE_COMMANDS,
-	"FreeForm",
-	"OpenTunnel",
-	"DownloadOTA",
-	"ExtendedNetworkTest",
-];
-
-type EditableCommand = {
-	variant: string;
-	continue_on_error: boolean;
-	cmd: string;
-	port: string;
-	user: string;
-	pub_key: string;
-	tools: string;
-	payload: string;
-	rate: string;
-	duration_minutes: string;
-};
-
-const emptyCommand = (variant = "Ping"): EditableCommand => ({
-	variant,
-	continue_on_error: false,
-	cmd: "",
-	port: "",
-	user: "",
-	pub_key: "",
-	tools: "",
-	payload: "",
-	rate: "",
-	duration_minutes: "",
-});
-
-// Build the SafeCommandTx shape that smithd expects from the editable form.
-function buildCommand(ec: EditableCommand): unknown {
-	switch (ec.variant) {
-		case "FreeForm":
-			return { FreeForm: { cmd: ec.cmd } };
-		case "OpenTunnel":
-			return {
-				OpenTunnel: {
-					port: ec.port.trim() ? Number(ec.port) : null,
-					user: ec.user.trim() || null,
-					pub_key: ec.pub_key.trim() || null,
-				},
-			};
-		case "DownloadOTA":
-			return {
-				DownloadOTA: {
-					tools: ec.tools,
-					payload: ec.payload,
-					rate: Number(ec.rate),
-				},
-			};
-		case "ExtendedNetworkTest":
-			return {
-				ExtendedNetworkTest: {
-					duration_minutes: Number(ec.duration_minutes),
-				},
-			};
-		default:
-			return ec.variant;
-	}
-}
-
-// Parse a stored command back into the editable form (for editing a recipe).
-function parseCommand(
-	cmd: unknown,
-	continue_on_error: boolean,
-): EditableCommand {
-	if (typeof cmd === "string")
-		return { ...emptyCommand(cmd), continue_on_error };
-	if (cmd && typeof cmd === "object") {
-		const variant = Object.keys(cmd)[0];
-		const p = (cmd as Record<string, Record<string, unknown>>)[variant] ?? {};
-		const ec = emptyCommand(variant);
-		ec.continue_on_error = continue_on_error;
-		ec.cmd = (p.cmd as string) ?? "";
-		ec.port = p.port != null ? String(p.port) : "";
-		ec.user = (p.user as string) ?? "";
-		ec.pub_key = (p.pub_key as string) ?? "";
-		ec.tools = (p.tools as string) ?? "";
-		ec.payload = (p.payload as string) ?? "";
-		ec.rate = p.rate != null ? String(p.rate) : "";
-		ec.duration_minutes =
-			p.duration_minutes != null ? String(p.duration_minutes) : "";
-		return ec;
-	}
-	return emptyCommand();
-}
-
 function commandsFromRecipe(recipe: CommandRecipe | null): EditableCommand[] {
 	if (!recipe) return [emptyCommand()];
 	const parsed = asArray<Record<string, unknown>>(recipe.commands).map((c) =>
@@ -130,161 +45,8 @@ function commandsFromRecipe(recipe: CommandRecipe | null): EditableCommand[] {
 	return parsed.length > 0 ? parsed : [emptyCommand()];
 }
 
-const isFiniteNumber = (v: string): boolean =>
-	v.trim().length > 0 && Number.isFinite(Number(v));
-
-function commandIsValid(ec: EditableCommand): boolean {
-	switch (ec.variant) {
-		case "FreeForm":
-			return ec.cmd.trim().length > 0;
-		case "DownloadOTA":
-			return (
-				ec.tools.trim().length > 0 &&
-				ec.payload.trim().length > 0 &&
-				isFiniteNumber(ec.rate)
-			);
-		case "ExtendedNetworkTest":
-			return (
-				isFiniteNumber(ec.duration_minutes) && Number(ec.duration_minutes) > 0
-			);
-		default:
-			return true;
-	}
-}
-
 const fieldClass =
 	"w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900 placeholder-gray-400 text-sm";
-
-// ---------------------------------------------------------------------------
-// Command row (one editable command inside the editor)
-// ---------------------------------------------------------------------------
-
-function CommandRow({
-	command,
-	index,
-	onChange,
-	onRemove,
-}: {
-	command: EditableCommand;
-	index: number;
-	onChange: (next: EditableCommand) => void;
-	onRemove: () => void;
-}) {
-	const set = (patch: Partial<EditableCommand>) =>
-		onChange({ ...command, ...patch });
-
-	return (
-		<div className="border border-gray-200/80 rounded-lg p-3 space-y-3">
-			<div className="flex items-center gap-2">
-				<span className="text-xs font-medium text-gray-400 w-5">
-					{index + 1}.
-				</span>
-				<select
-					value={command.variant}
-					onChange={(e) => set({ variant: e.target.value })}
-					className={`${fieldClass} flex-1`}
-				>
-					{COMMAND_OPTIONS.map((opt) => (
-						<option key={opt} value={opt}>
-							{opt}
-						</option>
-					))}
-				</select>
-				<button
-					type="button"
-					onClick={onRemove}
-					aria-label="Remove command"
-					className="text-gray-400 hover:text-red-600 cursor-pointer p-1"
-					title="Remove command"
-				>
-					<X className="w-4 h-4" />
-				</button>
-			</div>
-
-			{command.variant === "FreeForm" && (
-				<input
-					type="text"
-					value={command.cmd}
-					onChange={(e) => set({ cmd: e.target.value })}
-					placeholder="e.g., ls -la /var/log"
-					className={`${fieldClass} font-mono`}
-				/>
-			)}
-
-			{command.variant === "OpenTunnel" && (
-				<div className="grid grid-cols-3 gap-2">
-					<input
-						type="number"
-						value={command.port}
-						onChange={(e) => set({ port: e.target.value })}
-						placeholder="port (optional)"
-						className={fieldClass}
-					/>
-					<input
-						type="text"
-						value={command.user}
-						onChange={(e) => set({ user: e.target.value })}
-						placeholder="user (optional)"
-						className={fieldClass}
-					/>
-					<input
-						type="text"
-						value={command.pub_key}
-						onChange={(e) => set({ pub_key: e.target.value })}
-						placeholder="public key (optional)"
-						className={fieldClass}
-					/>
-				</div>
-			)}
-
-			{command.variant === "DownloadOTA" && (
-				<div className="grid grid-cols-3 gap-2">
-					<input
-						type="text"
-						value={command.tools}
-						onChange={(e) => set({ tools: e.target.value })}
-						placeholder="tools"
-						className={fieldClass}
-					/>
-					<input
-						type="text"
-						value={command.payload}
-						onChange={(e) => set({ payload: e.target.value })}
-						placeholder="payload"
-						className={fieldClass}
-					/>
-					<input
-						type="number"
-						step="any"
-						value={command.rate}
-						onChange={(e) => set({ rate: e.target.value })}
-						placeholder="rate"
-						className={fieldClass}
-					/>
-				</div>
-			)}
-
-			{command.variant === "ExtendedNetworkTest" && (
-				<input
-					type="number"
-					value={command.duration_minutes}
-					onChange={(e) => set({ duration_minutes: e.target.value })}
-					placeholder="duration (minutes)"
-					className={fieldClass}
-				/>
-			)}
-
-			<label className="flex items-center gap-2 text-xs text-gray-600">
-				<input
-					type="checkbox"
-					checked={command.continue_on_error}
-					onChange={(e) => set({ continue_on_error: e.target.checked })}
-				/>
-				Continue running the bundle if this command fails
-			</label>
-		</div>
-	);
-}
 
 // ---------------------------------------------------------------------------
 // Right panel: view / edit a recipe

--- a/dashboard/app/utils/wifiScan.tsx
+++ b/dashboard/app/utils/wifiScan.tsx
@@ -1,0 +1,103 @@
+/** Minimal shape `groupScanResults` needs from a scanned access point. Both the
+ * persisted `WifiScanResult` (device Network page) and the raw `WifiScan`
+ * command response (Commands tab) satisfy this without remapping, aside from
+ * `band`, which the command response doesn't carry and callers must derive
+ * (see `deriveBand`). */
+export interface ScanApLike {
+	bssid: string;
+	ssid?: string | null;
+	security?: string | null;
+	band?: string | null;
+	channel?: number | null;
+	signal?: number | null;
+	rate?: number | null;
+}
+
+/** One row per (SSID, security) pair the scan saw: APs sharing an SSID but
+ *  differing in security are different networks, so they get separate rows.
+ *  Hidden APs (no SSID) all collapse into a single group regardless of
+ *  security, since there is nothing more specific to group them by. */
+export interface ScanGroup<T extends ScanApLike = ScanApLike> {
+	key: string;
+	ssid: string | null;
+	/** Raw scan security string (e.g. "WPA1 WPA2"); null = open. Meaningless
+	 *  for the hidden group, which mixes securities. */
+	security: string | null;
+	bestSignal: number | null;
+	bands: string[];
+	aps: T[];
+}
+
+export const HIDDEN_GROUP_KEY = "\0hidden";
+
+export function groupScanResults<T extends ScanApLike>(
+	results: T[],
+): ScanGroup<T>[] {
+	const groups = new Map<string, ScanGroup<T>>();
+	for (const r of results) {
+		const key =
+			r.ssid == null ? HIDDEN_GROUP_KEY : `${r.ssid}\0${r.security ?? ""}`;
+		let group = groups.get(key);
+		if (!group) {
+			group = {
+				key,
+				ssid: r.ssid ?? null,
+				security: r.ssid == null ? null : (r.security ?? null),
+				bestSignal: null,
+				bands: [],
+				aps: [],
+			};
+			groups.set(key, group);
+		}
+		group.aps.push(r);
+	}
+
+	for (const group of groups.values()) {
+		group.aps.sort((a, b) => (b.signal ?? -1) - (a.signal ?? -1));
+		group.bestSignal = group.aps[0]?.signal ?? null;
+		group.bands = [
+			...new Set(
+				group.aps.map((ap) => ap.band).filter((b): b is string => !!b),
+			),
+		];
+	}
+
+	const visible = [...groups.values()]
+		.filter((g) => g.ssid != null)
+		.sort((a, b) => (b.bestSignal ?? -1) - (a.bestSignal ?? -1));
+	const hidden = groups.get(HIDDEN_GROUP_KEY);
+	return hidden ? [...visible, hidden] : visible;
+}
+
+/** Mirrors the api's persisted-scan band derivation (`api/src/device/route.rs`,
+ * `GET /devices/{serial}/wifi-scan`), for callers working from the raw
+ * `WifiScan` command response, which only carries `channel`. */
+export function deriveBand(channel: number | null): string | null {
+	if (channel == null) return null;
+	return channel <= 14 ? "2.4 GHz" : "5 GHz";
+}
+
+export function SignalBar({ value }: { value: number | null }) {
+	const pct = value ?? 0;
+	const color =
+		value == null
+			? "bg-gray-200"
+			: pct >= 60
+				? "bg-green-500"
+				: pct >= 35
+					? "bg-yellow-500"
+					: "bg-orange-500";
+	return (
+		<span className="inline-flex items-center gap-2 min-w-[110px]">
+			<span className="flex-1 h-1.5 min-w-[56px] rounded-full bg-gray-100 overflow-hidden">
+				<span
+					className={`block h-full rounded-full ${color}`}
+					style={{ width: `${Math.max(pct, value == null ? 0 : 2)}%` }}
+				/>
+			</span>
+			<span className="text-xs text-gray-500 tabular-nums w-9 text-right">
+				{value != null ? `${value}%` : "—"}
+			</span>
+		</span>
+	);
+}


### PR DESCRIPTION
## What
Adds typed-command support (WifiScan, Ping, TestNetwork, ExtendedNetworkTest, RunAudit, ReportNMProfiles, GetLogs, FreeForm) to the devices-page bulk-command modal, replacing the FreeForm-only free-text field, and groups WifiScan responses by SSID in the Commands tab to match the device Network page's new grouped view.

## Why
Closes #542

The bulk-command modal only ever issued FreeForm shell commands. Typed commands like WifiScan couldn't be dispatched to multiple devices from any UI — the WiFi panel on the single-device page issues them one at a time. During a customer network investigation, a fleet-wide WifiScan across 43 devices required resolving device IDs via SQL and calling `POST /commands/bundles` with curl. The backend already supported this end to end (any `SafeCommandRequest` on `POST /commands/bundles`, `WifiScan`/`Ping`/etc. already authorized under `commands:basic`) — this PR closes the frontend gap.

## Approach
Three moves, no backend/API changes:

1. **Lifted the command builder** out of `recipes/page.tsx` into `commands/shared.tsx`, split into a presentational `CommandFields` (variant picker + inputs + `continue_on_error` checkbox) and a list-row wrapper `CommandRow` (index + remove button, wraps `CommandFields`) — so the single-command bulk modal and the repeatable recipe list share the same builder without either carrying the other's chrome.
2. **Extended `commands/shared.tsx`'s typed-command surface**: `WifiScan`, `ReportNMProfiles`, `RunAudit` added to `SIMPLE_COMMANDS`/`getTxLabel`; `GetLogs` built out entirely (it wasn't in the command builder at all before — new `unit`/`since`/`until`/`grep` fields, its response reuses the existing `FreeForm{stdout,stderr}` renderer since `smithd`'s `execute_get_logs` returns that same shape). A curated `BULK_COMMAND_OPTIONS` allowlist (not a denylist filter of the recipes' list) gates what the bulk modal offers — dangerous/session-based variants (`UpdateNetwork`, `StartOTA`, `OpenTunnel`, `StreamLogs`, etc.) are excluded on purpose.
3. **Rewired the bulk modal** (`devices/page.tsx`) to hold one `EditableCommand`, build the payload with the shared `buildCommand`, gate dispatch on `commandIsValid`, and on success navigate to `/commands` (which auto-selects the newest bundle — no bundle-uuid filter needed). On error, a 403 while dispatching `FreeForm` (the only variant in the list still gated behind the admin-only `freeform` permission) shows a specific message; any other 403 or failure shows a generic one — previously errors were silently swallowed (`console.error` only).

**Follow-up after #541 merged** (grouped WiFi scan + hidden-network probing, `WifiPanel.tsx`): extracted the pure SSID-grouping logic (`groupScanResults`, `ScanGroup`, `SignalBar`) into a new `dashboard/app/utils/wifiScan.tsx`, generic over a minimal shape so both `WifiPanel.tsx` and the Commands tab's WifiScan table group identically instead of drifting. The Commands tab intentionally does **not** show #541's relationship badges (Active/Configured/In intent) — those need the device's configured profiles + intent, unavailable in a view that can show many different devices' responses in one bundle.

**Rejected alternatives**: a new `commands/builder.tsx` file (extending the existing shared module was less scattered); filtering the recipes' command list at the call site instead of a named allowlist (an allowlist is safer to review for "what's safe to blast at N devices"); client-side hiding of FreeForm for non-privileged users (no endpoint exists to read the current user's own permissions without admin-only `users:read`).

## Testing
- [x] `npm run lint` (Biome), `npx tsc --noEmit`, `npm run build` in `dashboard/` — all clean, no new errors introduced (repo has pre-existing unrelated errors elsewhere, untouched by this change)
- [x] Manual smoke test: driven via Playwright against the local dev stack (10 `smithd` docker containers + one real host `smithd`, real `api` + `postgres`)
  - Dispatched all 8 curated variants to 2-10 devices each; confirmed exact wire syntax in `command_queue.cmd` and that `smithd` deserialized each correctly via container logs, including `GetLogs`'s four filter fields and blank→`null` mapping
  - Confirmed full success round-trips for `Ping` (`"Pong"`), `FreeForm` (real `echo` stdout), `GetLogs` (real grepped journalctl output)
  - Confirmed the 403 path end-to-end: downgraded the test user to the `default` role in the DB, dispatched `FreeForm`, got the exact permission-denied message and a real 403 over the wire; restored `admin` and re-confirmed success
  - Confirmed WifiScan grouping against a real host device with actual wifi hardware: 25 raw APs correctly grouped into 8 SSID groups + one hidden-networks group forced last, expand/collapse per group, `wifi_scan_result` persistence (25 rows) all correct
  - Confirmed no regression on `WifiPanel.tsx` (device Network page): grouping, band badges, and relationship badges (Active/Configured) all still render exactly as PR #541 built them

## Checklist
- [x] No unintended side effects on adjacent features — recipes page verified working unchanged (create/edit/trigger a FreeForm recipe); `WifiPanel.tsx` verified unchanged in behavior via Playwright
- [x] Breaking change? No — frontend-only, no API/wire-format changes; `POST /commands/bundles` and `SafeCommandRequest`/`SafeCommandResponse` are untouched
- [x] Docs / changelog updated if user-facing — no CHANGELOG file in this repo; releases are automated (`chore(release)` commits), nothing manual to update