### PR TITLE
feat: add reachability time-range picker to devices list

### DIFF
--- a/dashboard/app/(private)/devices/[serial]/uptime.tsx
+++ b/dashboard/app/(private)/devices/[serial]/uptime.tsx
@@ -34,14 +34,14 @@ interface DeviceUptime {
  */
 const SMITHD_SERVICE_NAME = "smithd";
 
-const UPTIME_RANGES = [
-	{ label: "1h", hours: 1 },
-	{ label: "6h", hours: 6 },
-	{ label: "24h", hours: 24 },
-	{ label: "7d", hours: 24 * 7 },
+export const UPTIME_RANGES = [
+	{ label: "1h", hours: 1, listBuckets: 12 },
+	{ label: "6h", hours: 6, listBuckets: 18 },
+	{ label: "24h", hours: 24, listBuckets: 24 },
+	{ label: "7d", hours: 24 * 7, listBuckets: 28 },
 ] as const;
 
-type UptimeRange = (typeof UPTIME_RANGES)[number]["label"];
+export type UptimeRange = (typeof UPTIME_RANGES)[number]["label"];
 
 const useDeviceUptime = (
 	deviceId: string,
@@ -166,7 +166,7 @@ export const useOpenServiceOutages = (serial: string) => {
 	}, [data]);
 };
 
-const RangePicker = ({
+export const RangePicker = ({
 	value,
 	onChange,
 }: {
@@ -275,16 +275,21 @@ export const ReachabilityAlert = ({
 	);
 };
 
-const LIST_WINDOW_HOURS = 24 * 7;
-
 /**
- * Compact 7-day reachability bars for a devices-table row. The fetch is held
- * back until the row scrolls into view — the list paginates 100 devices at a
- * time and there is only a per-device uptime endpoint, so fetching eagerly
- * would fire a request per row up front. Once loaded the data is kept fresh
- * enough by staleness alone; a 7-day window doesn't need a refetch timer.
+ * Compact reachability bars for a devices-table row, at whatever range the
+ * table's shared picker is set to. The fetch is held back until the row
+ * scrolls into view — the list paginates 100 devices at a time and there is
+ * only a per-device uptime endpoint, so fetching eagerly would fire a request
+ * per row up front. Once loaded the data is kept fresh enough by staleness
+ * alone; the list doesn't need a refetch timer at any range.
  */
-export const ReachabilityCell = ({ serial }: { serial: string }) => {
+export const ReachabilityCell = ({
+	serial,
+	range,
+}: {
+	serial: string;
+	range: UptimeRange;
+}) => {
 	const ref = useRef<HTMLDivElement>(null);
 	const [visible, setVisible] = useState(false);
 
@@ -298,7 +303,10 @@ export const ReachabilityCell = ({ serial }: { serial: string }) => {
 		return () => observer.disconnect();
 	}, []);
 
-	const { data, isError } = useDeviceUptime(serial, LIST_WINDOW_HOURS, {
+	const { hours, listBuckets } =
+		UPTIME_RANGES.find((r) => r.label === range) ?? UPTIME_RANGES[3];
+
+	const { data, isError } = useDeviceUptime(serial, hours, {
 		enabled: visible,
 		refetchInterval: false,
 	});
@@ -316,9 +324,9 @@ export const ReachabilityCell = ({ serial }: { serial: string }) => {
 						from={summary.from}
 						to={summary.to}
 						spans={summary.spans}
-						buckets={28}
+						buckets={listBuckets}
 						height="1rem"
-						renderTooltip={bucketTooltip(LIST_WINDOW_HOURS)}
+						renderTooltip={bucketTooltip(hours)}
 					/>
 					<div className="mt-1 text-[10px] tabular-nums text-gray-400">
 						{(summary.ratio * 100).toFixed(1)}%

--- a/dashboard/app/(private)/devices/page.tsx
+++ b/dashboard/app/(private)/devices/page.tsx
@@ -1196,8 +1196,9 @@ const DevicesPage = () => {
 							<div>Labels</div>
 							<div>Location</div>
 							<div className="flex items-center gap-2">
-								<span>Reachability</span>
+								<label htmlFor="reachability-range">Reachability</label>
 								<Select
+									id="reachability-range"
 									value={reachabilityRange}
 									onChange={(v) => setReachabilityRange(v as UptimeRange)}
 									className="w-auto px-1.5 py-0.5 text-[11px] normal-case tracking-normal"

--- a/dashboard/app/(private)/devices/page.tsx
+++ b/dashboard/app/(private)/devices/page.tsx
@@ -1,6 +1,6 @@
 import { useAuth0 } from "@auth0/auth0-react";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
-import { Button, LabelChip, Toast } from "@teton/smith-ui";
+import { Button, LabelChip, Select, Toast } from "@teton/smith-ui";
 import { isAxiosError } from "axios";
 import {
 	AlertTriangle,
@@ -46,7 +46,11 @@ import {
 } from "../../api-client";
 import { useClientMutatorWithTotal } from "../../api-client-mutator";
 import { isStableRelease } from "../../utils/release";
-import { ReachabilityCell } from "./[serial]/uptime";
+import {
+	ReachabilityCell,
+	UPTIME_RANGES,
+	type UptimeRange,
+} from "./[serial]/uptime";
 
 const Tooltip = ({
 	children,
@@ -178,6 +182,8 @@ const DevicesPage = () => {
 	const releaseDropdownRef = useRef<HTMLDivElement>(null);
 	const sentinelRef = useRef<HTMLDivElement>(null);
 	const searchInputRef = useRef<HTMLInputElement>(null);
+
+	const [reachabilityRange, setReachabilityRange] = useState<UptimeRange>("7d");
 
 	// Bulk deploy state
 	const [selectedDeviceIds, setSelectedDeviceIds] = useState<Set<number>>(
@@ -1189,7 +1195,20 @@ const DevicesPage = () => {
 							<div>Device</div>
 							<div>Labels</div>
 							<div>Location</div>
-							<div>Reachability (7d)</div>
+							<div className="flex items-center gap-2">
+								<span>Reachability</span>
+								<Select
+									value={reachabilityRange}
+									onChange={(v) => setReachabilityRange(v as UptimeRange)}
+									className="w-auto px-1.5 py-0.5 text-[11px] normal-case tracking-normal"
+								>
+									{UPTIME_RANGES.map((r) => (
+										<option key={r.label} value={r.label}>
+											{r.label}
+										</option>
+									))}
+								</Select>
+							</div>
 							<div>Release</div>
 						</div>
 					</div>
@@ -1356,7 +1375,10 @@ const DevicesPage = () => {
 											})()}
 										</div>
 
-										<ReachabilityCell serial={device.serial_number} />
+										<ReachabilityCell
+											serial={device.serial_number}
+											range={reachabilityRange}
+										/>
 
 										<div>
 											{getReleaseInfo(device) ? (


### PR DESCRIPTION
## What
Adds a 1h / 6h / 24h / 7d time-range picker to the `/devices` list's Reachability column, matching the range options already available on `/devices/{id}/network`. Previously the list was locked to a fixed 7-day view.

## Why
Fleet operators scanning the devices table to spot connectivity problems had to open each device individually to see anything shorter than 7 days.

## Approach
- `ReachabilityCell` (the list's compact bars) now takes a `range: UptimeRange` prop instead of a hardcoded 7-day window and a hardcoded `buckets={28}`. `UPTIME_RANGES` (already shared with the device page's own picker) gained a `listBuckets` field per range (12/18/24/28) so bar density scales with the window instead of staying fixed.
- The devices list owns one shared `reachabilityRange` state for the whole table (not per-row), so all visible devices stay comparable at the same window. No new fetch machinery: `useDeviceUptime`'s query key already includes `hours`, so per-range caching and the existing lazy, scroll-gated fetch (`IntersectionObserver`) came for free.
- Header control: first pass reused the device page's 4-button `RangePicker`, but that meant dropping the "Reachability" column title entirely to fit, which read as broken. Replaced with the existing `Select` primitive (`@teton/smith-ui`) instead, so the header now shows the label and a compact `[7d ▾]` control side by side. The device page keeps its own `RangePicker`, unchanged, it has room for it.
- Rejected: per-row range pickers (requirement was one shared control), a second copy of `UPTIME_RANGES` for the list (unnecessary duplication), and keeping bucket count fixed across ranges (a 1h window at 28 buckets would mostly show flat, near-empty slices).
- No backend/API changes, `/devices/{id}/uptime` already accepts `from`/`to` and is range-agnostic.

## Testing
- [x] `biome check` and `tsc --noEmit` clean on both touched files (pre-existing unrelated errors elsewhere on `main` untouched)
- [x] Manual smoke test: ran against the live dev stack (`smith-dashboard` + `smith-api` docker containers, 5151 seeded devices), verified via Playwright — default 7d view unchanged, switching to 1h re-renders all visible rows with correct bucket count/percentages, dropdown shows all four options, network tab confirms a range switch only refetches rows that had already scrolled into view (no fetch stampede across the full device list)
- [ ] No automated test suite exists for these list/device components; none added, consistent with existing coverage in this area

## Checklist
- [x] No unintended side effects on adjacent features — `DeviceReachability` (`/devices/{id}/network`) is untouched and still uses its own local range state and `RangePicker`
- [ ] Breaking change? No
- [ ] Docs / changelog updated if user-facing — not applicable, no user-facing docs cover this list view