### PR TITLE
fix: retry nmcli psk read for flaky wpa-psk/sae profiles

### DIFF
--- a/smithd/src/commander/network.rs
+++ b/smithd/src/commander/network.rs
@@ -136,6 +136,23 @@ fn parse_nm_connection_list_line(line: &str) -> Option<(String, bool, String)> {
     }
 }
 
+// Empirically ~2-4% of secret-detail reads for wpa-psk/sae profiles come back
+// missing the psk even though it's genuinely stored (psk-flags=0), in short
+// bursts that self-clear within ~1s. A bounded retry catches most of these
+// before they reach the API and fork a duplicate `network` row (see ADR 0002
+// amendment, 2026-08-14).
+const DETAIL_RETRY_ATTEMPTS: u32 = 3;
+const DETAIL_RETRY_DELAY: Duration = Duration::from_millis(500);
+
+/// True only for the specific, empirically-diagnosed failure this retry exists
+/// for: a wpa-psk/sae profile (which always structurally has a psk) whose
+/// detail query came back without one. Never true for wpa-eap (out of scope,
+/// unverified) or open/unknown key-mgmt (nothing to retrieve).
+fn missing_required_psk(profile: &NMProfile) -> bool {
+    matches!(profile.key_mgmt.as_deref(), Some("wpa-psk") | Some("sae"))
+        && profile.password.is_none()
+}
+
 async fn get_nm_wifi_profiles() -> Result<Vec<NMProfile>> {
     let mut list_cmd = Command::new("nmcli");
     // Include UUID so each profile is queried by UUID in step 2, avoiding ambiguous
@@ -159,24 +176,41 @@ async fn get_nm_wifi_profiles() -> Result<Vec<NMProfile>> {
 
     let mut profiles = Vec::new();
     for (name, is_active, uuid) in entries {
-        let mut detail_cmd = Command::new("nmcli");
-        detail_cmd.args(["--show-secrets", "-t", "connection", "show", "uuid", &uuid]);
+        let mut detail = NMProfile::default();
+        for attempt in 1..=DETAIL_RETRY_ATTEMPTS {
+            let mut detail_cmd = Command::new("nmcli");
+            detail_cmd.args(["--show-secrets", "-t", "connection", "show", "uuid", &uuid]);
 
-        let detail = match execute_nmcli_command(detail_cmd).await {
-            Ok(output) if output.status.success() => {
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                parse_nm_profile_detail(&stdout)
+            detail = match execute_nmcli_command(detail_cmd).await {
+                Ok(output) if output.status.success() => {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    parse_nm_profile_detail(&stdout)
+                }
+                Ok(output) => {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    tracing::warn!("nmcli connection show uuid {uuid} failed: {stderr}");
+                    break; // command-error shape: not retried, see requirements.md FR3
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to run nmcli connection show uuid {uuid}: {e}");
+                    break; // command-error shape: not retried, see requirements.md FR3
+                }
+            };
+
+            if !missing_required_psk(&detail) {
+                if attempt > 1 {
+                    tracing::debug!("psk read for uuid {uuid} recovered on attempt {attempt}");
+                }
+                break;
             }
-            Ok(output) => {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                tracing::warn!("nmcli connection show uuid {uuid} failed: {stderr}");
-                NMProfile::default()
+            if attempt < DETAIL_RETRY_ATTEMPTS {
+                sleep(DETAIL_RETRY_DELAY).await;
+            } else {
+                tracing::warn!(
+                    "psk still missing for uuid {uuid} ({name}) after {DETAIL_RETRY_ATTEMPTS} attempts"
+                );
             }
-            Err(e) => {
-                tracing::warn!("Failed to run nmcli connection show uuid {uuid}: {e}");
-                NMProfile::default()
-            }
-        };
+        }
 
         profiles.push(NMProfile {
             name,

--- a/smithd/src/commander/network.rs
+++ b/smithd/src/commander/network.rs
@@ -1981,6 +1981,69 @@ OpenNet:802-11-wireless:OpenNet:--:--";
     }
 
     #[test]
+    fn missing_required_psk_true_for_wpa_psk_without_password() {
+        let profile = NMProfile {
+            key_mgmt: Some("wpa-psk".to_string()),
+            password: None,
+            ..Default::default()
+        };
+        assert!(missing_required_psk(&profile));
+    }
+
+    #[test]
+    fn missing_required_psk_false_for_wpa_psk_with_password() {
+        let profile = NMProfile {
+            key_mgmt: Some("wpa-psk".to_string()),
+            password: Some("secret123".to_string()),
+            ..Default::default()
+        };
+        assert!(!missing_required_psk(&profile));
+    }
+
+    #[test]
+    fn missing_required_psk_true_for_sae_without_password() {
+        let profile = NMProfile {
+            key_mgmt: Some("sae".to_string()),
+            password: None,
+            ..Default::default()
+        };
+        assert!(missing_required_psk(&profile));
+    }
+
+    #[test]
+    fn missing_required_psk_false_for_open_without_password() {
+        let profile = NMProfile {
+            key_mgmt: Some("open".to_string()),
+            password: None,
+            ..Default::default()
+        };
+        assert!(!missing_required_psk(&profile));
+    }
+
+    #[test]
+    fn missing_required_psk_false_for_wpa_eap_without_identity() {
+        // wpa-eap is deliberately out of scope for this retry (requirements.md
+        // FR4): the diagnosed failure and its fix are scoped to wpa-psk/sae only.
+        let profile = NMProfile {
+            key_mgmt: Some("wpa-eap".to_string()),
+            password: None,
+            eap_identity: None,
+            ..Default::default()
+        };
+        assert!(!missing_required_psk(&profile));
+    }
+
+    #[test]
+    fn missing_required_psk_false_for_unknown_key_mgmt() {
+        let profile = NMProfile {
+            key_mgmt: None,
+            password: None,
+            ..Default::default()
+        };
+        assert!(!missing_required_psk(&profile));
+    }
+
+    #[test]
     fn nm_profile_detail_open_network_no_security_block_sets_sentinel() {
         // No 802-11-wireless-security lines at all: sentinel "open" must be set.
         let stdout = "802-11-wireless.ssid:FreeWifi\n\


### PR DESCRIPTION
## What
smithd now retries a WiFi profile's `nmcli --show-secrets` detail query up to 3 times (500ms apart) before accepting a missing password on a wpa-psk/sae connection, instead of accepting the first empty result as final.

## Why
Investigating why Smith's `network` table kept accumulating rows referenced by nothing (27 new orphans found in a ~24h window during a routine dedupe sweep), the trail led to smithd: `nmcli --show-secrets` intermittently (~2-4% of calls, in short bursts) returns without the psk for a wpa-psk/sae profile even though the secret is genuinely stored. Smith's content-addressed matching (`network_find_by_content`) has no way to tell "psk unknown, this read failed" from "psk genuinely absent," so a single flaky read forks a brand-new `network` row instead of matching the existing one. That fork sticks around permanently unless the same device happens to re-report the same profile successfully later — nothing else ever merges it back.

Confirmed live against the actual affected fleet device: manual `nmcli` loops (50-100 calls) reproduced both failure shapes — an isolated miss and a 2-in-a-row burst — each self-clearing within one to a few subsequent calls with no deliberate delay between them.

## Approach
Bounded retry, source-side only, deliberately minimal:
- Retries only the "command succeeded but the psk came back empty" case, for `key_mgmt` values that structurally always have a psk (`wpa-psk`, `sae`). Command errors and the existing 60s `execute_nmcli_command` timeout are **not** retried — that keeps worst-case added latency to 2 × 500ms per profile instead of risking multiples of the 60s timeout, and stays targeted at the failure shape actually observed.
- `wpa-eap`/`eap_identity` is explicitly out of scope — the diagnosed and measured failure is specifically the `password` field on `wpa-psk`/`sae`; extending to EAP would be unverified scope creep.
- No API/DB-side changes. No new "psk unknown" sentinel or schema field, and no relaxing of `network_find_by_content`'s exact psk match. A residual fork rate (retries exhausted, or a burst longer than 3) is accepted and left to the existing `scripts/dedupe-network/` phase-1 sweep, now run periodically as an operational cleanup rather than a one-off. This was a deliberate simplicity-over-completeness call: a handful of orphans a week, already cheaply swept by tooling that exists, over new fields/match semantics/tests whose only job is guaranteeing zero orphans. Full reasoning is in the ADR 0002 amendment (2026-08-14, local `.claude/` planning notes, not part of this diff).
- The retry-worthiness decision is a separate pure function (`missing_required_psk`) so it's unit-testable independent of the async retry loop, which shells out to a real `nmcli` and has no mock point.

## Testing
- [x] Unit tests: 6 new cases for `missing_required_psk` (wpa-psk missing/present, sae missing, open missing, wpa-eap missing, unknown key_mgmt) plus the full existing suite — 36/36 passing in `commander::network`.
- [x] `cargo fmt` and `cargo clippy --all-features -- -Dwarnings` clean.
- [x] Manual smoke test: built and ran the real `smithd` binary as a systemd service against the local dev stack (`api`/`dashboard`/`postgres` in Docker, per `run-smith`), registered and approved a real device against it, and drove `ReportNMProfiles` through the actual dashboard "Refresh" action and ~100+ direct command-queue insertions. Confirmed end-to-end: queue → daemon → nmcli → API → DB, with correct psk values landing in `network.credentials` every time, no regression on the non-flaky path.
- [ ] **Not verified**: the retry loop actually firing against a real miss. Across all local testing (600+ individual nmcli reads on a dev laptop, plus the original 100-150 calls against the real affected fleet device during investigation) it never happened once. The dev laptop's NetworkManager/hardware likely doesn't reproduce the same race the embedded fleet device does. This is a real gap — the fix is verified to compile, run, and not regress, but the retry path itself is unverified in this PR. Real confirmation is watching the orphan-creation rate trend down on the fleet after this ships (tracked via the periodic phase-1 dedupe sweep), not something achievable pre-merge.

## Checklist
- [x] No unintended side effects on adjacent features — change is fully contained inside `get_nm_wifi_profiles`'s per-connection detail-query loop; no schema, wire-format, or API changes; every profile that isn't wpa-psk/sae with a missing password takes the same single-attempt path as before.
- [x] Breaking change? No.
- [x] Docs / changelog updated if user-facing — N/A, internal daemon behavior only, nothing user-facing to document. Investigation and decision are recorded in an ADR 0002 amendment (kept in local `.claude/` planning notes, not committed to this repo per existing convention).