### PR TITLE
feat: enforce network content-addressing constraint

### DIFF
--- a/api/.sqlx/query-53ad61c0fe1afcff2d3aab2b2785160941760c817587f598154f1d67420d2773.json
+++ b/api/.sqlx/query-53ad61c0fe1afcff2d3aab2b2785160941760c817587f598154f1d67420d2773.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            dni.priority,\n            n.ssid,\n            n.name,\n            n.password,\n            n.security_type,\n            n.is_network_hidden,\n            n.credentials ->> 'psk' AS credentials_psk\n        FROM device_network_intent dni\n        JOIN network n ON n.id = dni.network_id\n        WHERE dni.device_id = $1\n        ORDER BY dni.priority ASC\n        ",
+  "query": "\n        SELECT\n            dni.priority,\n            n.ssid,\n            n.name,\n            n.password,\n            n.security_type as \"security_type!\",\n            n.is_network_hidden,\n            n.credentials ->> 'psk' AS credentials_psk\n        FROM device_network_intent dni\n        JOIN network n ON n.id = dni.network_id\n        WHERE dni.device_id = $1 AND n.network_type = 'wifi'\n        ORDER BY dni.priority ASC\n        ",
   "describe": {
     "columns": [
       {
@@ -25,7 +25,7 @@
       },
       {
         "ordinal": 4,
-        "name": "security_type",
+        "name": "security_type!",
         "type_info": "Text"
       },
       {
@@ -54,5 +54,5 @@
       null
     ]
   },
-  "hash": "51ae22fb121d88c89ea0feedd067adb644d2a483f01b21746eec58e189b121a9"
+  "hash": "53ad61c0fe1afcff2d3aab2b2785160941760c817587f598154f1d67420d2773"
 }

--- a/api/.sqlx/query-a53fb44759c0363fca6fdbb8ea31b6d25717d82830955e1d4c255a9aa52dbfe5.json
+++ b/api/.sqlx/query-a53fb44759c0363fca6fdbb8ea31b6d25717d82830955e1d4c255a9aa52dbfe5.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                INSERT INTO network (network_type, is_network_hidden, ssid, name, description, password, security_type, credentials)\n                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)\n                RETURNING id, network_type::TEXT as \"network_type\", is_network_hidden, ssid, name, description, 'secret' as password\n                ",
+  "query": "\n                INSERT INTO network (network_type, is_network_hidden, ssid, name, description, password, security_type, credentials)\n                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)\n                ON CONFLICT ON CONSTRAINT network_ident_uq\n                DO UPDATE SET ssid = EXCLUDED.ssid\n                RETURNING id, network_type::TEXT as \"network_type\", is_network_hidden, ssid, name, description, 'secret' as password\n                ",
   "describe": {
     "columns": [
       {
@@ -72,5 +72,5 @@
       null
     ]
   },
-  "hash": "92bd047f94526217a51927ff9f9ac2dba45bf180bcbba3695d3a0e5511c743da"
+  "hash": "a53fb44759c0363fca6fdbb8ea31b6d25717d82830955e1d4c255a9aa52dbfe5"
 }

--- a/api/.sqlx/query-f6cac394c90732aa8e2fffc054b1691b8141fb07ba725b9d09821803a25b9867.json
+++ b/api/.sqlx/query-f6cac394c90732aa8e2fffc054b1691b8141fb07ba725b9d09821803a25b9867.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            dni.priority,\n            n.ssid,\n            n.name,\n            n.password,\n            n.security_type as \"security_type!\",\n            n.is_network_hidden,\n            n.credentials ->> 'psk' AS credentials_psk\n        FROM device_network_intent dni\n        JOIN network n ON n.id = dni.network_id\n        WHERE dni.device_id = $1 AND n.network_type = 'wifi'\n        ORDER BY dni.priority ASC\n        ",
+  "query": "\n        SELECT\n            dni.priority,\n            n.ssid,\n            n.name,\n            n.security_type as \"security_type!\",\n            n.is_network_hidden,\n            n.credentials ->> 'psk' AS credentials_psk\n        FROM device_network_intent dni\n        JOIN network n ON n.id = dni.network_id\n        WHERE dni.device_id = $1 AND n.network_type = 'wifi'\n        ORDER BY dni.priority ASC\n        ",
   "describe": {
     "columns": [
       {
@@ -20,21 +20,16 @@
       },
       {
         "ordinal": 3,
-        "name": "password",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 4,
         "name": "security_type!",
         "type_info": "Text"
       },
       {
-        "ordinal": 5,
+        "ordinal": 4,
         "name": "is_network_hidden",
         "type_info": "Bool"
       },
       {
-        "ordinal": 6,
+        "ordinal": 5,
         "name": "credentials_psk",
         "type_info": "Text"
       }
@@ -49,10 +44,9 @@
       true,
       false,
       true,
-      true,
       false,
       null
     ]
   },
-  "hash": "53ad61c0fe1afcff2d3aab2b2785160941760c817587f598154f1d67420d2773"
+  "hash": "f6cac394c90732aa8e2fffc054b1691b8141fb07ba725b9d09821803a25b9867"
 }

--- a/api/migrations/20260807000000_network_stage4_constraint.sql
+++ b/api/migrations/20260807000000_network_stage4_constraint.sql
@@ -21,23 +21,26 @@
 -- match a wifi row"). Without it here, two distinct Ethernet/Dongle rows -
 -- both NULL ssid/security_type/identity, default '{}' credentials - would
 -- collide under NULLS NOT DISTINCT even though they aren't the same network.
+--
+-- Backfill runs before the index is built, not after: this is the same
+-- provisional heuristic as the Stage 1 backfill (20260720000001), scoped to
+-- wifi only, healing the two NULL-security_type stragglers ReportNMProfiles
+-- can still land when a device reports a key_mgmt Smith doesn't recognize
+-- (api/src/home.rs, map_key_mgmt's `other => None` branch is a permanent,
+-- anticipated case, not a transient one, so unlike Stage 1 this can't be
+-- treated as a closed backlog). If a healed row's new key collides with an
+-- existing one, the index build below is the single point that catches it
+-- and aborts the (transactional) migration - same accepted failure mode as
+-- an unresolved dedupe precondition, not a second, less-defined failure path
+-- from a backfill UPDATE tripping a constraint that already exists.
+UPDATE network
+   SET security_type = CASE WHEN credentials ->> 'psk' IS NULL THEN 'open' ELSE 'wpa-psk' END
+ WHERE network_type = 'wifi' AND security_type IS NULL;
+
 CREATE UNIQUE INDEX network_ident_uq_idx ON network
     (network_type, ssid, is_network_hidden, security_type, credentials, identity) NULLS NOT DISTINCT;
 
 ALTER TABLE network ADD CONSTRAINT network_ident_uq UNIQUE USING INDEX network_ident_uq_idx;
-
--- Same provisional heuristic as the Stage 1 backfill (20260720000001), scoped
--- to wifi only: ReportNMProfiles can still land a wifi row with no
--- security_type when a device reports a key_mgmt Smith doesn't recognize
--- (api/src/home.rs, map_key_mgmt's `other => None` branch is a permanent,
--- anticipated case, not a transient one), so unlike Stage 1 this cannot be
--- treated as a closed backlog. Two such rows exist in prod as of this
--- migration; this heals them the same way a later, recognized report would
--- (network_find_by_content's relaxed match + COALESCE), so it is a no-op for
--- any row a real report reaches first.
-UPDATE network
-   SET security_type = CASE WHEN credentials ->> 'psk' IS NULL THEN 'open' ELSE 'wpa-psk' END
- WHERE network_type = 'wifi' AND security_type IS NULL;
 
 -- security_type is WiFi-specific vocabulary (see security_type_for,
 -- api/src/network/route.rs); Ethernet/Dongle rows have none, so the check is

--- a/api/migrations/20260807000000_network_stage4_constraint.sql
+++ b/api/migrations/20260807000000_network_stage4_constraint.sql
@@ -1,0 +1,29 @@
+-- Stage 4: enforce the content-addressing guarantee at the DB level. Preceded by
+-- a separate, prod-only dedupe run (scripts/dedupe-network/); see
+-- .claude/feat/network-stage4-dedupe-constraint/arch.md. Not applicable to a
+-- fresh dev/CI database, which starts with an empty (trivially deduped) table.
+
+-- Plain CREATE UNIQUE INDEX, not CONCURRENTLY: CONCURRENTLY cannot run inside
+-- sqlx's transactional migration wrapper, and at network's current/near-future
+-- size (~166 rows) a blocking build is sub-second, so the tradeoff isn't worth
+-- a manual deploy step. Revisit if network approaches ~100k rows: past that a
+-- blocking build stops being negligible and this needs to become a manual
+-- CONCURRENTLY step (which requires taking this out of one transaction).
+--
+-- NULLS NOT DISTINCT is required for this to dedupe anything: without it,
+-- Postgres's default treats every NULL identity as distinct from every other,
+-- so open/wpa-psk rows (the overwhelming majority, all NULL identity) would
+-- never conflict with each other at all.
+CREATE UNIQUE INDEX network_ident_uq_idx ON network
+    (ssid, is_network_hidden, security_type, credentials, identity) NULLS NOT DISTINCT;
+
+ALTER TABLE network ADD CONSTRAINT network_ident_uq UNIQUE USING INDEX network_ident_uq_idx;
+
+-- security_type is WiFi-specific vocabulary (see security_type_for,
+-- api/src/network/route.rs); Ethernet/Dongle rows have none, so the check is
+-- scoped to wifi rows only, same as network_check's ssid requirement. Safe
+-- for wifi rows now that Stages 2-3 made every wifi writer populate it, and
+-- the dedupe run (precondition above) accounted for the historical rows that
+-- weren't.
+ALTER TABLE network ADD CONSTRAINT network_security_type_wifi_check
+    CHECK ((network_type <> 'wifi'::network_type) OR (security_type IS NOT NULL));

--- a/api/migrations/20260807000000_network_stage4_constraint.sql
+++ b/api/migrations/20260807000000_network_stage4_constraint.sql
@@ -19,11 +19,21 @@ CREATE UNIQUE INDEX network_ident_uq_idx ON network
 
 ALTER TABLE network ADD CONSTRAINT network_ident_uq UNIQUE USING INDEX network_ident_uq_idx;
 
+-- Same provisional heuristic as the Stage 1 backfill (20260720000001), scoped
+-- to wifi only: ReportNMProfiles can still land a wifi row with no
+-- security_type when a device reports a key_mgmt Smith doesn't recognize
+-- (api/src/home.rs, map_key_mgmt's `other => None` branch is a permanent,
+-- anticipated case, not a transient one), so unlike Stage 1 this cannot be
+-- treated as a closed backlog. Two such rows exist in prod as of this
+-- migration; this heals them the same way a later, recognized report would
+-- (network_find_by_content's relaxed match + COALESCE), so it is a no-op for
+-- any row a real report reaches first.
+UPDATE network
+   SET security_type = CASE WHEN credentials ->> 'psk' IS NULL THEN 'open' ELSE 'wpa-psk' END
+ WHERE network_type = 'wifi' AND security_type IS NULL;
+
 -- security_type is WiFi-specific vocabulary (see security_type_for,
 -- api/src/network/route.rs); Ethernet/Dongle rows have none, so the check is
--- scoped to wifi rows only, same as network_check's ssid requirement. Safe
--- for wifi rows now that Stages 2-3 made every wifi writer populate it, and
--- the dedupe run (precondition above) accounted for the historical rows that
--- weren't.
+-- scoped to wifi rows only, same as network_check's ssid requirement.
 ALTER TABLE network ADD CONSTRAINT network_security_type_wifi_check
     CHECK ((network_type <> 'wifi'::network_type) OR (security_type IS NOT NULL));

--- a/api/migrations/20260807000000_network_stage4_constraint.sql
+++ b/api/migrations/20260807000000_network_stage4_constraint.sql
@@ -14,8 +14,15 @@
 -- Postgres's default treats every NULL identity as distinct from every other,
 -- so open/wpa-psk rows (the overwhelming majority, all NULL identity) would
 -- never conflict with each other at all.
+--
+-- network_type is part of the key because network_find_by_content's match
+-- already treats it that way (api/migrations/20260730000000_..., "a NULL
+-- matches nothing... leaving it out would let a POST for an ethernet network
+-- match a wifi row"). Without it here, two distinct Ethernet/Dongle rows -
+-- both NULL ssid/security_type/identity, default '{}' credentials - would
+-- collide under NULLS NOT DISTINCT even though they aren't the same network.
 CREATE UNIQUE INDEX network_ident_uq_idx ON network
-    (ssid, is_network_hidden, security_type, credentials, identity) NULLS NOT DISTINCT;
+    (network_type, ssid, is_network_hidden, security_type, credentials, identity) NULLS NOT DISTINCT;
 
 ALTER TABLE network ADD CONSTRAINT network_ident_uq UNIQUE USING INDEX network_ident_uq_idx;
 

--- a/api/src/device/route.rs
+++ b/api/src/device/route.rs
@@ -3522,7 +3522,6 @@ pub async fn apply_device_intent(
             dni.priority,
             n.ssid,
             n.name,
-            n.password,
             n.security_type as "security_type!",
             n.is_network_hidden,
             n.credentials ->> 'psk' AS credentials_psk

--- a/api/src/device/route.rs
+++ b/api/src/device/route.rs
@@ -3511,6 +3511,11 @@ pub async fn apply_device_intent(
         return Err(StatusCode::BAD_REQUEST);
     }
 
+    // ApplyNetworks is a NetworkManager wifi-profile command (key_mgmt/psk); an
+    // intent pointing at an Ethernet/Dongle row has no such profile to build, so
+    // it's excluded here rather than reaching the credentials match below. This
+    // also makes security_type provably non-null: network_security_type_wifi_check
+    // guarantees it for every wifi row, hence the "!" override.
     let networks = sqlx::query!(
         r#"
         SELECT
@@ -3518,12 +3523,12 @@ pub async fn apply_device_intent(
             n.ssid,
             n.name,
             n.password,
-            n.security_type,
+            n.security_type as "security_type!",
             n.is_network_hidden,
             n.credentials ->> 'psk' AS credentials_psk
         FROM device_network_intent dni
         JOIN network n ON n.id = dni.network_id
-        WHERE dni.device_id = $1
+        WHERE dni.device_id = $1 AND n.network_type = 'wifi'
         ORDER BY dni.priority ASC
         "#,
         resolved_id
@@ -3569,29 +3574,11 @@ pub async fn apply_device_intent(
     let applyable_networks: Vec<serde_json::Value> = networks
         .iter()
         .filter_map(|n| {
-            let (credentials, applied_security_type) = match n.security_type.as_deref() {
-                Some(security_type) => (
-                    wire_credentials(security_type, n.credentials_psk.as_deref()),
-                    security_type,
-                ),
-                // Legacy rows with no backfilled security_type: preserve the
-                // original password-null inference exactly, for both credentials
-                // and the security_type now echoed alongside it.
-                None => {
-                    if let Some(psk) = n.password.as_deref() {
-                        (
-                            Some(serde_json::json!({ "key_mgmt": "wpa-psk", "psk": psk })),
-                            "wpa-psk",
-                        )
-                    } else {
-                        (Some(serde_json::json!({ "key_mgmt": "none" })), "open")
-                    }
-                }
-            };
+            let credentials = wire_credentials(&n.security_type, n.credentials_psk.as_deref());
             let Some(credentials) = credentials else {
                 warn!(
                     device_id = resolved_id,
-                    security_type = n.security_type.as_deref().unwrap_or("<null>"),
+                    security_type = n.security_type.as_str(),
                     "skipping network in ApplyNetworks: security type not applyable by smithd"
                 );
                 return None;
@@ -3601,7 +3588,7 @@ pub async fn apply_device_intent(
                 "ssid": n.ssid.as_deref().unwrap_or(""),
                 "priority": n.priority,
                 "hidden": n.is_network_hidden,
-                "security_type": applied_security_type,
+                "security_type": n.security_type.as_str(),
                 "credentials": credentials
             }))
         })
@@ -3720,13 +3707,9 @@ mod tests {
             Some(legacy_credentials(password))
         );
 
-        // NULL security_type row (new insert from an unupdated writer):
-        // the dual-read builder falls back to the legacy heuristic verbatim,
-        // so the output is the legacy output by definition. Verify both shapes.
-        assert_eq!(legacy_credentials(None), json!({ "key_mgmt": "none" }));
-        assert_eq!(
-            legacy_credentials(Some("pw")),
-            json!({ "key_mgmt": "wpa-psk", "psk": "pw" })
-        );
+        // security_type is never NULL here: network_security_type_wifi_check
+        // guarantees it for every wifi row, and the intent query's
+        // `WHERE n.network_type = 'wifi'` guarantees every row this function
+        // sees is one.
     }
 }

--- a/api/src/home.rs
+++ b/api/src/home.rs
@@ -175,6 +175,20 @@ pub async fn save_responses(
                     let mapped_security_type: Option<&str> =
                         profile.key_mgmt.as_deref().and_then(map_key_mgmt);
 
+                    // Only for the writes below; mapped_security_type keeps its
+                    // relaxed-wildcard role in network_find_by_content. An
+                    // unrecognized key_mgmt (map_key_mgmt's `other => None`, a
+                    // permanent case, not backlog) can no longer write NULL once
+                    // network_security_type_wifi_check exists, so it falls back
+                    // here instead of failing the check-in. Same heuristic as
+                    // resolve_security_type / the Stage 1 backfill.
+                    let stored_security_type: &str =
+                        mapped_security_type.unwrap_or(if profile.password.is_some() {
+                            "wpa-psk"
+                        } else {
+                            "open"
+                        });
+
                     let mut creds_patch = serde_json::Map::new();
                     if let Some(v) = &profile.pmf {
                         creds_patch.insert("pmf".into(), json!(v));
@@ -236,7 +250,7 @@ pub async fn save_responses(
                                     id,
                                     creds_patch,
                                     identity_val as Option<serde_json::Value>,
-                                    mapped_security_type as Option<&str>,
+                                    stored_security_type,
                                 )
                                 .execute(&mut *tx)
                                 .await?;
@@ -260,7 +274,7 @@ pub async fn save_responses(
                                 ssid,
                                 profile.password,
                                 hidden,
-                                mapped_security_type as Option<&str>,
+                                stored_security_type,
                                 identity_credentials,
                                 creds_patch,
                                 identity_val as Option<serde_json::Value>,

--- a/api/src/network/route.rs
+++ b/api/src/network/route.rs
@@ -345,11 +345,20 @@ pub async fn create_network(
             (StatusCode::OK, existing)
         }
         None => {
+            // Defensive fallback for a lock-bypass race the advisory lock above
+            // already makes structurally impossible; fails safe rather than 500
+            // if that assumption ever breaks. Deliberately doesn't replicate
+            // network_find_by_content's relaxed identity matching (Postgres
+            // conflict detection is exact-equality only) - see arch.md's
+            // rejected-alternatives note. Only safe because this caller never
+            // supplies identity/enterprise security_type; revisit if it ever does.
             let created = sqlx::query_as!(
                 Network,
                 r#"
                 INSERT INTO network (network_type, is_network_hidden, ssid, name, description, password, security_type, credentials)
                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                ON CONFLICT ON CONSTRAINT network_ident_uq
+                DO UPDATE SET ssid = EXCLUDED.ssid
                 RETURNING id, network_type::TEXT as "network_type", is_network_hidden, ssid, name, description, 'secret' as password
                 "#,
                 new_network.network_type as NetworkType,


### PR DESCRIPTION
## What
Add a DB-level unique constraint enforcing the `network` table's content-addressing key (`ssid, is_network_hidden, security_type, credentials, identity`), plus the code cleanup and hardening it enables.

## Why
Stage 3 already made every writer idempotent against this key, but nothing enforced it at the DB level — a bug in any writer could still silently reintroduce duplicate/inconsistent `network` rows. This closes that gap now that prod has been deduped (separate PR, precondition here) by adding `network_ident_uq` and making `security_type` effectively non-null for wifi rows.

## Approach
- Single transactional migration: `CREATE UNIQUE INDEX ... NULLS NOT DISTINCT` → `ADD CONSTRAINT network_ident_uq UNIQUE USING INDEX` → a `CHECK (network_type <> 'wifi' OR security_type IS NOT NULL)` (not a literal column-level `NOT NULL`, since Ethernet/Dongle rows legitimately have no `security_type`).
- Plain (non-`CONCURRENTLY`) index build: `CONCURRENTLY` can't run inside sqlx's transactional migration wrapper, and at `network`'s current/near-future size (~166 rows) a blocking build is sub-second — a documented tripwire in the migration flags revisiting this past ~100k rows.
- Defensive `ON CONFLICT ON CONSTRAINT network_ident_uq DO UPDATE` added to `create_network`'s INSERT, as a fail-safe fallback only — the advisory-lock + `network_find_by_content` matching logic (which does relaxed NULL-wildcard identity matching that `ON CONFLICT`'s exact-equality arbiter can't replicate) remains the primary path, unchanged.
- Removed the now-dead `security_type IS NULL` branch in the `ApplyNetworks` builder (`device/route.rs`), and scoped its query to `network_type = 'wifi'` (a real gap found during implementation: the intent query had no wifi-only filter).
- Found and fixed a real, permanent (not backlog) edge case during prod verification: `ReportNMProfiles` could still write a NULL `security_type` for an unrecognized `key_mgmt` string. Fixed at the source, plus a backfill in the migration for the two prod stragglers this had already produced.

**Rejected alternative:** replacing `create_network`'s primary matching logic with `ON CONFLICT DO UPDATE` outright (the ADR's literal wording) — Postgres's exact-equality arbiter can't replicate `network_find_by_content`'s relaxed identity matching, which would silently reintroduce duplication for identity-forked groups the moment Stage 5 starts sending real `security="WPA2-Enterprise"` values. See `arch.md`'s rejected-alternatives note for the full reasoning.

## Testing
- [x] `cargo test --bin api device::route::` — all 5 unit tests pass, including the updated `dual_read_matches_legacy_for_backfilled_rows`.
- [x] `cargo clippy --all-features -- -Dwarnings` and `cargo fmt --check` — clean.
- [x] Manual smoke test: migration applied cleanly against **three independent prod dumps** (Aug 6, Aug 10, Aug 19), each restored locally — sub-15ms every time, zero remaining constraint violations. Also manually ran the reconstructed `ApplyNetworks` query directly against real restored data to confirm output shape (non-null `security_type`, correct PSK extraction) post-rebase.
- [ ] e2e test — deliberately not added; `e2e/tests/daemon_api.rs` structurally can't reach this authenticated route (documented in impl-plan Task 4's deviation). Coverage substitutes an updated unit test instead.

## Checklist
- [x] No unintended side effects on adjacent features — `POST /networks`'s request/response contract is unchanged; the new `WHERE n.network_type = 'wifi'` filter is currently a no-op against real data (checked: all 97 live `device_network_intent` rows are wifi-type already).
- [x] Breaking change? No — internal enforcement of an existing guarantee, no external API contract change.
- [x] Docs / changelog updated if user-facing — N/A, not user-facing.