### PR TITLE
fix: adopt existing NM profile by content match instead of duplicating

### DIFF
--- a/api/.sqlx/query-51ae22fb121d88c89ea0feedd067adb644d2a483f01b21746eec58e189b121a9.json
+++ b/api/.sqlx/query-51ae22fb121d88c89ea0feedd067adb644d2a483f01b21746eec58e189b121a9.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            dni.priority,\n            n.ssid,\n            n.name,\n            n.password,\n            n.security_type,\n            n.credentials ->> 'psk' AS credentials_psk\n        FROM device_network_intent dni\n        JOIN network n ON n.id = dni.network_id\n        WHERE dni.device_id = $1\n        ORDER BY dni.priority ASC\n        ",
+  "query": "\n        SELECT\n            dni.priority,\n            n.ssid,\n            n.name,\n            n.password,\n            n.security_type,\n            n.is_network_hidden,\n            n.credentials ->> 'psk' AS credentials_psk\n        FROM device_network_intent dni\n        JOIN network n ON n.id = dni.network_id\n        WHERE dni.device_id = $1\n        ORDER BY dni.priority ASC\n        ",
   "describe": {
     "columns": [
       {
@@ -30,6 +30,11 @@
       },
       {
         "ordinal": 5,
+        "name": "is_network_hidden",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
         "name": "credentials_psk",
         "type_info": "Text"
       }
@@ -45,8 +50,9 @@
       false,
       true,
       true,
+      false,
       null
     ]
   },
-  "hash": "f5b209c801bd9829b51271c59be56f611e76adae900a5138ed5348b46a670516"
+  "hash": "51ae22fb121d88c89ea0feedd067adb644d2a483f01b21746eec58e189b121a9"
 }

--- a/api/src/device/route.rs
+++ b/api/src/device/route.rs
@@ -3412,14 +3412,17 @@ pub async fn delete_device_intent(
 
 /// Map a stored `security_type` (and its psk, if any) to the wire credential
 /// object smithd's applier consumes. Capability-bounded: it only ever emits a
-/// `key_mgmt` smithd can currently apply (`none`/`wpa-psk`), degrading `sae` to
-/// `wpa-psk` and `owe` to `none`. Returns `None` when smithd cannot apply the
-/// type yet (`wpa-eap`, unknown) or a psk-requiring type has no psk, so the
-/// caller can skip the network rather than emit an unusable credential.
+/// `key_mgmt` smithd can currently apply (`none`/`wpa-psk`). Returns `None`
+/// when smithd cannot apply the type yet (`sae`, `owe`, `wpa-eap`, unknown) or
+/// a psk-requiring type has no psk, so the caller can skip the network rather
+/// than emit an unusable or silently-downgraded credential. `sae`/`owe` used
+/// to degrade to `wpa-psk`/`none`, but that silently applies weaker security
+/// than the network is configured for (WPA3 loses forward secrecy, OWE loses
+/// its only encryption entirely) — refused instead.
 fn wire_credentials(security_type: &str, psk: Option<&str>) -> Option<serde_json::Value> {
     match security_type {
-        "open" | "owe" => Some(serde_json::json!({ "key_mgmt": "none" })),
-        "wpa-psk" | "sae" => {
+        "open" => Some(serde_json::json!({ "key_mgmt": "none" })),
+        "wpa-psk" => {
             let psk = psk?;
             Some(serde_json::json!({ "key_mgmt": "wpa-psk", "psk": psk }))
         }
@@ -3484,6 +3487,7 @@ pub async fn apply_device_intent(
             n.name,
             n.password,
             n.security_type,
+            n.is_network_hidden,
             n.credentials ->> 'psk' AS credentials_psk
         FROM device_network_intent dni
         JOIN network n ON n.id = dni.network_id
@@ -3520,26 +3524,38 @@ pub async fn apply_device_intent(
     //     "version": <intent_version: i32>,
     //     "networks": [
     //       { "profile_name": "<catalog name>", "ssid": "<ssid>", "priority": <i32>,
+    //         "hidden": <bool>, "security_type": "wpa-psk",
     //         "credentials": { "key_mgmt": "wpa-psk", "psk": "<password>" } }
     //       { "profile_name": "<catalog name>", "ssid": "<ssid>", "priority": <i32>,
+    //         "hidden": <bool>, "security_type": "open",
     //         "credentials": { "key_mgmt": "none" } }  // open network
     //     ]
     //   }
     // }
+    // `hidden`/`security_type` are siblings of `credentials`, not nested in it:
+    // `credentials` stays exactly the shape smithd applies, the other two are
+    // purely for smithd's own existing-profile identity matching.
     let applyable_networks: Vec<serde_json::Value> = networks
         .iter()
         .filter_map(|n| {
-            let credentials = match n.security_type.as_deref() {
-                Some(security_type) => {
-                    wire_credentials(security_type, n.credentials_psk.as_deref())
-                }
+            let (credentials, applied_security_type) = match n.security_type.as_deref() {
+                Some(security_type) => (
+                    wire_credentials(security_type, n.credentials_psk.as_deref()),
+                    security_type,
+                ),
                 // Legacy rows with no backfilled security_type: preserve the
-                // original password-null inference exactly.
-                None => Some(if let Some(psk) = n.password.as_deref() {
-                    serde_json::json!({ "key_mgmt": "wpa-psk", "psk": psk })
-                } else {
-                    serde_json::json!({ "key_mgmt": "none" })
-                }),
+                // original password-null inference exactly, for both credentials
+                // and the security_type now echoed alongside it.
+                None => {
+                    if let Some(psk) = n.password.as_deref() {
+                        (
+                            Some(serde_json::json!({ "key_mgmt": "wpa-psk", "psk": psk })),
+                            "wpa-psk",
+                        )
+                    } else {
+                        (Some(serde_json::json!({ "key_mgmt": "none" })), "open")
+                    }
+                }
             };
             let Some(credentials) = credentials else {
                 warn!(
@@ -3553,6 +3569,8 @@ pub async fn apply_device_intent(
                 "profile_name": n.name,
                 "ssid": n.ssid.as_deref().unwrap_or(""),
                 "priority": n.priority,
+                "hidden": n.is_network_hidden,
+                "security_type": applied_security_type,
                 "credentials": credentials
             }))
         })
@@ -3619,31 +3637,17 @@ mod tests {
     }
 
     #[test]
-    fn open_and_owe_map_to_none() {
+    fn open_maps_to_none() {
         assert_eq!(
             wire_credentials("open", None),
-            Some(json!({ "key_mgmt": "none" }))
-        );
-        assert_eq!(
-            wire_credentials("owe", None),
-            Some(json!({ "key_mgmt": "none" }))
-        );
-        // psk is ignored for open-family types
-        assert_eq!(
-            wire_credentials("owe", Some("ignored")),
             Some(json!({ "key_mgmt": "none" }))
         );
     }
 
     #[test]
-    fn wpa_psk_and_sae_map_to_wpa_psk_with_psk() {
+    fn wpa_psk_maps_to_wpa_psk_with_psk() {
         assert_eq!(
             wire_credentials("wpa-psk", Some("secret")),
-            Some(json!({ "key_mgmt": "wpa-psk", "psk": "secret" }))
-        );
-        // sae degrades to wpa-psk (works on WPA2/WPA3-mixed APs smithd can apply)
-        assert_eq!(
-            wire_credentials("sae", Some("secret")),
             Some(json!({ "key_mgmt": "wpa-psk", "psk": "secret" }))
         );
     }
@@ -3651,11 +3655,13 @@ mod tests {
     #[test]
     fn psk_required_but_missing_is_skipped() {
         assert_eq!(wire_credentials("wpa-psk", None), None);
-        assert_eq!(wire_credentials("sae", None), None);
     }
 
     #[test]
     fn unapplyable_types_are_skipped() {
+        // WPA3 and Enhanced Open have no correct nmcli-applicable degradation
+        assert_eq!(wire_credentials("sae", Some("secret")), None);
+        assert_eq!(wire_credentials("owe", None), None);
         // enterprise not applyable by smithd yet
         assert_eq!(wire_credentials("wpa-eap", Some("secret")), None);
         // unknown / unmodelled types

--- a/api/src/device/route.rs
+++ b/api/src/device/route.rs
@@ -3411,14 +3411,12 @@ pub async fn delete_device_intent(
 }
 
 /// Map a stored `security_type` (and its psk, if any) to the wire credential
-/// object smithd's applier consumes. Capability-bounded: it only ever emits a
-/// `key_mgmt` smithd can currently apply (`none`/`wpa-psk`). Returns `None`
-/// when smithd cannot apply the type yet (`sae`, `owe`, `wpa-eap`, unknown) or
-/// a psk-requiring type has no psk, so the caller can skip the network rather
-/// than emit an unusable or silently-downgraded credential. `sae`/`owe` used
-/// to degrade to `wpa-psk`/`none`, but that silently applies weaker security
-/// than the network is configured for (WPA3 loses forward secrecy, OWE loses
-/// its only encryption entirely) — refused instead.
+/// object smithd's applier consumes. Capability-bounded: only ever emits a
+/// `key_mgmt` smithd can apply (`none`/`wpa-psk`). Returns `None` when smithd
+/// can't apply the type yet (`sae`, `owe`, `wpa-eap`, unknown) or a
+/// psk-requiring type has no psk. `sae`/`owe` used to degrade to
+/// `wpa-psk`/`none`, but that silently applies weaker security than the
+/// network is actually configured for — refused instead.
 fn wire_credentials(security_type: &str, psk: Option<&str>) -> Option<serde_json::Value> {
     match security_type {
         "open" => Some(serde_json::json!({ "key_mgmt": "none" })),
@@ -3532,9 +3530,8 @@ pub async fn apply_device_intent(
     //     ]
     //   }
     // }
-    // `hidden`/`security_type` are siblings of `credentials`, not nested in it:
-    // `credentials` stays exactly the shape smithd applies, the other two are
-    // purely for smithd's own existing-profile identity matching.
+    // hidden/security_type sit alongside credentials, not inside it: they're
+    // for smithd's existing-profile matching, not the applied shape itself.
     let applyable_networks: Vec<serde_json::Value> = networks
         .iter()
         .filter_map(|n| {

--- a/smithd/src/commander/network.rs
+++ b/smithd/src/commander/network.rs
@@ -1417,6 +1417,24 @@ fn psk_matches(existing: Option<&str>, intent: Option<&str>, is_open: bool) -> b
     }
 }
 
+/// True when nothing about an active profile needs to change, so
+/// execute_apply_networks can just bump priority instead of touching the
+/// connection. `hidden` must be checked here too: it doesn't affect ssid/psk
+/// equality, so a hidden-only change was previously invisible to this check.
+fn active_profile_matches(
+    profile: &NMProfile,
+    ssid: &str,
+    hidden: bool,
+    psk: Option<&str>,
+) -> bool {
+    let ssid_matches = profile.ssid.as_deref() == Some(ssid);
+    let hidden_matches = profile.hidden.unwrap_or(false) == hidden;
+    match psk {
+        None => ssid_matches && hidden_matches,
+        Some(psk) => ssid_matches && hidden_matches && profile.password.as_deref() == Some(psk),
+    }
+}
+
 /// Finds a pre-existing NM profile that's the same network under a different
 /// name, so execute_apply_networks can adopt (rename) it instead of creating
 /// a duplicate. Matches on the same identity fields the DB's
@@ -1778,8 +1796,7 @@ pub(crate) async fn execute_apply_networks(
         let result = match resolved {
             Some(profile) if profile.is_active => {
                 if is_open {
-                    let ssid_matches = profile.ssid.as_deref() == Some(ssid.as_str());
-                    if ssid_matches {
+                    if active_profile_matches(profile, ssid, network.hidden, None) {
                         nmcli_update_priority(profile_name, priority)
                             .await
                             .map_err(|e| {
@@ -1801,9 +1818,7 @@ pub(crate) async fn execute_apply_networks(
                 } else {
                     // psk is guaranteed Some by the pre-match guard above.
                     let psk = psk.expect("wpa-psk with None psk reached active branch");
-                    let ssid_matches = profile.ssid.as_deref() == Some(ssid.as_str());
-                    let psk_matches = profile.password.as_deref() == Some(psk);
-                    if ssid_matches && psk_matches {
+                    if active_profile_matches(profile, ssid, network.hidden, Some(psk)) {
                         // Nothing changed: only update priority to avoid an unnecessary reconnect.
                         // profile.password can still come back None on a rare post-retry read
                         // flake (missing_required_psk); this check just misses and falls to
@@ -2404,6 +2419,54 @@ connection.autoconnect-priority:500\n";
             is_active,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn active_profile_matches_open_same_ssid_and_hidden() {
+        let profile = nm_profile("n", "OpenNet", "open", None, false, true);
+        assert!(active_profile_matches(&profile, "OpenNet", false, None));
+    }
+
+    #[test]
+    fn active_profile_matches_open_hidden_mismatch_is_not_a_match() {
+        // Same SSID both ways, but hidden state flips: must not read as unchanged.
+        let profile = nm_profile("n", "OpenNet", "open", None, true, true);
+        assert!(!active_profile_matches(&profile, "OpenNet", false, None));
+        let profile = nm_profile("n", "OpenNet", "open", None, false, true);
+        assert!(!active_profile_matches(&profile, "OpenNet", true, None));
+    }
+
+    #[test]
+    fn active_profile_matches_secured_same_ssid_psk_and_hidden() {
+        let profile = nm_profile("n", "HC-Teton", "wpa-psk", Some("secret"), false, true);
+        assert!(active_profile_matches(
+            &profile,
+            "HC-Teton",
+            false,
+            Some("secret")
+        ));
+    }
+
+    #[test]
+    fn active_profile_matches_secured_hidden_mismatch_is_not_a_match() {
+        let profile = nm_profile("n", "HC-Teton", "wpa-psk", Some("secret"), true, true);
+        assert!(!active_profile_matches(
+            &profile,
+            "HC-Teton",
+            false,
+            Some("secret")
+        ));
+    }
+
+    #[test]
+    fn active_profile_matches_secured_psk_mismatch_is_not_a_match() {
+        let profile = nm_profile("n", "HC-Teton", "wpa-psk", Some("old"), false, true);
+        assert!(!active_profile_matches(
+            &profile,
+            "HC-Teton",
+            false,
+            Some("new")
+        ));
     }
 
     #[test]

--- a/smithd/src/commander/network.rs
+++ b/smithd/src/commander/network.rs
@@ -1323,6 +1323,7 @@ async fn nmcli_modify_profile(
     ssid: &str,
     psk: Option<&str>,
     priority: i32,
+    hidden: bool,
 ) -> Result<()> {
     let mut cmd = Command::new("nmcli");
     cmd.args([
@@ -1331,6 +1332,8 @@ async fn nmcli_modify_profile(
         name,
         "802-11-wireless.ssid",
         ssid,
+        "802-11-wireless.hidden",
+        if hidden { "yes" } else { "no" },
         "connection.autoconnect",
         "yes",
         "connection.autoconnect-priority",
@@ -1354,6 +1357,7 @@ async fn nmcli_create_profile(
     ssid: &str,
     psk: Option<&str>,
     priority: i32,
+    hidden: bool,
 ) -> Result<()> {
     let mut cmd = Command::new("nmcli");
     cmd.args([
@@ -1365,6 +1369,8 @@ async fn nmcli_create_profile(
         profile_name,
         "ssid",
         ssid,
+        "802-11-wireless.hidden",
+        if hidden { "yes" } else { "no" },
         "autoconnect",
         "yes",
         "connection.autoconnect-priority",
@@ -1383,6 +1389,68 @@ async fn nmcli_create_profile(
     Ok(())
 }
 
+/// The profile's true security type, in the same vocabulary `map_key_mgmt`
+/// uses server-side — distinct from the already-degraded `credentials.key_mgmt`
+/// an intent entry carries.
+fn profile_security_type(p: &NMProfile) -> Option<&'static str> {
+    match p.key_mgmt.as_deref() {
+        Some("open") | Some("none") => Some("open"),
+        Some("wpa-psk") => Some("wpa-psk"),
+        Some("sae") => Some("sae"),
+        Some("owe") => Some("owe"),
+        Some("wpa-eap") => Some("wpa-eap"),
+        _ => None,
+    }
+}
+
+/// Open networks ignore PSK. For secured ones, an unreadable existing PSK
+/// (`None`) is a wildcard rather than a mismatch — get_nm_wifi_profiles
+/// already retries the secret read, so `None` here is a rare residual, not
+/// the routine case.
+fn psk_matches(existing: Option<&str>, intent: Option<&str>, is_open: bool) -> bool {
+    if is_open {
+        return true;
+    }
+    match existing {
+        None => true,
+        Some(x) => Some(x) == intent,
+    }
+}
+
+/// Finds a pre-existing NM profile that's the same network under a different
+/// name, so execute_apply_networks can adopt (rename) it instead of creating
+/// a duplicate. Matches on the same identity fields the DB's
+/// network_find_by_content uses (ssid, hidden, security_type, psk), so
+/// smithd's notion of "same network" can't diverge from the catalog's.
+#[allow(clippy::too_many_arguments)]
+fn select_adoption_candidate<'a>(
+    current_profiles: &'a HashMap<String, NMProfile>,
+    intent_profile_names: &HashSet<String>,
+    claimed: &HashSet<String>,
+    profile_name: &str,
+    ssid: &str,
+    hidden: bool,
+    security_type: &str,
+    intent_psk: Option<&str>,
+) -> Option<&'a NMProfile> {
+    let is_open = security_type == "open";
+    current_profiles
+        .values()
+        .filter(|p| {
+            p.name != profile_name
+                && !intent_profile_names.contains(&p.name)
+                && !claimed.contains(&p.name)
+                && p.ssid.as_deref() == Some(ssid)
+                && p.hidden.unwrap_or(false) == hidden
+                && profile_security_type(p) == Some(security_type)
+                && psk_matches(p.password.as_deref(), intent_psk, is_open)
+        })
+        // Prefer the active candidate (lower disruption); otherwise fall back
+        // to the lexically-first name for a deterministic pick, since HashMap
+        // iteration order isn't.
+        .max_by_key(|p| (p.is_active, std::cmp::Reverse(p.name.clone())))
+}
+
 fn classify_connect_error(stderr: &str) -> ConditionReason {
     let lower = stderr.to_lowercase();
     if lower.contains("secrets") || lower.contains("psk") || lower.contains("authentication") {
@@ -1399,6 +1467,7 @@ async fn connectivity_guard(
     ssid: &str,
     psk: &str,
     priority: i32,
+    hidden: bool,
 ) -> Result<(), ConditionReason> {
     let tmp_name = format!("tmp-{profile_name}");
 
@@ -1413,6 +1482,8 @@ async fn connectivity_guard(
         &tmp_name,
         "ssid",
         ssid,
+        "802-11-wireless.hidden",
+        if hidden { "yes" } else { "no" },
         "autoconnect",
         "no",
         "connection.autoconnect-priority",
@@ -1516,6 +1587,40 @@ async fn connectivity_guard(
     }
 }
 
+/// Renames a profile picked by select_adoption_candidate to the intent's
+/// profile_name, merging it in place instead of creating a duplicate. Same
+/// connection.id rename primitive connectivity_guard already uses on a live
+/// active connection. `ssid` is log-only, already verified by the caller.
+async fn adopt_matching_profile(
+    old_name: &str,
+    new_name: &str,
+    ssid: &str,
+) -> Result<(), ConditionReason> {
+    let mut rename_cmd = Command::new("nmcli");
+    rename_cmd.args(["connection", "modify", old_name, "connection.id", new_name]);
+    match execute_nmcli_command(rename_cmd).await {
+        Ok(out) if out.status.success() => {
+            tracing::info!(
+                "execute_apply_networks: adopted existing profile {old_name} as {new_name} (same ssid {ssid})"
+            );
+            Ok(())
+        }
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            tracing::error!(
+                "execute_apply_networks: failed to rename {old_name} to {new_name}: {stderr}"
+            );
+            Err(ConditionReason::NmcliError)
+        }
+        Err(e) => {
+            tracing::error!(
+                "execute_apply_networks: failed to rename {old_name} to {new_name}: {e:#}"
+            );
+            Err(ConditionReason::NmcliError)
+        }
+    }
+}
+
 async fn try_connect_to_fallback(
     active_profile_name: &str,
     networks: &[IntentNetwork],
@@ -1595,6 +1700,9 @@ pub(crate) async fn execute_apply_networks(
         networks.iter().map(|nw| nw.profile_name.clone()).collect();
     let mut conditions: Vec<NetworkCondition> = Vec::new();
     let mut applied_profile_names: Vec<String> = Vec::new();
+    // Pre-existing profiles adopted (renamed) into an intent name this pass, so a
+    // later intent entry doesn't try to adopt the same one.
+    let mut claimed: HashSet<String> = HashSet::new();
 
     for (index, network) in networks.iter().enumerate() {
         let priority = ((n - index) * 10) as i32;
@@ -1633,7 +1741,41 @@ pub(crate) async fn execute_apply_networks(
             continue;
         }
 
-        let result = match current_profiles.get(profile_name.as_str()) {
+        // Exact-name match first; otherwise adopt a pre-existing profile for the
+        // same network under a different name, so it doesn't get duplicated.
+        let exact_match = current_profiles.get(profile_name.as_str());
+        let adoption_candidate = if exact_match.is_none() {
+            select_adoption_candidate(
+                &current_profiles,
+                &intent_profile_names,
+                &claimed,
+                profile_name,
+                ssid,
+                network.hidden,
+                &network.security_type,
+                psk,
+            )
+        } else {
+            None
+        };
+
+        if let Some(candidate) = adoption_candidate {
+            // ssid already verified by select_adoption_candidate
+            if let Err(reason) = adopt_matching_profile(&candidate.name, profile_name, ssid).await {
+                conditions.push(NetworkCondition {
+                    profile_name: profile_name.clone(),
+                    state: ConditionState::Failed,
+                    reason: Some(reason),
+                    message: None,
+                });
+                continue;
+            }
+            claimed.insert(candidate.name.clone());
+        }
+
+        let resolved: Option<&NMProfile> = exact_match.or(adoption_candidate);
+
+        let result = match resolved {
             Some(profile) if profile.is_active => {
                 if is_open {
                     let ssid_matches = profile.ssid.as_deref() == Some(ssid.as_str());
@@ -1647,7 +1789,7 @@ pub(crate) async fn execute_apply_networks(
                                 ConditionReason::NmcliError
                             })
                     } else {
-                        nmcli_modify_profile(profile_name, ssid, psk, priority)
+                        nmcli_modify_profile(profile_name, ssid, psk, priority, network.hidden)
                             .await
                             .map_err(|e| {
                                 tracing::error!(
@@ -1663,9 +1805,9 @@ pub(crate) async fn execute_apply_networks(
                     let psk_matches = profile.password.as_deref() == Some(psk);
                     if ssid_matches && psk_matches {
                         // Nothing changed: only update priority to avoid an unnecessary reconnect.
-                        // Note: profile.password is None when the PSK is stored in a system keyring
-                        // rather than the NM config file. In that case this check always misses and
-                        // the guard runs with the same PSK, which succeeds harmlessly.
+                        // profile.password can still come back None on a rare post-retry read
+                        // flake (missing_required_psk); this check just misses and falls to
+                        // connectivity_guard with the same PSK, which succeeds harmlessly.
                         nmcli_update_priority(profile_name, priority)
                             .await
                             .map_err(|e| {
@@ -1677,13 +1819,13 @@ pub(crate) async fn execute_apply_networks(
                     } else {
                         // SSID or PSK changed on an active profile: use connectivity guard to
                         // validate new credentials before committing (avoids stranding the device).
-                        connectivity_guard(profile_name, ssid, psk, priority).await
+                        connectivity_guard(profile_name, ssid, psk, priority, network.hidden).await
                     }
                 }
             }
             Some(_) => {
                 // Inactive profile: overwrite SSID, credentials, and priority in place.
-                nmcli_modify_profile(profile_name, ssid, psk, priority)
+                nmcli_modify_profile(profile_name, ssid, psk, priority, network.hidden)
                     .await
                     .map_err(|e| {
                         tracing::error!(
@@ -1692,7 +1834,7 @@ pub(crate) async fn execute_apply_networks(
                         ConditionReason::NmcliError
                     })
             }
-            None => nmcli_create_profile(profile_name, ssid, psk, priority)
+            None => nmcli_create_profile(profile_name, ssid, psk, priority, network.hidden)
                 .await
                 .map_err(|e| {
                     tracing::error!("execute_apply_networks: create {profile_name} failed: {e:#}");
@@ -2243,5 +2385,414 @@ connection.autoconnect-priority:500\n";
         // Too few fields.
         assert!(parse_wifi_scan_line("Net:AA\\:BB\\:CC\\:DD\\:EE\\:FF:60").is_none());
         assert!(parse_wifi_scan_line("").is_none());
+    }
+
+    fn nm_profile(
+        name: &str,
+        ssid: &str,
+        key_mgmt: &str,
+        password: Option<&str>,
+        hidden: bool,
+        is_active: bool,
+    ) -> NMProfile {
+        NMProfile {
+            name: name.to_string(),
+            ssid: Some(ssid.to_string()),
+            password: password.map(str::to_string),
+            key_mgmt: Some(key_mgmt.to_string()),
+            hidden: Some(hidden),
+            is_active,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn profile_security_type_maps_known_key_mgmt() {
+        assert_eq!(
+            profile_security_type(&nm_profile("n", "s", "open", None, false, false)),
+            Some("open")
+        );
+        assert_eq!(
+            profile_security_type(&nm_profile("n", "s", "none", None, false, false)),
+            Some("open")
+        );
+        assert_eq!(
+            profile_security_type(&nm_profile("n", "s", "wpa-psk", None, false, false)),
+            Some("wpa-psk")
+        );
+        assert_eq!(
+            profile_security_type(&nm_profile("n", "s", "sae", None, false, false)),
+            Some("sae")
+        );
+        assert_eq!(
+            profile_security_type(&nm_profile("n", "s", "owe", None, false, false)),
+            Some("owe")
+        );
+        assert_eq!(
+            profile_security_type(&nm_profile("n", "s", "wpa-eap", None, false, false)),
+            Some("wpa-eap")
+        );
+    }
+
+    #[test]
+    fn profile_security_type_unknown_key_mgmt_is_none() {
+        let mut p = nm_profile("n", "s", "wep", None, false, false);
+        assert_eq!(profile_security_type(&p), None);
+        p.key_mgmt = None;
+        assert_eq!(profile_security_type(&p), None);
+    }
+
+    #[test]
+    fn psk_matches_open_ignores_psk() {
+        assert!(psk_matches(Some("a"), Some("b"), true));
+        assert!(psk_matches(None, None, true));
+    }
+
+    #[test]
+    fn psk_matches_secured_none_is_wildcard() {
+        assert!(psk_matches(None, Some("secret"), false));
+    }
+
+    #[test]
+    fn psk_matches_secured_equal_matches() {
+        assert!(psk_matches(Some("secret"), Some("secret"), false));
+    }
+
+    #[test]
+    fn psk_matches_secured_unequal_does_not_match() {
+        assert!(!psk_matches(Some("old"), Some("new"), false));
+    }
+
+    #[test]
+    fn select_adoption_candidate_finds_matching_profile_under_different_name() {
+        let mut current_profiles = HashMap::new();
+        current_profiles.insert(
+            "hazeldene-house-new".to_string(),
+            nm_profile(
+                "hazeldene-house-new",
+                "HC-Teton",
+                "wpa-psk",
+                Some("secret"),
+                false,
+                false,
+            ),
+        );
+        let intent_profile_names = HashSet::new();
+        let claimed = HashSet::new();
+
+        let candidate = select_adoption_candidate(
+            &current_profiles,
+            &intent_profile_names,
+            &claimed,
+            "HC-Teton",
+            "HC-Teton",
+            false,
+            "wpa-psk",
+            Some("secret"),
+        );
+
+        assert_eq!(
+            candidate.map(|p| p.name.as_str()),
+            Some("hazeldene-house-new")
+        );
+    }
+
+    #[test]
+    fn select_adoption_candidate_excludes_profile_owned_by_another_intent_entry() {
+        let mut current_profiles = HashMap::new();
+        current_profiles.insert(
+            "other-owner".to_string(),
+            nm_profile(
+                "other-owner",
+                "HC-Teton",
+                "wpa-psk",
+                Some("secret"),
+                false,
+                false,
+            ),
+        );
+        let mut intent_profile_names = HashSet::new();
+        intent_profile_names.insert("other-owner".to_string());
+        let claimed = HashSet::new();
+
+        let candidate = select_adoption_candidate(
+            &current_profiles,
+            &intent_profile_names,
+            &claimed,
+            "HC-Teton",
+            "HC-Teton",
+            false,
+            "wpa-psk",
+            Some("secret"),
+        );
+
+        assert!(candidate.is_none());
+    }
+
+    #[test]
+    fn select_adoption_candidate_excludes_already_claimed_profile() {
+        let mut current_profiles = HashMap::new();
+        current_profiles.insert(
+            "already-claimed".to_string(),
+            nm_profile(
+                "already-claimed",
+                "HC-Teton",
+                "wpa-psk",
+                Some("secret"),
+                false,
+                false,
+            ),
+        );
+        let intent_profile_names = HashSet::new();
+        let mut claimed = HashSet::new();
+        claimed.insert("already-claimed".to_string());
+
+        let candidate = select_adoption_candidate(
+            &current_profiles,
+            &intent_profile_names,
+            &claimed,
+            "HC-Teton",
+            "HC-Teton",
+            false,
+            "wpa-psk",
+            Some("secret"),
+        );
+
+        assert!(candidate.is_none());
+    }
+
+    #[test]
+    fn select_adoption_candidate_excludes_ssid_mismatch() {
+        let mut current_profiles = HashMap::new();
+        current_profiles.insert(
+            "other-net".to_string(),
+            nm_profile(
+                "other-net",
+                "SomeOtherSSID",
+                "wpa-psk",
+                Some("secret"),
+                false,
+                false,
+            ),
+        );
+
+        let candidate = select_adoption_candidate(
+            &current_profiles,
+            &HashSet::new(),
+            &HashSet::new(),
+            "HC-Teton",
+            "HC-Teton",
+            false,
+            "wpa-psk",
+            Some("secret"),
+        );
+
+        assert!(candidate.is_none());
+    }
+
+    #[test]
+    fn select_adoption_candidate_excludes_hidden_mismatch() {
+        let mut current_profiles = HashMap::new();
+        current_profiles.insert(
+            "hidden-net".to_string(),
+            nm_profile(
+                "hidden-net",
+                "HC-Teton",
+                "wpa-psk",
+                Some("secret"),
+                true,
+                false,
+            ),
+        );
+
+        let candidate = select_adoption_candidate(
+            &current_profiles,
+            &HashSet::new(),
+            &HashSet::new(),
+            "HC-Teton",
+            "HC-Teton",
+            false,
+            "wpa-psk",
+            Some("secret"),
+        );
+
+        assert!(candidate.is_none());
+    }
+
+    #[test]
+    fn select_adoption_candidate_never_adopts_sae_or_owe() {
+        // sae/owe are refused upstream, so a surviving intent entry's
+        // security_type is never sae/owe, and this must never match one.
+        let mut current_profiles = HashMap::new();
+        current_profiles.insert(
+            "wpa3-net".to_string(),
+            nm_profile("wpa3-net", "HC-Teton", "sae", Some("secret"), false, false),
+        );
+
+        let candidate = select_adoption_candidate(
+            &current_profiles,
+            &HashSet::new(),
+            &HashSet::new(),
+            "HC-Teton",
+            "HC-Teton",
+            false,
+            "wpa-psk",
+            Some("secret"),
+        );
+
+        assert!(candidate.is_none());
+    }
+
+    #[test]
+    fn select_adoption_candidate_excludes_psk_mismatch_for_secured_network() {
+        let mut current_profiles = HashMap::new();
+        current_profiles.insert(
+            "wrong-psk".to_string(),
+            nm_profile(
+                "wrong-psk",
+                "HC-Teton",
+                "wpa-psk",
+                Some("old-secret"),
+                false,
+                false,
+            ),
+        );
+
+        let candidate = select_adoption_candidate(
+            &current_profiles,
+            &HashSet::new(),
+            &HashSet::new(),
+            "HC-Teton",
+            "HC-Teton",
+            false,
+            "wpa-psk",
+            Some("new-secret"),
+        );
+
+        assert!(candidate.is_none());
+    }
+
+    #[test]
+    fn select_adoption_candidate_includes_unreadable_psk_as_wildcard() {
+        let mut current_profiles = HashMap::new();
+        current_profiles.insert(
+            "unreadable-psk".to_string(),
+            nm_profile("unreadable-psk", "HC-Teton", "wpa-psk", None, false, false),
+        );
+
+        let candidate = select_adoption_candidate(
+            &current_profiles,
+            &HashSet::new(),
+            &HashSet::new(),
+            "HC-Teton",
+            "HC-Teton",
+            false,
+            "wpa-psk",
+            Some("secret"),
+        );
+
+        assert_eq!(candidate.map(|p| p.name.as_str()), Some("unreadable-psk"));
+    }
+
+    #[test]
+    fn select_adoption_candidate_open_network_ignores_psk() {
+        let mut current_profiles = HashMap::new();
+        current_profiles.insert(
+            "open-net".to_string(),
+            nm_profile("open-net", "OpenGuest", "open", None, false, false),
+        );
+
+        let candidate = select_adoption_candidate(
+            &current_profiles,
+            &HashSet::new(),
+            &HashSet::new(),
+            "OpenGuest",
+            "OpenGuest",
+            false,
+            "open",
+            None,
+        );
+
+        assert_eq!(candidate.map(|p| p.name.as_str()), Some("open-net"));
+    }
+
+    #[test]
+    fn select_adoption_candidate_tie_break_prefers_active() {
+        let mut current_profiles = HashMap::new();
+        current_profiles.insert(
+            "inactive-one".to_string(),
+            nm_profile(
+                "inactive-one",
+                "HC-Teton",
+                "wpa-psk",
+                Some("secret"),
+                false,
+                false,
+            ),
+        );
+        current_profiles.insert(
+            "active-one".to_string(),
+            nm_profile(
+                "active-one",
+                "HC-Teton",
+                "wpa-psk",
+                Some("secret"),
+                false,
+                true,
+            ),
+        );
+
+        let candidate = select_adoption_candidate(
+            &current_profiles,
+            &HashSet::new(),
+            &HashSet::new(),
+            "HC-Teton",
+            "HC-Teton",
+            false,
+            "wpa-psk",
+            Some("secret"),
+        );
+
+        assert_eq!(candidate.map(|p| p.name.as_str()), Some("active-one"));
+    }
+
+    #[test]
+    fn select_adoption_candidate_tie_break_falls_back_to_lexically_first_name() {
+        let mut current_profiles = HashMap::new();
+        current_profiles.insert(
+            "zzz-profile".to_string(),
+            nm_profile(
+                "zzz-profile",
+                "HC-Teton",
+                "wpa-psk",
+                Some("secret"),
+                false,
+                false,
+            ),
+        );
+        current_profiles.insert(
+            "aaa-profile".to_string(),
+            nm_profile(
+                "aaa-profile",
+                "HC-Teton",
+                "wpa-psk",
+                Some("secret"),
+                false,
+                false,
+            ),
+        );
+
+        let candidate = select_adoption_candidate(
+            &current_profiles,
+            &HashSet::new(),
+            &HashSet::new(),
+            "HC-Teton",
+            "HC-Teton",
+            false,
+            "wpa-psk",
+            Some("secret"),
+        );
+
+        assert_eq!(candidate.map(|p| p.name.as_str()), Some("aaa-profile"));
     }
 }

--- a/smithd/src/utils/schema.rs
+++ b/smithd/src/utils/schema.rs
@@ -103,11 +103,9 @@ pub struct IntentNetwork {
     pub profile_name: String,
     pub ssid: String,
     pub priority: i32,
-    // Defaulted: an updated smithd may receive a command queued before the API
-    // rolled out these fields, and must still apply it rather than drop it.
-    // "" is not a value `profile_security_type` ever produces, so a missing
-    // security_type just disables adopt-matching for that network instead of
-    // coincidentally matching an existing profile.
+    // Defaulted: a command queued before the API rolled out these fields must
+    // still deserialize. "" is a value profile_security_type never produces,
+    // so a missing security_type just disables adopt-matching, not a false match.
     #[serde(default)]
     pub hidden: bool,
     #[serde(default)]

--- a/smithd/src/utils/schema.rs
+++ b/smithd/src/utils/schema.rs
@@ -103,6 +103,15 @@ pub struct IntentNetwork {
     pub profile_name: String,
     pub ssid: String,
     pub priority: i32,
+    // Defaulted: an updated smithd may receive a command queued before the API
+    // rolled out these fields, and must still apply it rather than drop it.
+    // "" is not a value `profile_security_type` ever produces, so a missing
+    // security_type just disables adopt-matching for that network instead of
+    // coincidentally matching an existing profile.
+    #[serde(default)]
+    pub hidden: bool,
+    #[serde(default)]
+    pub security_type: String,
     pub credentials: NetworkCredentials,
 }
 
@@ -572,6 +581,17 @@ mod tests {
             }
             _ => panic!("expected GetLogs variant"),
         }
+    }
+
+    #[test]
+    fn intent_network_omitted_hidden_and_security_type_default() {
+        // A command queued before the API rolled out these fields must still
+        // deserialize, not get dropped.
+        let json = r#"{"profile_name":"HC-Teton","ssid":"HC-Teton","priority":10,
+            "credentials":{"key_mgmt":"wpa-psk","psk":"secret"}}"#;
+        let network: IntentNetwork = serde_json::from_str(json).unwrap();
+        assert!(!network.hidden);
+        assert_eq!(network.security_type, "");
     }
 
     #[test]


### PR DESCRIPTION
## What
Stops smithd from creating a duplicate NetworkManager profile when a device already has a profile for a network under a different name, and closes the separate bug where the `hidden` flag never reached NetworkManager at all.

## Why
A device with a pre-existing/manually-created NM profile (e.g. `hazeldene-house-new` for SSID `HC-Teton`) that later gets added to a device's intent under the catalog's name ended up with **two** NM connections for the same network after Apply. Both got reported back sharing the same deduped `network_id`, so the dashboard showed both as "In intent" even though only one was actually tracked — and the original profile became permanently unreachable by smithd's cleanup sweep (which only ever deletes profiles it applied itself), so there was no way to get rid of it.

Closes #549

## Approach
- `execute_apply_networks` now searches existing on-device profiles for one that's the same network under a different name before falling back to creating a new profile. "Same network" is judged by the same identity fields the DB's own `network_find_by_content` uses (ssid, hidden, security_type, psk), not an invented heuristic — the API's `ApplyNetworks` payload now carries the true `hidden`/`security_type` fields (previously only the network's SSID and an already-degraded `wpa-psk`/`none` credential shape crossed the wire), which also happens to close #549 (hidden flag was never threaded through to `nmcli` at all).
- A matching profile is adopted by renaming it in place (`connection.id`), reusing the same primitive `connectivity_guard` already uses on a live active connection, then flowing through the existing modify logic unchanged. An adopted profile becomes smithd-managed going forward, so it's now reachable by the cleanup sweep if later removed from intent — previously-stuck profiles like the original bug report's stay stuck until re-adopted, but new ones won't get stuck the same way.
- **sae/owe networks are now refused outright** instead of being silently downgraded to `wpa-psk`/`none` on apply. That downgrade already existed before this PR; extending the new adopt-match to it would have let smithd silently weaken a device's real WPA3/OWE profile the moment its SSID collided with something unrelated added to intent. Checked against a 2-day-old prod dump: 0 of 192 `network` rows and 0 of 75 intent rows are `sae`/`owe`, so this has no current blast radius. No operator-visible signal added for this refusal yet (matches the existing silent `wpa-eap` refusal) — deferred.
- PSK comparison treats an unreadable existing secret as a wildcard rather than a mismatch, relying on the already-merged read-retry fix (#548) to make that safe (a `None` reaching this code is a genuine post-retry residual, not the routine case).
- Rejected: matching on SSID alone (too loose, risks merging distinct networks); a live connectivity-test-before-adopt (unnecessary once #548 was confirmed merged); refusing sae/owe inside smithd instead of the API's existing `wire_credentials` refusal point (would duplicate policy across two services).

## Testing
- [x] Tests pass — `cargo test` (smithd + api), `cargo clippy --all-features -Dwarnings` on both crates, `cargo fmt`. One pre-existing, unrelated test failure (`tunnel::tests::secret_from_magic_toml`) confirmed to fail identically on unmodified `main`.
- [x] Manual smoke test, against a real device (id 5976, the same device #549 was diagnosed on) via its live NetworkManager stack:
  - Adopt path: pre-existing out-of-band profile + a same-ssid/security/psk catalog network under a different name → renamed in place, one profile, log confirms `adopted existing profile ... as ...`.
  - Hidden flag: new hidden network with no pre-existing profile → `802-11-wireless.hidden: yes` on the created profile.
  - Non-match safety: pre-existing profile with a genuinely different PSK for the same SSID → **not** adopted, a second separate profile created instead, original left untouched (the failure mode this design exists to avoid).
  - Exact-name reapply with a mismatched PSK → in-place overwrite as before (unrelated pre-existing path, confirmed unaffected).
  - Tie-break: two identical-content candidates under different names → exactly one adopted, deterministic.
  - Real device profiles (`teton-ai-internal`, `MAWifi`, `AntoineiPhone`) and the active connection were confirmed untouched throughout every test.

## Checklist
- [x] No unintended side effects on adjacent features — `credentials`/`key_mgmt` shape smithd applies is unchanged; only new identity-matching fields were added alongside it.
- [x] Breaking change? Yes, one deliberate behavior change: an `sae`/`owe` network added to intent no longer gets silently applied as downgraded WPA2-PSK/open — it's refused (silently, matching existing `wpa-eap` behavior) until real WPA3/OWE support exists. No migration needed; confirmed zero current users of this path.
- [ ] Docs / changelog updated if user-facing — no dashboard/user-facing changes in this PR (internal smithd/API wire contract only).