### PR TITLE
feat: add reference ledger for external network holders

### DIFF
--- a/api/.sqlx/query-17fe2e60bd718d5a33d2080405d6ff175f3233168e2fb7c88ddd0e6fd9834d13.json
+++ b/api/.sqlx/query-17fe2e60bd718d5a33d2080405d6ff175f3233168e2fb7c88ddd0e6fd9834d13.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO network_reference (holder, external_key, network_id)\n        VALUES ($1, $2, $3)\n        ON CONFLICT (holder, external_key, network_id) DO NOTHING\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "17fe2e60bd718d5a33d2080405d6ff175f3233168e2fb7c88ddd0e6fd9834d13"
+}

--- a/api/.sqlx/query-1a539ec1edee751912b672bb070ff54fc33ccd2927543f7e1c112fc44e2a965c.json
+++ b/api/.sqlx/query-1a539ec1edee751912b672bb070ff54fc33ccd2927543f7e1c112fc44e2a965c.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS(SELECT 1 FROM network_reference WHERE network_id = $1) AS \"exists!\"",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "1a539ec1edee751912b672bb070ff54fc33ccd2927543f7e1c112fc44e2a965c"
+}

--- a/api/.sqlx/query-5c913f6a8ee52779e25e4f4f1eb299d272bbf08882bd0b51f3fa6ea04ef7da82.json
+++ b/api/.sqlx/query-5c913f6a8ee52779e25e4f4f1eb299d272bbf08882bd0b51f3fa6ea04ef7da82.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM network_reference WHERE holder = $1 AND external_key = $2 AND network_id = $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5c913f6a8ee52779e25e4f4f1eb299d272bbf08882bd0b51f3fa6ea04ef7da82"
+}

--- a/api/.sqlx/query-716e6a9fdb5b1b77b7a63390bef6b833eb9d286fb105d747ef7923b7c8301a09.json
+++ b/api/.sqlx/query-716e6a9fdb5b1b77b7a63390bef6b833eb9d286fb105d747ef7923b7c8301a09.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                INSERT INTO network (network_type, is_network_hidden, ssid, name, description, password, security_type, credentials)\n                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)\n                ON CONFLICT ON CONSTRAINT network_ident_uq\n                DO UPDATE SET ssid = EXCLUDED.ssid\n                RETURNING id, network_type::TEXT as \"network_type\", is_network_hidden, ssid, name, description, 'secret' as password\n                ",
+  "query": "\n        INSERT INTO network (network_type, is_network_hidden, ssid, name, description, password, security_type, credentials)\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)\n        ON CONFLICT ON CONSTRAINT network_ident_uq\n        DO UPDATE SET ssid = EXCLUDED.ssid\n        RETURNING id, network_type::TEXT as \"network_type\", is_network_hidden, ssid, name, description, 'secret' as password\n        ",
   "describe": {
     "columns": [
       {
@@ -72,5 +72,5 @@
       null
     ]
   },
-  "hash": "a53fb44759c0363fca6fdbb8ea31b6d25717d82830955e1d4c255a9aa52dbfe5"
+  "hash": "716e6a9fdb5b1b77b7a63390bef6b833eb9d286fb105d747ef7923b7c8301a09"
 }

--- a/api/.sqlx/query-9982ffbb77075d2b5e591c27f54f2bca39d255767872247c1e6972a80a70355b.json
+++ b/api/.sqlx/query-9982ffbb77075d2b5e591c27f54f2bca39d255767872247c1e6972a80a70355b.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM network WHERE id = ANY($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4Array"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9982ffbb77075d2b5e591c27f54f2bca39d255767872247c1e6972a80a70355b"
+}

--- a/api/.sqlx/query-a06e1d9f6f95e4c4c2b98310ebddcc9d963cc033582bf2e945e8bf3a301b4247.json
+++ b/api/.sqlx/query-a06e1d9f6f95e4c4c2b98310ebddcc9d963cc033582bf2e945e8bf3a301b4247.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT pg_advisory_xact_lock($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pg_advisory_xact_lock",
+        "type_info": "Void"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "a06e1d9f6f95e4c4c2b98310ebddcc9d963cc033582bf2e945e8bf3a301b4247"
+}

--- a/api/.sqlx/query-a789ece7dcf0b5c0a605eadebdf81f3d99fd18c217442ebc2e0371c73ea8400b.json
+++ b/api/.sqlx/query-a789ece7dcf0b5c0a605eadebdf81f3d99fd18c217442ebc2e0371c73ea8400b.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT network_has_internal_reference($1) AS \"exists!\"",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "a789ece7dcf0b5c0a605eadebdf81f3d99fd18c217442ebc2e0371c73ea8400b"
+}

--- a/api/.sqlx/query-b6d7635d56f757efbdf1951af9c6cb1f27a7dc7100df174b9c526081c32c439d.json
+++ b/api/.sqlx/query-b6d7635d56f757efbdf1951af9c6cb1f27a7dc7100df174b9c526081c32c439d.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT pg_advisory_xact_lock(pg_catalog.hashtextextended($1, 1))",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pg_advisory_xact_lock",
+        "type_info": "Void"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "b6d7635d56f757efbdf1951af9c6cb1f27a7dc7100df174b9c526081c32c439d"
+}

--- a/api/.sqlx/query-dd27ed4dce28464063405b3c90b7900ee75dcadff9bf32bb97cf8c63ffb55b42.json
+++ b/api/.sqlx/query-dd27ed4dce28464063405b3c90b7900ee75dcadff9bf32bb97cf8c63ffb55b42.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT external_key, network_id FROM network_reference WHERE holder = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "external_key",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "network_id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "dd27ed4dce28464063405b3c90b7900ee75dcadff9bf32bb97cf8c63ffb55b42"
+}

--- a/api/.sqlx/query-e305e7a6171744cf7db3250481842025a319af75dfad2479921fa587d54e8d4e.json
+++ b/api/.sqlx/query-e305e7a6171744cf7db3250481842025a319af75dfad2479921fa587d54e8d4e.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS(SELECT 1 FROM network WHERE id = $1) AS \"exists!\"",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "e305e7a6171744cf7db3250481842025a319af75dfad2479921fa587d54e8d4e"
+}

--- a/api/migrations/20260820000000_network_reference_ledger.sql
+++ b/api/migrations/20260820000000_network_reference_ledger.sql
@@ -1,0 +1,19 @@
+-- network_reference (20260720000000_network_schema_expand.sql) already tracks
+-- external holds; this is the other half of collection: single definition of
+-- "does anything internal to Smith still reference this network", so
+-- `collect_network` (api/src/network/ledger.rs) and any later caller share one
+-- answer instead of drifting into two different opinions of what counts as
+-- referenced.
+CREATE OR REPLACE FUNCTION public.network_has_internal_reference(p_network_id integer)
+RETURNS boolean LANGUAGE sql STABLE
+SET search_path = pg_catalog, public
+AS $$
+    SELECT EXISTS (
+        SELECT 1 FROM device
+         WHERE network_id = p_network_id OR current_network_id = p_network_id
+        UNION ALL
+        SELECT 1 FROM device_configured_network WHERE network_id = p_network_id
+        UNION ALL
+        SELECT 1 FROM device_network_intent WHERE network_id = p_network_id
+    );
+$$;

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use axum::http::HeaderMap;
+use std::collections::HashMap;
 use std::env;
 use std::time::Duration;
 use tracing::{info, warn};
@@ -98,6 +99,31 @@ pub struct Config {
     pub device_jwt_issuer: String,
     /// Lifetime of issued device JWTs.
     pub device_jwt_ttl_seconds: u64,
+    /// Maps an M2M token's Auth0 `sub` claim (e.g. `"<client_id>@clients"`) to
+    /// the network-reference-ledger `holder` name it is trusted to act as.
+    /// `holder` is never client-supplied: this map is the sole source of truth
+    /// for who a caller is allowed to hold references as.
+    pub known_holders: HashMap<String, String>,
+}
+
+/// Builds the M2M-sub -> holder map from one env var per known holder. Missing
+/// (unset in dev/CI, where no App API integration is exercised) only warns,
+/// matching how every other optional integration in this file behaves
+/// (`VictoriaMetricsClient`, `ip_api_key`, ...); a misconfigured production
+/// deploy is caught operationally (App API's ledger calls 403) rather than by
+/// refusing to boot the whole API over one holder's credentials.
+fn known_holders_from_env() -> HashMap<String, String> {
+    let mut holders = HashMap::new();
+    match env::var("APP_API_M2M_CLIENT_ID") {
+        Ok(client_id) => {
+            holders.insert(format!("{client_id}@clients"), "app_api".to_string());
+        }
+        Err(_) => warn!(
+            "APP_API_M2M_CLIENT_ID is not set: App API's ledger calls (acquire/release/reconcile, \
+             POST /networks with `reference`) will all 403"
+        ),
+    }
+    holders
 }
 
 impl Config {
@@ -134,6 +160,7 @@ impl Config {
                 .ok()
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(3600),
+            known_holders: known_holders_from_env(),
         })
     }
 }

--- a/api/src/holder.rs
+++ b/api/src/holder.rs
@@ -1,0 +1,10 @@
+/// The network-reference-ledger holder identity resolved from the caller's M2M
+/// token, or `None` for a caller with no resolved holder (a dashboard/CLI user
+/// token, or an M2M token whose `sub` isn't in `Config::known_holders`).
+///
+/// Always inserted into request extensions by `middlewares::authentication::check`
+/// (never left absent), so ledger handlers can extract `Extension<Holder>`
+/// unconditionally and turn `None` into a `403` themselves, rather than hitting
+/// axum's default `500` for a missing extension.
+#[derive(Clone, Debug)]
+pub struct Holder(pub Option<String>);

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -42,6 +42,7 @@ mod event;
 mod files;
 mod handlers;
 mod health;
+mod holder;
 mod home;
 mod ip_address;
 mod logging;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -261,6 +261,11 @@ async fn start_main_server(
             network::route::get_network_by_id,
             network::route::delete_network_by_id
         ))
+        .routes(routes!(
+            network::ledger::acquire_reference,
+            network::ledger::release_reference
+        ))
+        .routes(routes!(network::ledger::reconcile_references))
         .routes(routes!(network::route::start_extended_network_test))
         .routes(routes!(network::route::get_extended_test_status))
         .routes(routes!(network::route::list_extended_test_sessions))

--- a/api/src/middlewares/authentication/mod.rs
+++ b/api/src/middlewares/authentication/mod.rs
@@ -1,4 +1,5 @@
 mod audience;
+use crate::holder::Holder;
 use crate::middlewares::authorization::{AccountsConfig, AuthorizationConfig};
 use crate::{State, user::CurrentUser};
 use audience::Audience;
@@ -71,6 +72,12 @@ pub async fn check(
     // M2M tokens have sub claim ending with "@clients" - they can't call /userinfo
     let is_m2m_token = claims.sub.ends_with("@clients");
 
+    // Resolved once, up front, from config rather than the request: a caller
+    // whose sub isn't a known holder (any user token, or an unrecognized M2M
+    // client) gets None, not an error - the ledger endpoints are the only
+    // callers that care, and they turn None into their own 403.
+    let holder = Holder(state.config.known_holders.get(&claims.sub).cloned());
+
     let needs_userinfo = !is_m2m_token
         && existing_user
             .map(|(_, has_email)| !has_email)
@@ -137,6 +144,7 @@ pub async fn check(
         .map_err(|_| StatusCode::UNAUTHORIZED)?;
 
     request.extensions_mut().insert(current_user);
+    request.extensions_mut().insert(holder);
 
     let response = next.run(request).await;
     Ok(response)

--- a/api/src/network/ledger.rs
+++ b/api/src/network/ledger.rs
@@ -16,6 +16,7 @@ use axum::http::StatusCode;
 use serde::Deserialize;
 use sqlx::PgConnection;
 use std::collections::{BTreeSet, HashSet};
+use tracing::warn;
 use utoipa::ToSchema;
 
 use super::route::{NETWORKS_TAG, internal_error};
@@ -35,6 +36,12 @@ pub struct ReconcileKey {
 pub struct ReconcileRequest {
     pub keys: Vec<ReconcileKey>,
 }
+
+/// Generous headroom over a holder's actual fleet size (App API's is in the
+/// low thousands), not a tuned business limit - just a guard against a
+/// malformed or runaway request locking an unbounded number of network ids
+/// in one transaction. Same convention as `TELEMETRY_MAX_SERIALS`.
+const RECONCILE_MAX_KEYS: usize = 10_000;
 
 async fn lock_network(tx: &mut PgConnection, network_id: i32) -> Result<(), sqlx::Error> {
     sqlx::query!("SELECT pg_advisory_xact_lock($1)", i64::from(network_id))
@@ -286,6 +293,7 @@ impl ReconcileDiff {
     request_body = ReconcileRequest,
     responses(
         (status = 204, description = "This holder's ledger rows now exactly match the pushed key set"),
+        (status = 400, description = "Too many keys, or `keys` references a network_id that doesn't exist"),
         (status = 403, description = "Caller has no resolved ledger holder identity"),
         (status = 500, description = "Failed to reconcile references", body = String),
     ),
@@ -298,6 +306,10 @@ pub async fn reconcile_references(
     Json(body): Json<ReconcileRequest>,
 ) -> Result<StatusCode, StatusCode> {
     let holder = holder.ok_or(StatusCode::FORBIDDEN)?;
+
+    if body.keys.len() > RECONCILE_MAX_KEYS {
+        return Err(StatusCode::BAD_REQUEST);
+    }
 
     let mut tx = state.pg_pool.begin().await.map_err(internal_error(
         "Failed to begin reconcile_references transaction",
@@ -337,6 +349,33 @@ pub async fn reconcile_references(
         .collect();
 
     let diff = ReconcileDiff::compute(&current, &desired);
+
+    // Checked separately from the insert loop below, same reasoning as
+    // acquire_reference's existence check: an FK violation on insert_reference
+    // would otherwise surface as an opaque 500 for what is really a caller
+    // error (a pushed network_id that doesn't exist), and would do so only
+    // after the locks above are already held. All to_add ids are already
+    // locked (they come from body.keys, included in lock_ids above), so this
+    // read is consistent with the insert loop that follows it.
+    let to_add_ids: Vec<i32> = diff.to_add.iter().map(|(_, id)| *id).collect();
+    if !to_add_ids.is_empty() {
+        let existing: HashSet<i32> =
+            sqlx::query_scalar!("SELECT id FROM network WHERE id = ANY($1)", &to_add_ids)
+                .fetch_all(&mut *tx)
+                .await
+                .map_err(internal_error("Failed to validate pushed network ids"))?
+                .into_iter()
+                .collect();
+        let missing: Vec<i32> = to_add_ids
+            .iter()
+            .filter(|id| !existing.contains(id))
+            .copied()
+            .collect();
+        if !missing.is_empty() {
+            warn!(?missing, %holder, "reconcile pushed unknown network_id(s)");
+            return Err(StatusCode::BAD_REQUEST);
+        }
+    }
 
     for (external_key, network_id) in &diff.to_add {
         insert_reference(&mut tx, &holder, external_key, *network_id)

--- a/api/src/network/ledger.rs
+++ b/api/src/network/ledger.rs
@@ -225,7 +225,7 @@ pub async fn release_reference(
         .await
         .map_err(internal_error("Failed to take network lock"))?;
 
-    sqlx::query!(
+    let released = sqlx::query!(
         "DELETE FROM network_reference WHERE holder = $1 AND external_key = $2 AND network_id = $3",
         holder,
         body.external_key,
@@ -233,13 +233,20 @@ pub async fn release_reference(
     )
     .execute(&mut *tx)
     .await
-    .map_err(internal_error("Failed to delete network reference"))?;
+    .map_err(internal_error("Failed to delete network reference"))?
+    .rows_affected()
+        > 0;
 
-    // The caller does not decide and does not inspect internal FK state - 204
-    // either way, whether or not this actually collected the row.
-    collect_network(&mut tx, network_id)
-        .await
-        .map_err(internal_error("Failed to attempt network collection"))?;
+    // Collection is only attempted for a hold this call actually released -
+    // otherwise any authenticated holder could use a network_id/external_key
+    // it never registered to trigger collection of a network it has no
+    // relationship to. Still 204 either way, and the caller still never
+    // inspects internal FK state or whether collection actually happened.
+    if released {
+        collect_network(&mut tx, network_id)
+            .await
+            .map_err(internal_error("Failed to attempt network collection"))?;
+    }
 
     tx.commit().await.map_err(internal_error(
         "Failed to commit release_reference transaction",

--- a/api/src/network/ledger.rs
+++ b/api/src/network/ledger.rs
@@ -38,9 +38,9 @@ pub struct ReconcileRequest {
 }
 
 /// Generous headroom over a holder's actual fleet size (App API's is in the
-/// low thousands), not a tuned business limit - just a guard against a
-/// malformed or runaway request locking an unbounded number of network ids
-/// in one transaction. Same convention as `TELEMETRY_MAX_SERIALS`.
+/// low thousands) - a guard against a malformed/runaway request locking an
+/// unbounded number of network ids, not a tuned business limit. Same
+/// convention as `TELEMETRY_MAX_SERIALS`.
 const RECONCILE_MAX_KEYS: usize = 10_000;
 
 async fn lock_network(tx: &mut PgConnection, network_id: i32) -> Result<(), sqlx::Error> {
@@ -238,10 +238,9 @@ pub async fn release_reference(
         > 0;
 
     // Collection is only attempted for a hold this call actually released -
-    // otherwise any authenticated holder could use a network_id/external_key
-    // it never registered to trigger collection of a network it has no
-    // relationship to. Still 204 either way, and the caller still never
-    // inspects internal FK state or whether collection actually happened.
+    // otherwise any holder could trigger collection of a network it has no
+    // relationship to via a network_id/external_key it never registered.
+    // Response is still 204 either way.
     if released {
         collect_network(&mut tx, network_id)
             .await
@@ -358,12 +357,10 @@ pub async fn reconcile_references(
     let diff = ReconcileDiff::compute(&current, &desired);
 
     // Checked separately from the insert loop below, same reasoning as
-    // acquire_reference's existence check: an FK violation on insert_reference
-    // would otherwise surface as an opaque 500 for what is really a caller
-    // error (a pushed network_id that doesn't exist), and would do so only
-    // after the locks above are already held. All to_add ids are already
-    // locked (they come from body.keys, included in lock_ids above), so this
-    // read is consistent with the insert loop that follows it.
+    // acquire_reference's existence check: an FK violation here would surface
+    // as an opaque 500 for what is really a caller error. All to_add ids are
+    // already locked (from lock_ids above), so this read is consistent with
+    // the insert loop that follows.
     let to_add_ids: Vec<i32> = diff.to_add.iter().map(|(_, id)| *id).collect();
     if !to_add_ids.is_empty() {
         let existing: HashSet<i32> =

--- a/api/src/network/ledger.rs
+++ b/api/src/network/ledger.rs
@@ -1,0 +1,413 @@
+//! The network reference ledger: acquire/release/reconcile for external
+//! holders (App API today) plus `collect_network`, the private collection
+//! check that deletes a network once nothing references it anymore.
+//!
+//! `holder` is never read from a request body anywhere in this module: it is
+//! always the caller's ledger identity resolved server-side from their M2M
+//! token by `middlewares::authentication::check` (see `crate::holder::Holder`),
+//! so a caller can't release or reconcile another holder's references by
+//! spoofing the field. A caller with no resolved holder is rejected with `403`
+//! before any DB work.
+
+use crate::State;
+use crate::holder::Holder;
+use axum::extract::{Extension, Json, Path};
+use axum::http::StatusCode;
+use serde::Deserialize;
+use sqlx::PgConnection;
+use std::collections::{BTreeSet, HashSet};
+use utoipa::ToSchema;
+
+use super::route::{NETWORKS_TAG, internal_error};
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ReferenceRequest {
+    pub external_key: String,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ReconcileKey {
+    pub external_key: String,
+    pub network_id: i32,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ReconcileRequest {
+    pub keys: Vec<ReconcileKey>,
+}
+
+async fn lock_network(tx: &mut PgConnection, network_id: i32) -> Result<(), sqlx::Error> {
+    sqlx::query!("SELECT pg_advisory_xact_lock($1)", i64::from(network_id))
+        .execute(tx)
+        .await?;
+    Ok(())
+}
+
+/// The one construction of a `network_reference` insert; shared verbatim by
+/// `acquire_reference` and `create_network`'s `reference` field so the two
+/// insert paths cannot silently diverge. Idempotent: re-registering an
+/// already-held `(holder, external_key, network_id)` triple is a no-op, not an
+/// error. Deliberately does not call `collect_network` - a row this just added
+/// a hold to is never a collection candidate in the same breath.
+pub(crate) async fn insert_reference(
+    tx: &mut PgConnection,
+    holder: &str,
+    external_key: &str,
+    network_id: i32,
+) -> Result<(), sqlx::Error> {
+    sqlx::query!(
+        r#"
+        INSERT INTO network_reference (holder, external_key, network_id)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (holder, external_key, network_id) DO NOTHING
+        "#,
+        holder,
+        external_key,
+        network_id,
+    )
+    .execute(tx)
+    .await?;
+    Ok(())
+}
+
+/// Given a `network_id` whose advisory lock (`pg_advisory_xact_lock`, taken by
+/// the caller for the lifetime of `tx`) is already held, deletes the network
+/// row if it has zero ledger references and zero internal FK references.
+/// `network_reference`'s `ON DELETE RESTRICT` FK is why this order matters:
+/// both counts are verified zero first, so the delete below can never be the
+/// thing that would have violated it.
+pub(crate) async fn collect_network(
+    tx: &mut PgConnection,
+    network_id: i32,
+) -> Result<bool, sqlx::Error> {
+    let has_ledger_reference = sqlx::query_scalar!(
+        r#"SELECT EXISTS(SELECT 1 FROM network_reference WHERE network_id = $1) AS "exists!""#,
+        network_id
+    )
+    .fetch_one(&mut *tx)
+    .await?;
+    if has_ledger_reference {
+        return Ok(false);
+    }
+
+    let has_internal_reference = sqlx::query_scalar!(
+        r#"SELECT network_has_internal_reference($1) AS "exists!""#,
+        network_id
+    )
+    .fetch_one(&mut *tx)
+    .await?;
+    if has_internal_reference {
+        return Ok(false);
+    }
+
+    sqlx::query!("DELETE FROM network WHERE id = $1", network_id)
+        .execute(tx)
+        .await?;
+    Ok(true)
+}
+
+#[utoipa::path(
+    post,
+    path = "/networks/{network_id}/references",
+    params(("network_id" = i32, Path)),
+    request_body = ReferenceRequest,
+    responses(
+        (status = 204, description = "Reference held (idempotent: a no-op if already held)"),
+        (status = 403, description = "Caller has no resolved ledger holder identity"),
+        (status = 404, description = "Network does not exist"),
+        (status = 500, description = "Failed to acquire reference", body = String),
+    ),
+    security(("auth_token" = [])),
+    tag = NETWORKS_TAG
+)]
+pub async fn acquire_reference(
+    Extension(state): Extension<State>,
+    Extension(Holder(holder)): Extension<Holder>,
+    Path(network_id): Path<i32>,
+    Json(body): Json<ReferenceRequest>,
+) -> Result<StatusCode, StatusCode> {
+    let holder = holder.ok_or(StatusCode::FORBIDDEN)?;
+
+    let mut tx = state.pg_pool.begin().await.map_err(internal_error(
+        "Failed to begin acquire_reference transaction",
+    ))?;
+
+    lock_network(&mut tx, network_id)
+        .await
+        .map_err(internal_error("Failed to take network lock"))?;
+
+    // Existence check kept deliberately separate from the insert below rather
+    // than inferred from an FK-violation error code: network_reference's only
+    // FK today is to network(id), so that inference happens to be safe, but a
+    // future FK on this table would silently turn an unrelated violation into
+    // a wrong 404.
+    let exists: bool = sqlx::query_scalar!(
+        r#"SELECT EXISTS(SELECT 1 FROM network WHERE id = $1) AS "exists!""#,
+        network_id
+    )
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(internal_error("Failed to check network existence"))?;
+    if !exists {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    insert_reference(&mut tx, &holder, &body.external_key, network_id)
+        .await
+        .map_err(internal_error("Failed to insert network reference"))?;
+
+    tx.commit().await.map_err(internal_error(
+        "Failed to commit acquire_reference transaction",
+    ))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[utoipa::path(
+    delete,
+    path = "/networks/{network_id}/references",
+    params(("network_id" = i32, Path)),
+    request_body = ReferenceRequest,
+    responses(
+        (status = 204, description = "Reference released; always returned, regardless of whether a row was deleted or collection happened"),
+        (status = 403, description = "Caller has no resolved ledger holder identity"),
+        (status = 500, description = "Failed to release reference", body = String),
+    ),
+    security(("auth_token" = [])),
+    tag = NETWORKS_TAG
+)]
+pub async fn release_reference(
+    Extension(state): Extension<State>,
+    Extension(Holder(holder)): Extension<Holder>,
+    Path(network_id): Path<i32>,
+    Json(body): Json<ReferenceRequest>,
+) -> Result<StatusCode, StatusCode> {
+    let holder = holder.ok_or(StatusCode::FORBIDDEN)?;
+
+    let mut tx = state.pg_pool.begin().await.map_err(internal_error(
+        "Failed to begin release_reference transaction",
+    ))?;
+
+    lock_network(&mut tx, network_id)
+        .await
+        .map_err(internal_error("Failed to take network lock"))?;
+
+    sqlx::query!(
+        "DELETE FROM network_reference WHERE holder = $1 AND external_key = $2 AND network_id = $3",
+        holder,
+        body.external_key,
+        network_id,
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(internal_error("Failed to delete network reference"))?;
+
+    // The caller does not decide and does not inspect internal FK state - 204
+    // either way, whether or not this actually collected the row.
+    collect_network(&mut tx, network_id)
+        .await
+        .map_err(internal_error("Failed to attempt network collection"))?;
+
+    tx.commit().await.map_err(internal_error(
+        "Failed to commit release_reference transaction",
+    ))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn fetch_holder_references(
+    tx: &mut PgConnection,
+    holder: &str,
+) -> Result<Vec<(String, i32)>, sqlx::Error> {
+    let rows = sqlx::query!(
+        "SELECT external_key, network_id FROM network_reference WHERE holder = $1",
+        holder
+    )
+    .fetch_all(tx)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(|r| (r.external_key, r.network_id))
+        .collect())
+}
+
+/// Pure set diff, factored out of `reconcile_references` so it is unit-testable
+/// without a database.
+struct ReconcileDiff {
+    to_add: Vec<(String, i32)>,
+    to_remove: Vec<(String, i32)>,
+}
+
+impl ReconcileDiff {
+    fn compute(current: &HashSet<(String, i32)>, desired: &HashSet<(String, i32)>) -> Self {
+        ReconcileDiff {
+            to_add: desired.difference(current).cloned().collect(),
+            to_remove: current.difference(desired).cloned().collect(),
+        }
+    }
+
+    /// Every `network_id` that lost a hold this call - the only rows collection
+    /// needs to be attempted on, since a row nothing was removed from cannot
+    /// have just dropped to zero references.
+    fn collection_candidates(&self) -> BTreeSet<i32> {
+        self.to_remove.iter().map(|(_, id)| *id).collect()
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/networks/references/reconcile",
+    request_body = ReconcileRequest,
+    responses(
+        (status = 204, description = "This holder's ledger rows now exactly match the pushed key set"),
+        (status = 403, description = "Caller has no resolved ledger holder identity"),
+        (status = 500, description = "Failed to reconcile references", body = String),
+    ),
+    security(("auth_token" = [])),
+    tag = NETWORKS_TAG
+)]
+pub async fn reconcile_references(
+    Extension(state): Extension<State>,
+    Extension(Holder(holder)): Extension<Holder>,
+    Json(body): Json<ReconcileRequest>,
+) -> Result<StatusCode, StatusCode> {
+    let holder = holder.ok_or(StatusCode::FORBIDDEN)?;
+
+    let mut tx = state.pg_pool.begin().await.map_err(internal_error(
+        "Failed to begin reconcile_references transaction",
+    ))?;
+
+    // Unlocked first pass: gather every network_id this call could touch (the
+    // pushed set plus whatever this holder currently holds) so every lock below
+    // can be taken in one ascending sweep, avoiding deadlock against another
+    // reconcile/acquire/release touching an overlapping set. A hold landing on
+    // a network_id in neither set, in the gap between this read and the locks
+    // below, is a known accepted residual race: the next scheduled reconcile
+    // call converges it regardless.
+    let current_before = fetch_holder_references(&mut tx, &holder)
+        .await
+        .map_err(internal_error("Failed to read current references"))?;
+
+    let mut lock_ids: Vec<i32> = body
+        .keys
+        .iter()
+        .map(|k| k.network_id)
+        .chain(current_before.iter().map(|(_, id)| *id))
+        .collect();
+    lock_ids.sort_unstable();
+    lock_ids.dedup();
+
+    for network_id in &lock_ids {
+        lock_network(&mut tx, *network_id)
+            .await
+            .map_err(internal_error("Failed to take network lock"))?;
+    }
+
+    let current: HashSet<(String, i32)> = fetch_holder_references(&mut tx, &holder)
+        .await
+        .map_err(internal_error("Failed to read current references"))?
+        .into_iter()
+        .collect();
+
+    let desired: HashSet<(String, i32)> = body
+        .keys
+        .iter()
+        .map(|k| (k.external_key.clone(), k.network_id))
+        .collect();
+
+    let diff = ReconcileDiff::compute(&current, &desired);
+
+    for (external_key, network_id) in &diff.to_add {
+        insert_reference(&mut tx, &holder, external_key, *network_id)
+            .await
+            .map_err(internal_error("Failed to insert network reference"))?;
+    }
+
+    for (external_key, network_id) in &diff.to_remove {
+        sqlx::query!(
+            "DELETE FROM network_reference WHERE holder = $1 AND external_key = $2 AND network_id = $3",
+            holder,
+            external_key,
+            network_id,
+        )
+        .execute(&mut *tx)
+        .await
+        .map_err(internal_error("Failed to delete network reference"))?;
+    }
+
+    for network_id in diff.collection_candidates() {
+        collect_network(&mut tx, network_id)
+            .await
+            .map_err(internal_error("Failed to attempt network collection"))?;
+    }
+
+    tx.commit().await.map_err(internal_error(
+        "Failed to commit reconcile_references transaction",
+    ))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ReconcileDiff;
+    use std::collections::HashSet;
+
+    fn set(pairs: &[(&str, i32)]) -> HashSet<(String, i32)> {
+        pairs.iter().map(|(k, id)| (k.to_string(), *id)).collect()
+    }
+
+    #[test]
+    fn adds_missing_and_removes_extra() {
+        let current = set(&[("a", 1), ("b", 2)]);
+        let desired = set(&[("b", 2), ("c", 3)]);
+
+        let diff = ReconcileDiff::compute(&current, &desired);
+
+        assert_eq!(diff.to_add, vec![("c".to_string(), 3)]);
+        assert_eq!(diff.to_remove, vec![("a".to_string(), 1)]);
+        assert_eq!(
+            diff.collection_candidates().into_iter().collect::<Vec<_>>(),
+            vec![1]
+        );
+    }
+
+    #[test]
+    fn empty_desired_removes_everything() {
+        let current = set(&[("a", 1), ("b", 2)]);
+        let desired = HashSet::new();
+
+        let diff = ReconcileDiff::compute(&current, &desired);
+
+        assert!(diff.to_add.is_empty());
+        let mut removed = diff.to_remove.clone();
+        removed.sort();
+        assert_eq!(removed, vec![("a".to_string(), 1), ("b".to_string(), 2)]);
+    }
+
+    #[test]
+    fn identical_sets_produce_no_diff() {
+        let current = set(&[("a", 1)]);
+        let desired = set(&[("a", 1)]);
+
+        let diff = ReconcileDiff::compute(&current, &desired);
+
+        assert!(diff.to_add.is_empty());
+        assert!(diff.to_remove.is_empty());
+        assert!(diff.collection_candidates().is_empty());
+    }
+
+    #[test]
+    fn same_external_key_different_network_id_is_not_a_match() {
+        // The ledger PK is the full (holder, external_key, network_id) triple:
+        // one holder can reference several network_ids under the same
+        // external_key, so these must diff as add+remove, not as "unchanged".
+        let current = set(&[("dept-1", 10)]);
+        let desired = set(&[("dept-1", 20)]);
+
+        let diff = ReconcileDiff::compute(&current, &desired);
+
+        assert_eq!(diff.to_add, vec![("dept-1".to_string(), 20)]);
+        assert_eq!(diff.to_remove, vec![("dept-1".to_string(), 10)]);
+    }
+}

--- a/api/src/network/ledger.rs
+++ b/api/src/network/ledger.rs
@@ -43,6 +43,23 @@ async fn lock_network(tx: &mut PgConnection, network_id: i32) -> Result<(), sqlx
     Ok(())
 }
 
+/// Serializes every `network_reference` mutation for one holder against every
+/// other mutation for that holder. Without it, reconcile's read of what a
+/// holder currently holds could race a concurrent acquire/create adding a row
+/// on a `network_id` nothing has locked via `lock_network` yet - this makes
+/// that read-then-act atomic per holder. Salted (`1`) to avoid colliding with
+/// `network_content_lock_key`'s unsalted (`0`) hash in the same
+/// `pg_advisory_xact_lock(bigint)` keyspace.
+pub(crate) async fn lock_holder(tx: &mut PgConnection, holder: &str) -> Result<(), sqlx::Error> {
+    sqlx::query!(
+        "SELECT pg_advisory_xact_lock(pg_catalog.hashtextextended($1, 1))",
+        holder
+    )
+    .execute(tx)
+    .await?;
+    Ok(())
+}
+
 /// The one construction of a `network_reference` insert; shared verbatim by
 /// `acquire_reference` and `create_network`'s `reference` field so the two
 /// insert paths cannot silently diverge. Idempotent: re-registering an
@@ -76,6 +93,9 @@ pub(crate) async fn insert_reference(
 /// `network_reference`'s `ON DELETE RESTRICT` FK is why this order matters:
 /// both counts are verified zero first, so the delete below can never be the
 /// thing that would have violated it.
+///
+/// `e2e/tests/daemon_api.rs` hand-copies this check (can't call it directly -
+/// see that file's header); keep the two in sync.
 pub(crate) async fn collect_network(
     tx: &mut PgConnection,
     network_id: i32,
@@ -132,6 +152,9 @@ pub async fn acquire_reference(
         "Failed to begin acquire_reference transaction",
     ))?;
 
+    lock_holder(&mut tx, &holder)
+        .await
+        .map_err(internal_error("Failed to take holder lock"))?;
     lock_network(&mut tx, network_id)
         .await
         .map_err(internal_error("Failed to take network lock"))?;
@@ -188,6 +211,9 @@ pub async fn release_reference(
         "Failed to begin release_reference transaction",
     ))?;
 
+    lock_holder(&mut tx, &holder)
+        .await
+        .map_err(internal_error("Failed to take holder lock"))?;
     lock_network(&mut tx, network_id)
         .await
         .map_err(internal_error("Failed to take network lock"))?;
@@ -277,22 +303,23 @@ pub async fn reconcile_references(
         "Failed to begin reconcile_references transaction",
     ))?;
 
-    // Unlocked first pass: gather every network_id this call could touch (the
-    // pushed set plus whatever this holder currently holds) so every lock below
-    // can be taken in one ascending sweep, avoiding deadlock against another
-    // reconcile/acquire/release touching an overlapping set. A hold landing on
-    // a network_id in neither set, in the gap between this read and the locks
-    // below, is a known accepted residual race: the next scheduled reconcile
-    // call converges it regardless.
-    let current_before = fetch_holder_references(&mut tx, &holder)
+    // Taken before the read below, not after: that's what makes the read a
+    // complete, stable view of this holder's rows (see lock_holder's doc).
+    lock_holder(&mut tx, &holder)
         .await
-        .map_err(internal_error("Failed to read current references"))?;
+        .map_err(internal_error("Failed to take holder lock"))?;
+
+    let current: HashSet<(String, i32)> = fetch_holder_references(&mut tx, &holder)
+        .await
+        .map_err(internal_error("Failed to read current references"))?
+        .into_iter()
+        .collect();
 
     let mut lock_ids: Vec<i32> = body
         .keys
         .iter()
         .map(|k| k.network_id)
-        .chain(current_before.iter().map(|(_, id)| *id))
+        .chain(current.iter().map(|(_, id)| *id))
         .collect();
     lock_ids.sort_unstable();
     lock_ids.dedup();
@@ -302,12 +329,6 @@ pub async fn reconcile_references(
             .await
             .map_err(internal_error("Failed to take network lock"))?;
     }
-
-    let current: HashSet<(String, i32)> = fetch_holder_references(&mut tx, &holder)
-        .await
-        .map_err(internal_error("Failed to read current references"))?
-        .into_iter()
-        .collect();
 
     let desired: HashSet<(String, i32)> = body
         .keys

--- a/api/src/network/ledger.rs
+++ b/api/src/network/ledger.rs
@@ -43,7 +43,10 @@ pub struct ReconcileRequest {
 /// convention as `TELEMETRY_MAX_SERIALS`.
 const RECONCILE_MAX_KEYS: usize = 10_000;
 
-async fn lock_network(tx: &mut PgConnection, network_id: i32) -> Result<(), sqlx::Error> {
+pub(crate) async fn lock_network(
+    tx: &mut PgConnection,
+    network_id: i32,
+) -> Result<(), sqlx::Error> {
     sqlx::query!("SELECT pg_advisory_xact_lock($1)", i64::from(network_id))
         .execute(tx)
         .await?;

--- a/api/src/network/mod.rs
+++ b/api/src/network/mod.rs
@@ -1,2 +1,3 @@
 pub mod evaluation;
+pub mod ledger;
 pub mod route;

--- a/api/src/network/route.rs
+++ b/api/src/network/route.rs
@@ -257,12 +257,11 @@ fn security_type_for(
     resolve_security_type(security, password).map(Some)
 }
 
-/// The one construction of the insert-or-adopt-existing upsert; shared by both
-/// arms of `create_network`'s match (no prior match, and a matched row that
-/// turned out to have been collected before it could be touched). Safe by
-/// construction against a concurrent insert of the same content: Postgres's
-/// own conflict handling on `network_ident_uq` serializes that, no advisory
-/// lock needed here the way the matched-row path needs one.
+/// The one construction of the insert-or-adopt-existing upsert, shared by
+/// both arms of `create_network`'s match. Safe against a concurrent insert of
+/// the same content by construction - Postgres's own conflict handling on
+/// `network_ident_uq` serializes that, no advisory lock needed here the way
+/// the matched-row path needs one.
 async fn insert_or_conflict_network(
     tx: &mut PgConnection,
     new_network: &NewNetwork,
@@ -382,16 +381,13 @@ pub async fn create_network(
 
     let (status, network) = match existing_id {
         Some(id) => {
-            // The content lock above only protects the match query itself; it
-            // does not stop a concurrent release_reference/collect_network
-            // from deleting this exact matched row before the UPDATE below
-            // runs. Taking the same per-network_id lock every ledger mutation
-            // uses (see ledger::lock_network's callers) serializes against
-            // that: either this call proceeds first and the row survives to
-            // be updated, or a concurrent collection wins first and the
-            // fetch_optional below sees it gone. Without this, a release
-            // racing this exact match could 500 on the ON DELETE RESTRICT
-            // violation once this call's later insert_reference lands.
+            // The content lock above only protects the match query; it
+            // doesn't stop a concurrent release_reference/collect_network
+            // from deleting this exact matched row before the UPDATE below.
+            // This is the same per-network_id lock every other ledger
+            // mutation uses (see lock_network's other callers) - without it,
+            // a release racing this match could 500 on the ON DELETE
+            // RESTRICT violation once this call's insert_reference lands.
             lock_network(&mut tx, id)
                 .await
                 .map_err(internal_error("Failed to take network lock"))?;
@@ -417,10 +413,9 @@ pub async fn create_network(
 
             match existing {
                 Some(existing) => (StatusCode::OK, existing),
-                // The matched row was collected out from under us in the gap
-                // between the unlocked match query and the lock above - the
-                // same insert-or-conflict path the "no match" case uses is
-                // safe to fall back to here too.
+                // Collected out from under us in the gap between the unlocked
+                // match and the lock above - the "no match" case's
+                // insert-or-conflict path is a safe fallback.
                 None => (
                     StatusCode::CREATED,
                     insert_or_conflict_network(&mut tx, &new_network, security_type, &credentials)

--- a/api/src/network/route.rs
+++ b/api/src/network/route.rs
@@ -12,12 +12,13 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use smith::utils::schema::NetworkType;
 use smith::utils::schema::{Network, NetworkInfo, NewNetwork, SpeedSample};
+use sqlx::PgConnection;
 use tracing::{error, info, warn};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
 use super::evaluation::{Evaluation, evaluate};
-use super::ledger::{insert_reference, lock_holder};
+use super::ledger::{insert_reference, lock_holder, lock_network};
 
 pub(crate) const NETWORKS_TAG: &str = "networks";
 const EXTENDED_TEST_TAG: &str = "extended-network-test";
@@ -256,6 +257,40 @@ fn security_type_for(
     resolve_security_type(security, password).map(Some)
 }
 
+/// The one construction of the insert-or-adopt-existing upsert; shared by both
+/// arms of `create_network`'s match (no prior match, and a matched row that
+/// turned out to have been collected before it could be touched). Safe by
+/// construction against a concurrent insert of the same content: Postgres's
+/// own conflict handling on `network_ident_uq` serializes that, no advisory
+/// lock needed here the way the matched-row path needs one.
+async fn insert_or_conflict_network(
+    tx: &mut PgConnection,
+    new_network: &NewNetwork,
+    security_type: Option<&str>,
+    credentials: &Value,
+) -> Result<Network, sqlx::Error> {
+    sqlx::query_as!(
+        Network,
+        r#"
+        INSERT INTO network (network_type, is_network_hidden, ssid, name, description, password, security_type, credentials)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        ON CONFLICT ON CONSTRAINT network_ident_uq
+        DO UPDATE SET ssid = EXCLUDED.ssid
+        RETURNING id, network_type::TEXT as "network_type", is_network_hidden, ssid, name, description, 'secret' as password
+        "#,
+        new_network.network_type.clone() as NetworkType,
+        new_network.is_network_hidden,
+        new_network.ssid,
+        new_network.name,
+        new_network.description,
+        new_network.password,
+        security_type,
+        credentials,
+    )
+    .fetch_one(tx)
+    .await
+}
+
 #[utoipa::path(
     post,
     path = "/networks",
@@ -347,6 +382,20 @@ pub async fn create_network(
 
     let (status, network) = match existing_id {
         Some(id) => {
+            // The content lock above only protects the match query itself; it
+            // does not stop a concurrent release_reference/collect_network
+            // from deleting this exact matched row before the UPDATE below
+            // runs. Taking the same per-network_id lock every ledger mutation
+            // uses (see ledger::lock_network's callers) serializes against
+            // that: either this call proceeds first and the row survives to
+            // be updated, or a concurrent collection wins first and the
+            // fetch_optional below sees it gone. Without this, a release
+            // racing this exact match could 500 on the ON DELETE RESTRICT
+            // violation once this call's later insert_reference lands.
+            lock_network(&mut tx, id)
+                .await
+                .map_err(internal_error("Failed to take network lock"))?;
+
             // Heal in place exactly as ReportNMProfiles does (api/src/home.rs):
             // the relaxed match can only route a typed caller to a NULL row or an
             // already-equal typed row, so COALESCE fills unknown -> known and
@@ -362,10 +411,23 @@ pub async fn create_network(
                 id,
                 security_type as Option<&str>,
             )
-            .fetch_one(&mut *tx)
+            .fetch_optional(&mut *tx)
             .await
             .map_err(internal_error("Failed to fetch matched network"))?;
-            (StatusCode::OK, existing)
+
+            match existing {
+                Some(existing) => (StatusCode::OK, existing),
+                // The matched row was collected out from under us in the gap
+                // between the unlocked match query and the lock above - the
+                // same insert-or-conflict path the "no match" case uses is
+                // safe to fall back to here too.
+                None => (
+                    StatusCode::CREATED,
+                    insert_or_conflict_network(&mut tx, &new_network, security_type, &credentials)
+                        .await
+                        .map_err(internal_error("Failed to insert network"))?,
+                ),
+            }
         }
         None => {
             // Defensive fallback for a lock-bypass race the advisory lock above
@@ -375,27 +437,10 @@ pub async fn create_network(
             // conflict detection is exact-equality only) - see arch.md's
             // rejected-alternatives note. Only safe because this caller never
             // supplies identity/enterprise security_type; revisit if it ever does.
-            let created = sqlx::query_as!(
-                Network,
-                r#"
-                INSERT INTO network (network_type, is_network_hidden, ssid, name, description, password, security_type, credentials)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-                ON CONFLICT ON CONSTRAINT network_ident_uq
-                DO UPDATE SET ssid = EXCLUDED.ssid
-                RETURNING id, network_type::TEXT as "network_type", is_network_hidden, ssid, name, description, 'secret' as password
-                "#,
-                new_network.network_type as NetworkType,
-                new_network.is_network_hidden,
-                new_network.ssid,
-                new_network.name,
-                new_network.description,
-                new_network.password,
-                security_type as Option<&str>,
-                credentials,
-            )
-            .fetch_one(&mut *tx)
-            .await
-            .map_err(internal_error("Failed to insert network"))?;
+            let created =
+                insert_or_conflict_network(&mut tx, &new_network, security_type, &credentials)
+                    .await
+                    .map_err(internal_error("Failed to insert network"))?;
             (StatusCode::CREATED, created)
         }
     };

--- a/api/src/network/route.rs
+++ b/api/src/network/route.rs
@@ -17,7 +17,7 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 use super::evaluation::{Evaluation, evaluate};
-use super::ledger::insert_reference;
+use super::ledger::{insert_reference, lock_holder};
 
 pub(crate) const NETWORKS_TAG: &str = "networks";
 const EXTENDED_TEST_TAG: &str = "extended-network-test";
@@ -305,6 +305,18 @@ pub async fn create_network(
         .await
         .map_err(internal_error("Failed to begin create_network transaction"))?;
 
+    // Taken before the content lock so a concurrent reconcile's read of this
+    // holder's rows can't miss the one this call is about to add (see
+    // lock_holder's doc). `holder` is `Some` by construction - the guard
+    // above already rejected `reference.is_some() && holder.is_none()`.
+    if new_network.reference.is_some()
+        && let Some(holder) = &holder
+    {
+        lock_holder(&mut tx, holder)
+            .await
+            .map_err(internal_error("Failed to take holder lock"))?;
+    }
+
     // Race-tested in e2e/tests/daemon_api.rs
     // (concurrent_identical_network_posts_converge_to_one_row).
     sqlx::query!(
@@ -390,10 +402,13 @@ pub async fn create_network(
 
     // Same transaction as the upsert above: the network row and its ledger
     // hold either both exist after this call or neither does. `holder` is
-    // Some here by construction - checked at the top of this function before
-    // any DB work happened.
+    // `Some` here by construction (guard above), but this fails safe instead
+    // of unwrapping in case that guard is ever weakened or reordered.
     if let Some(reference) = new_network.reference {
-        let holder = holder.expect("checked before create_network's transaction began");
+        let Some(holder) = holder else {
+            error!("create_network reached the reference-insert step with no holder");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        };
         insert_reference(&mut tx, &holder, &reference.external_key, network.id)
             .await
             .map_err(internal_error("Failed to insert network reference"))?;

--- a/api/src/network/route.rs
+++ b/api/src/network/route.rs
@@ -1,4 +1,5 @@
 use crate::State;
+use crate::holder::Holder;
 use crate::user::CurrentUser;
 use axum::http::StatusCode;
 use axum::response::Result;
@@ -16,8 +17,9 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 use super::evaluation::{Evaluation, evaluate};
+use super::ledger::insert_reference;
 
-const NETWORKS_TAG: &str = "networks";
+pub(crate) const NETWORKS_TAG: &str = "networks";
 const EXTENDED_TEST_TAG: &str = "extended-network-test";
 
 #[derive(Debug, serde::Deserialize)]
@@ -193,9 +195,10 @@ fn network_type_label(network_type: &NetworkType) -> &'static str {
     }
 }
 
-/// Every failure in `create_network` is an opaque 500 to the caller; only the log
-/// line differs. Keeps the handler readable instead of repeating the same closure.
-fn internal_error(context: &'static str) -> impl Fn(sqlx::Error) -> StatusCode {
+/// Every failure in `create_network` (and, reused, the ledger handlers in
+/// `super::ledger`) is an opaque 500 to the caller; only the log line differs.
+/// Keeps handlers readable instead of repeating the same closure.
+pub(crate) fn internal_error(context: &'static str) -> impl Fn(sqlx::Error) -> StatusCode {
     move |err| {
         error!("{context}: {err}");
         StatusCode::INTERNAL_SERVER_ERROR
@@ -269,8 +272,16 @@ fn security_type_for(
 )]
 pub async fn create_network(
     Extension(state): Extension<State>,
+    Extension(Holder(holder)): Extension<Holder>,
     Json(new_network): Json<NewNetwork>,
 ) -> Result<(StatusCode, Json<Network>), StatusCode> {
+    // Checked before any DB work: a caller with no resolved holder cannot
+    // register a reference, full stop, regardless of what else the call would
+    // have done.
+    if new_network.reference.is_some() && holder.is_none() {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
     let security_type: Option<&str> = security_type_for(
         &new_network.network_type,
         new_network.security.as_deref(),
@@ -376,6 +387,17 @@ pub async fn create_network(
             (StatusCode::CREATED, created)
         }
     };
+
+    // Same transaction as the upsert above: the network row and its ledger
+    // hold either both exist after this call or neither does. `holder` is
+    // Some here by construction - checked at the top of this function before
+    // any DB work happened.
+    if let Some(reference) = new_network.reference {
+        let holder = holder.expect("checked before create_network's transaction began");
+        insert_reference(&mut tx, &holder, &reference.external_key, network.id)
+            .await
+            .map_err(internal_error("Failed to insert network reference"))?;
+    }
 
     tx.commit().await.map_err(internal_error(
         "Failed to commit create_network transaction",

--- a/e2e/tests/daemon_api.rs
+++ b/e2e/tests/daemon_api.rs
@@ -826,8 +826,9 @@ async fn acquire_reference_is_idempotent() -> Result<()> {
 }
 
 /// Mirrors `release_reference`: delete the ledger row, then `collect_network`'s
-/// check. With zero ledger rows and zero internal FK references, the network
-/// row itself must be deleted as a side effect.
+/// check (hand-copied - keep in sync). With zero ledger rows and zero
+/// internal FK references, the network row itself must be deleted as a
+/// side effect.
 #[tokio::test]
 #[ignore = "requires running compose stack; use make test.e2e"]
 async fn release_last_reference_collects_unreferenced_network() -> Result<()> {
@@ -1096,6 +1097,10 @@ async fn hard_delete_fails_on_a_held_network() -> Result<()> {
 /// real concurrency. N tasks lock the *same two* network ids in ascending
 /// order, racing on which gets there first; drop the ordering and this
 /// reliably deadlocks, keep it and every task completes.
+///
+/// Simulates the invariant rather than calling `reconcile_references`'s own
+/// `.sort_unstable()` (same reason as every other test in this section): a
+/// regression that drops that call from `ledger.rs` would slip past this.
 #[tokio::test]
 #[ignore = "requires running compose stack; use make test.e2e"]
 async fn ascending_lock_order_avoids_deadlock_under_concurrency() -> Result<()> {

--- a/e2e/tests/daemon_api.rs
+++ b/e2e/tests/daemon_api.rs
@@ -704,3 +704,446 @@ async fn typed_match_prefers_exact_row_over_mismatched_type() -> Result<()> {
 
     Ok(())
 }
+
+// --- Reference ledger -----------------------------------------------------
+//
+// The ledger endpoints (`POST/DELETE /networks/{id}/references`,
+// `POST /networks/references/reconcile`) sit behind the Auth0 `check()`
+// middleware, which this harness has no way to mint a token for (see this
+// file's own top comment: every scenario here drives Postgres directly
+// instead, exactly as the dashboard's Auth0-gated routes already do). So,
+// like `concurrent_identical_network_posts_converge_to_one_row` above, these
+// tests replicate the handlers' SQL directly rather than going over HTTP.
+// The pure reconcile-diff algorithm itself (add/remove set computation) is
+// covered separately by unit tests in `api/src/network/ledger.rs`; what's
+// worth an e2e test is the DB-only behavior a unit test can't reach: locking,
+// the `ON DELETE RESTRICT` interaction, and transaction atomicity.
+
+/// `network_has_internal_reference` only exists once the reference ledger's
+/// application code has landed; its absence means a released-api
+/// version-skew run, not a bug.
+async fn has_reference_ledger(ctx: &Ctx) -> Result<bool> {
+    sqlx::query_scalar(
+        "SELECT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'network_has_internal_reference')",
+    )
+    .fetch_one(&ctx.db)
+    .await
+    .context("checking for network_has_internal_reference")
+}
+
+/// Minimal wifi network row for ledger tests: `security_type` must be set
+/// (a wifi-scoped CHECK requires it), everything else can be a placeholder.
+async fn insert_test_network(ctx: &Ctx, ssid: &str) -> Result<i32> {
+    sqlx::query_scalar(
+        "INSERT INTO network (network_type, is_network_hidden, ssid, name, security_type)
+         VALUES ('wifi', false, $1, $1, 'open')
+         RETURNING id",
+    )
+    .bind(ssid)
+    .fetch_one(&ctx.db)
+    .await
+    .context("inserting test network")
+}
+
+async fn insert_reference(
+    ctx: &Ctx,
+    holder: &str,
+    external_key: &str,
+    network_id: i32,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO network_reference (holder, external_key, network_id)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (holder, external_key, network_id) DO NOTHING",
+    )
+    .bind(holder)
+    .bind(external_key)
+    .bind(network_id)
+    .execute(&ctx.db)
+    .await
+    .context("inserting test network_reference")?;
+    Ok(())
+}
+
+async fn network_reference_count(ctx: &Ctx, network_id: i32) -> Result<i64> {
+    sqlx::query_scalar("SELECT count(*) FROM network_reference WHERE network_id = $1")
+        .bind(network_id)
+        .fetch_one(&ctx.db)
+        .await
+        .context("counting network_reference rows")
+}
+
+async fn network_exists(ctx: &Ctx, network_id: i32) -> Result<bool> {
+    sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM network WHERE id = $1)")
+        .bind(network_id)
+        .fetch_one(&ctx.db)
+        .await
+        .context("checking network existence")
+}
+
+/// Mirrors `acquire_reference`'s insert: `ON CONFLICT DO NOTHING` on the full
+/// `(holder, external_key, network_id)` triple.
+#[tokio::test]
+#[ignore = "requires running compose stack; use make test.e2e"]
+async fn acquire_reference_is_idempotent() -> Result<()> {
+    let ctx = Ctx::connect().await?;
+    wait_for_api(&ctx).await?;
+    if !has_reference_ledger(&ctx).await? {
+        println!("skipping acquire_reference_is_idempotent: ledger not present (version-skew job)");
+        return Ok(());
+    }
+
+    let ssid = format!("e2e-ledger-acquire-{}", uuid::Uuid::new_v4());
+    let outcome: Result<i64> = async {
+        let network_id = insert_test_network(&ctx, &ssid).await?;
+        insert_reference(&ctx, "app_api", &ssid, network_id).await?;
+        insert_reference(&ctx, "app_api", &ssid, network_id).await?; // idempotent repeat
+        network_reference_count(&ctx, network_id).await
+    }
+    .await;
+
+    sqlx::query("DELETE FROM network WHERE ssid = $1")
+        .bind(&ssid)
+        .execute(&ctx.db)
+        .await
+        .context("cleaning up acquire-idempotency network")?;
+
+    let count = outcome?;
+    ensure!(
+        count == 1,
+        "expected exactly one reference row, got {count}"
+    );
+    Ok(())
+}
+
+/// Mirrors `release_reference`: delete the ledger row, then `collect_network`'s
+/// check. With zero ledger rows and zero internal FK references, the network
+/// row itself must be deleted as a side effect.
+#[tokio::test]
+#[ignore = "requires running compose stack; use make test.e2e"]
+async fn release_last_reference_collects_unreferenced_network() -> Result<()> {
+    let ctx = Ctx::connect().await?;
+    wait_for_api(&ctx).await?;
+    if !has_reference_ledger(&ctx).await? {
+        println!(
+            "skipping release_last_reference_collects_unreferenced_network: \
+             ledger not present (version-skew job)"
+        );
+        return Ok(());
+    }
+
+    let ssid = format!("e2e-ledger-collect-{}", uuid::Uuid::new_v4());
+    let outcome: Result<bool> = async {
+        let network_id = insert_test_network(&ctx, &ssid).await?;
+        insert_reference(&ctx, "app_api", &ssid, network_id).await?;
+
+        let mut tx = ctx.db.begin().await?;
+        sqlx::query("SELECT pg_advisory_xact_lock($1)")
+            .bind(i64::from(network_id))
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query(
+            "DELETE FROM network_reference WHERE holder = $1 AND external_key = $2 AND network_id = $3",
+        )
+        .bind("app_api")
+        .bind(&ssid)
+        .bind(network_id)
+        .execute(&mut *tx)
+        .await?;
+        let has_ledger_ref: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM network_reference WHERE network_id = $1)")
+                .bind(network_id)
+                .fetch_one(&mut *tx)
+                .await?;
+        let has_internal_ref: bool =
+            sqlx::query_scalar("SELECT network_has_internal_reference($1)")
+                .bind(network_id)
+                .fetch_one(&mut *tx)
+                .await?;
+        if !has_ledger_ref && !has_internal_ref {
+            sqlx::query("DELETE FROM network WHERE id = $1")
+                .bind(network_id)
+                .execute(&mut *tx)
+                .await?;
+        }
+        tx.commit().await?;
+
+        network_exists(&ctx, network_id).await
+    }
+    .await;
+
+    sqlx::query("DELETE FROM network WHERE ssid = $1")
+        .bind(&ssid)
+        .execute(&ctx.db)
+        .await
+        .context("cleaning up collect-on-release network")?;
+
+    ensure!(
+        !outcome?,
+        "network with zero ledger and zero internal references should have been collected"
+    );
+    Ok(())
+}
+
+/// Same mechanism as above, but a `device_configured_network` row still points
+/// at the network: `collect_network` must leave it alone even though its
+/// ledger reference count just hit zero.
+#[tokio::test]
+#[ignore = "requires running compose stack; use make test.e2e"]
+async fn release_does_not_collect_while_internal_reference_remains() -> Result<()> {
+    let (ctx, device_id) = setup().await?;
+    if !has_reference_ledger(&ctx).await? {
+        println!(
+            "skipping release_does_not_collect_while_internal_reference_remains: \
+             ledger not present (version-skew job)"
+        );
+        return Ok(());
+    }
+
+    let ssid = format!("e2e-ledger-internal-{}", uuid::Uuid::new_v4());
+    let outcome: Result<bool> = async {
+        let network_id = insert_test_network(&ctx, &ssid).await?;
+        insert_reference(&ctx, "app_api", &ssid, network_id).await?;
+        sqlx::query(
+            "INSERT INTO device_configured_network (device_id, network_id, profile_name)
+             VALUES ($1, $2, $3)",
+        )
+        .bind(device_id)
+        .bind(network_id)
+        .bind(&ssid)
+        .execute(&ctx.db)
+        .await?;
+
+        let mut tx = ctx.db.begin().await?;
+        sqlx::query("SELECT pg_advisory_xact_lock($1)")
+            .bind(i64::from(network_id))
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query(
+            "DELETE FROM network_reference WHERE holder = $1 AND external_key = $2 AND network_id = $3",
+        )
+        .bind("app_api")
+        .bind(&ssid)
+        .bind(network_id)
+        .execute(&mut *tx)
+        .await?;
+        let has_internal_ref: bool =
+            sqlx::query_scalar("SELECT network_has_internal_reference($1)")
+                .bind(network_id)
+                .fetch_one(&mut *tx)
+                .await?;
+        if !has_internal_ref {
+            sqlx::query("DELETE FROM network WHERE id = $1")
+                .bind(network_id)
+                .execute(&mut *tx)
+                .await?;
+        }
+        tx.commit().await?;
+
+        network_exists(&ctx, network_id).await
+    }
+    .await;
+
+    sqlx::query("DELETE FROM device_configured_network WHERE network_id IN (SELECT id FROM network WHERE ssid = $1)")
+        .bind(&ssid)
+        .execute(&ctx.db)
+        .await
+        .context("cleaning up configured-network row")?;
+    sqlx::query("DELETE FROM network WHERE ssid = $1")
+        .bind(&ssid)
+        .execute(&ctx.db)
+        .await
+        .context("cleaning up internal-reference network")?;
+
+    ensure!(
+        outcome?,
+        "network with a surviving device_configured_network row must not be collected"
+    );
+    Ok(())
+}
+
+/// Mirrors `reconcile_references`' atomicity: one bad element (a `network_id`
+/// with no matching `network` row, tripping the FK) must roll back every
+/// insert the same call already staged, not just skip the bad one.
+#[tokio::test]
+#[ignore = "requires running compose stack; use make test.e2e"]
+async fn reconcile_rolls_back_entirely_on_invalid_element() -> Result<()> {
+    let ctx = Ctx::connect().await?;
+    wait_for_api(&ctx).await?;
+    if !has_reference_ledger(&ctx).await? {
+        println!(
+            "skipping reconcile_rolls_back_entirely_on_invalid_element: \
+             ledger not present (version-skew job)"
+        );
+        return Ok(());
+    }
+
+    let ssid = format!("e2e-ledger-reconcile-atomic-{}", uuid::Uuid::new_v4());
+    let holder = format!("e2e-holder-{}", uuid::Uuid::new_v4());
+    let outcome: Result<i64> = async {
+        let network_id = insert_test_network(&ctx, &ssid).await?;
+        // Same nonexistent id every run would collide across parallel test
+        // runs sharing the same DB; derive one from a value that cannot exist
+        // (negative ids are never issued by the IDENTITY sequence).
+        let bogus_network_id = -1;
+
+        let mut tx = ctx.db.begin().await?;
+        let good_insert = sqlx::query(
+            "INSERT INTO network_reference (holder, external_key, network_id) VALUES ($1, $2, $3)",
+        )
+        .bind(&holder)
+        .bind(&ssid)
+        .bind(network_id)
+        .execute(&mut *tx)
+        .await;
+        ensure!(
+            good_insert.is_ok(),
+            "the valid insert should not fail on its own"
+        );
+
+        let bad_insert = sqlx::query(
+            "INSERT INTO network_reference (holder, external_key, network_id) VALUES ($1, $2, $3)",
+        )
+        .bind(&holder)
+        .bind(&ssid)
+        .bind(bogus_network_id)
+        .execute(&mut *tx)
+        .await;
+        ensure!(
+            bad_insert.is_err(),
+            "inserting a reference for a nonexistent network_id should violate the FK"
+        );
+        // A real reconcile call would map this into a 500 and let axum/sqlx
+        // drop (roll back) the transaction; explicit here for clarity.
+        tx.rollback().await?;
+
+        network_reference_count(&ctx, network_id).await
+    }
+    .await;
+
+    sqlx::query("DELETE FROM network WHERE ssid = $1")
+        .bind(&ssid)
+        .execute(&ctx.db)
+        .await
+        .context("cleaning up reconcile-atomicity network")?;
+
+    let count = outcome?;
+    ensure!(
+        count == 0,
+        "the valid insert must not survive the rollback triggered by the invalid one, got {count} rows"
+    );
+    Ok(())
+}
+
+/// `network_reference`'s `ON DELETE RESTRICT` FK means the existing public
+/// `DELETE /networks/{id}` can no longer silently orphan a held network now
+/// that the ledger exists: it must fail instead.
+#[tokio::test]
+#[ignore = "requires running compose stack; use make test.e2e"]
+async fn hard_delete_fails_on_a_held_network() -> Result<()> {
+    let ctx = Ctx::connect().await?;
+    wait_for_api(&ctx).await?;
+    if !has_reference_ledger(&ctx).await? {
+        println!(
+            "skipping hard_delete_fails_on_a_held_network: ledger not present (version-skew job)"
+        );
+        return Ok(());
+    }
+
+    let ssid = format!("e2e-ledger-restrict-{}", uuid::Uuid::new_v4());
+    let outcome: Result<bool> = async {
+        let network_id = insert_test_network(&ctx, &ssid).await?;
+        insert_reference(&ctx, "app_api", &ssid, network_id).await?;
+
+        let delete_result = sqlx::query("DELETE FROM network WHERE id = $1")
+            .bind(network_id)
+            .execute(&ctx.db)
+            .await;
+        Ok(delete_result.is_err())
+    }
+    .await;
+
+    sqlx::query("DELETE FROM network_reference WHERE external_key = $1")
+        .bind(&ssid)
+        .execute(&ctx.db)
+        .await
+        .context("cleaning up restrict-test reference")?;
+    sqlx::query("DELETE FROM network WHERE ssid = $1")
+        .bind(&ssid)
+        .execute(&ctx.db)
+        .await
+        .context("cleaning up restrict-test network")?;
+
+    ensure!(
+        outcome?,
+        "DELETE FROM network on a held network should fail under ON DELETE RESTRICT"
+    );
+    Ok(())
+}
+
+/// `reconcile_references` locks every network_id it touches in ascending
+/// order specifically to avoid deadlocking against another overlapping
+/// reconcile/acquire/release call - a claim that only means something under
+/// real concurrency. N tasks lock the *same two* network ids in ascending
+/// order, racing on which gets there first; drop the ordering and this
+/// reliably deadlocks, keep it and every task completes.
+#[tokio::test]
+#[ignore = "requires running compose stack; use make test.e2e"]
+async fn ascending_lock_order_avoids_deadlock_under_concurrency() -> Result<()> {
+    let ctx = Ctx::connect().await?;
+    wait_for_api(&ctx).await?;
+    if !has_reference_ledger(&ctx).await? {
+        println!(
+            "skipping ascending_lock_order_avoids_deadlock_under_concurrency: \
+             ledger not present (version-skew job)"
+        );
+        return Ok(());
+    }
+
+    let ssid_a = format!("e2e-ledger-lock-a-{}", uuid::Uuid::new_v4());
+    let ssid_b = format!("e2e-ledger-lock-b-{}", uuid::Uuid::new_v4());
+    let outcome: Result<()> = async {
+        let mut id_a = insert_test_network(&ctx, &ssid_a).await?;
+        let mut id_b = insert_test_network(&ctx, &ssid_b).await?;
+        if id_a > id_b {
+            std::mem::swap(&mut id_a, &mut id_b);
+        }
+
+        const WRITERS: usize = 8;
+        let mut writers = Vec::with_capacity(WRITERS);
+        for _ in 0..WRITERS {
+            let pool = ctx.db.clone();
+            writers.push(tokio::spawn(async move {
+                let mut tx = pool.begin().await?;
+                // Ascending order, every task, every time - the invariant
+                // `reconcile_references` relies on.
+                sqlx::query("SELECT pg_advisory_xact_lock($1)")
+                    .bind(i64::from(id_a))
+                    .execute(&mut *tx)
+                    .await?;
+                sqlx::query("SELECT pg_advisory_xact_lock($1)")
+                    .bind(i64::from(id_b))
+                    .execute(&mut *tx)
+                    .await?;
+                tx.commit().await?;
+                anyhow::Ok(())
+            }));
+        }
+
+        for writer in writers {
+            writer.await.context("lock-order writer task panicked")??;
+        }
+        Ok(())
+    }
+    .await;
+
+    sqlx::query("DELETE FROM network WHERE ssid IN ($1, $2)")
+        .bind(&ssid_a)
+        .bind(&ssid_b)
+        .execute(&ctx.db)
+        .await
+        .context("cleaning up lock-order networks")?;
+
+    outcome.context("concurrent ascending-order lockers should all complete without deadlock")?;
+    Ok(())
+}

--- a/e2e/tests/daemon_api.rs
+++ b/e2e/tests/daemon_api.rs
@@ -909,10 +909,9 @@ async fn release_last_reference_collects_unreferenced_network() -> Result<()> {
 }
 
 /// A release whose `(holder, external_key, network_id)` matches no row must
-/// not attempt collection at all - otherwise any authenticated holder could
-/// use a network_id/external_key it never registered to garbage-collect a
-/// network it has no relationship to, merely because that network happened
-/// to be at zero references already.
+/// not attempt collection - otherwise any holder could garbage-collect a
+/// network it has no relationship to, just by guessing a network_id/
+/// external_key it never registered.
 #[tokio::test]
 #[ignore = "requires running compose stack; use make test.e2e"]
 async fn release_of_an_unheld_reference_does_not_collect() -> Result<()> {
@@ -928,9 +927,8 @@ async fn release_of_an_unheld_reference_does_not_collect() -> Result<()> {
 
     let ssid = format!("e2e-ledger-unheld-release-{}", uuid::Uuid::new_v4());
     let outcome: Result<bool> = async {
-        // No insert_reference call: this network already has zero ledger and
-        // zero internal references from the moment it's created - exactly
-        // the state a buggy/unauthorized release must not be able to exploit.
+        // No insert_reference call: this network has zero references from
+        // creation - the exact state an unauthorized release must not exploit.
         let network_id = insert_test_network(&ctx, &ssid).await?;
 
         let mut tx = ctx.db.begin().await?;

--- a/e2e/tests/daemon_api.rs
+++ b/e2e/tests/daemon_api.rs
@@ -802,6 +802,15 @@ async fn acquire_reference_is_idempotent() -> Result<()> {
     }
     .await;
 
+    // network_reference's ON DELETE RESTRICT means the network row can't go
+    // first: this test leaves a real, committed reference behind (unlike
+    // e.g. release_last_reference_collects_unreferenced_network, which clears
+    // its own reference as part of what it's testing).
+    sqlx::query("DELETE FROM network_reference WHERE external_key = $1")
+        .bind(&ssid)
+        .execute(&ctx.db)
+        .await
+        .context("cleaning up acquire-idempotency reference")?;
     sqlx::query("DELETE FROM network WHERE ssid = $1")
         .bind(&ssid)
         .execute(&ctx.db)

--- a/e2e/tests/daemon_api.rs
+++ b/e2e/tests/daemon_api.rs
@@ -852,29 +852,33 @@ async fn release_last_reference_collects_unreferenced_network() -> Result<()> {
             .bind(i64::from(network_id))
             .execute(&mut *tx)
             .await?;
-        sqlx::query(
+        let rows_affected = sqlx::query(
             "DELETE FROM network_reference WHERE holder = $1 AND external_key = $2 AND network_id = $3",
         )
         .bind("app_api")
         .bind(&ssid)
         .bind(network_id)
         .execute(&mut *tx)
-        .await?;
-        let has_ledger_ref: bool =
-            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM network_reference WHERE network_id = $1)")
-                .bind(network_id)
-                .fetch_one(&mut *tx)
-                .await?;
-        let has_internal_ref: bool =
-            sqlx::query_scalar("SELECT network_has_internal_reference($1)")
-                .bind(network_id)
-                .fetch_one(&mut *tx)
-                .await?;
-        if !has_ledger_ref && !has_internal_ref {
-            sqlx::query("DELETE FROM network WHERE id = $1")
-                .bind(network_id)
-                .execute(&mut *tx)
-                .await?;
+        .await?
+        .rows_affected();
+        if rows_affected > 0 {
+            let has_ledger_ref: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM network_reference WHERE network_id = $1)",
+            )
+            .bind(network_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let has_internal_ref: bool =
+                sqlx::query_scalar("SELECT network_has_internal_reference($1)")
+                    .bind(network_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            if !has_ledger_ref && !has_internal_ref {
+                sqlx::query("DELETE FROM network WHERE id = $1")
+                    .bind(network_id)
+                    .execute(&mut *tx)
+                    .await?;
+            }
         }
         tx.commit().await?;
 
@@ -900,6 +904,83 @@ async fn release_last_reference_collects_unreferenced_network() -> Result<()> {
     ensure!(
         !outcome?,
         "network with zero ledger and zero internal references should have been collected"
+    );
+    Ok(())
+}
+
+/// A release whose `(holder, external_key, network_id)` matches no row must
+/// not attempt collection at all - otherwise any authenticated holder could
+/// use a network_id/external_key it never registered to garbage-collect a
+/// network it has no relationship to, merely because that network happened
+/// to be at zero references already.
+#[tokio::test]
+#[ignore = "requires running compose stack; use make test.e2e"]
+async fn release_of_an_unheld_reference_does_not_collect() -> Result<()> {
+    let ctx = Ctx::connect().await?;
+    wait_for_api(&ctx).await?;
+    if !has_reference_ledger(&ctx).await? {
+        println!(
+            "skipping release_of_an_unheld_reference_does_not_collect: \
+             ledger not present (version-skew job)"
+        );
+        return Ok(());
+    }
+
+    let ssid = format!("e2e-ledger-unheld-release-{}", uuid::Uuid::new_v4());
+    let outcome: Result<bool> = async {
+        // No insert_reference call: this network already has zero ledger and
+        // zero internal references from the moment it's created - exactly
+        // the state a buggy/unauthorized release must not be able to exploit.
+        let network_id = insert_test_network(&ctx, &ssid).await?;
+
+        let mut tx = ctx.db.begin().await?;
+        sqlx::query("SELECT pg_advisory_xact_lock($1)")
+            .bind(i64::from(network_id))
+            .execute(&mut *tx)
+            .await?;
+        let rows_affected = sqlx::query(
+            "DELETE FROM network_reference WHERE holder = $1 AND external_key = $2 AND network_id = $3",
+        )
+        .bind("app_api")
+        .bind("never-registered-key")
+        .bind(network_id)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected();
+        if rows_affected > 0 {
+            let has_ledger_ref: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM network_reference WHERE network_id = $1)",
+            )
+            .bind(network_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let has_internal_ref: bool =
+                sqlx::query_scalar("SELECT network_has_internal_reference($1)")
+                    .bind(network_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            if !has_ledger_ref && !has_internal_ref {
+                sqlx::query("DELETE FROM network WHERE id = $1")
+                    .bind(network_id)
+                    .execute(&mut *tx)
+                    .await?;
+            }
+        }
+        tx.commit().await?;
+
+        network_exists(&ctx, network_id).await
+    }
+    .await;
+
+    sqlx::query("DELETE FROM network WHERE ssid = $1")
+        .bind(&ssid)
+        .execute(&ctx.db)
+        .await
+        .context("cleaning up unheld-release network")?;
+
+    ensure!(
+        outcome?,
+        "a release matching no hold must not collect an unrelated network"
     );
     Ok(())
 }

--- a/e2e/tests/daemon_api.rs
+++ b/e2e/tests/daemon_api.rs
@@ -882,6 +882,15 @@ async fn release_last_reference_collects_unreferenced_network() -> Result<()> {
     }
     .await;
 
+    // In the expected (success) path the reference is already gone by the
+    // time the transaction above commits, but if the test body errors before
+    // that commit, the reference `insert_reference` created up front is still
+    // real and committed - same reasoning as acquire_reference_is_idempotent.
+    sqlx::query("DELETE FROM network_reference WHERE external_key = $1")
+        .bind(&ssid)
+        .execute(&ctx.db)
+        .await
+        .context("cleaning up collect-on-release reference")?;
     sqlx::query("DELETE FROM network WHERE ssid = $1")
         .bind(&ssid)
         .execute(&ctx.db)
@@ -959,6 +968,13 @@ async fn release_does_not_collect_while_internal_reference_remains() -> Result<(
         .execute(&ctx.db)
         .await
         .context("cleaning up configured-network row")?;
+    // Same reasoning as the sibling collect-on-release test above: a
+    // committed reference can outlive an errored test body.
+    sqlx::query("DELETE FROM network_reference WHERE external_key = $1")
+        .bind(&ssid)
+        .execute(&ctx.db)
+        .await
+        .context("cleaning up internal-reference reference")?;
     sqlx::query("DELETE FROM network WHERE ssid = $1")
         .bind(&ssid)
         .execute(&ctx.db)
@@ -972,9 +988,12 @@ async fn release_does_not_collect_while_internal_reference_remains() -> Result<(
     Ok(())
 }
 
-/// Mirrors `reconcile_references`' atomicity: one bad element (a `network_id`
-/// with no matching `network` row, tripping the FK) must roll back every
-/// insert the same call already staged, not just skip the bad one.
+/// Mirrors the transaction-level guarantee `reconcile_references` relies on:
+/// an insert referencing a nonexistent `network_id` must roll back every
+/// insert the same transaction already staged, not just skip the bad one.
+/// `reconcile_references` itself now pre-validates `to_add` network_ids and
+/// returns `400` before this FK path is ever reached in practice; this test
+/// exercises the underlying DB guarantee directly as a backstop.
 #[tokio::test]
 #[ignore = "requires running compose stack; use make test.e2e"]
 async fn reconcile_rolls_back_entirely_on_invalid_element() -> Result<()> {
@@ -1023,8 +1042,8 @@ async fn reconcile_rolls_back_entirely_on_invalid_element() -> Result<()> {
             bad_insert.is_err(),
             "inserting a reference for a nonexistent network_id should violate the FK"
         );
-        // A real reconcile call would map this into a 500 and let axum/sqlx
-        // drop (roll back) the transaction; explicit here for clarity.
+        // Explicit for clarity; a dropped, uncommitted transaction rolls back
+        // the same way.
         tx.rollback().await?;
 
         network_reference_count(&ctx, network_id).await

--- a/smithd/src/utils/schema.rs
+++ b/smithd/src/utils/schema.rs
@@ -503,6 +503,16 @@ pub struct NewNetwork {
     /// Absent for older callers; falls back to the password heuristic.
     #[serde(default)]
     pub security: Option<String>,
+    /// Atomically register a ledger hold on the returned network id, in the
+    /// same transaction as the upsert. Never carries `holder`: that is derived
+    /// server-side from the caller's M2M identity, not client-supplied.
+    #[serde(default)]
+    pub reference: Option<NewReference>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct NewReference {
+    pub external_key: String,
 }
 
 // Extended network test types


### PR DESCRIPTION
## What
Adds a reference ledger (acquire/release/reconcile) so Smith can safely delete `network` rows once no internal reference and no external holder (App API) references them anymore, replacing the current "never delete" posture with a real ownership handshake.

## Why
Smith's `network` table is shared across two databases that can't see each other: Smith's own FKs (internal references) and App API's `network_smith` mapping (external references). Neither classic mechanism (reference counting or mark-and-sweep) works alone when the count lives in two places. This gives Smith sole ownership of both counts, so deletion becomes a local decision instead of needing cross-database reads.

## Approach
- `holder` (who is allowed to hold a reference) is derived **server-side** from the caller's M2M JWT (`claims.sub` matched against a small `Config.known_holders` allowlist), never read from a request body. This closes the obvious spoofing angle - there's no field a caller could lie in. `api/src/holder.rs`, `api/src/config.rs`, `api/src/middlewares/authentication/mod.rs`.
- Three new endpoints plus one extension of an existing one, all under the already-authenticated `protected_router`:
  - `POST /networks/{id}/references` (acquire, idempotent)
  - `DELETE /networks/{id}/references` (release; collects the network row as a side effect if it's now fully unreferenced)
  - `POST /networks/references/reconcile` (set-convergent: makes a holder's ledger rows exactly match a pushed key set, healing missed acquires/releases)
  - `POST /networks` gains an optional `reference` field to atomically register a hold in the same transaction as the upsert

  All in `api/src/network/ledger.rs` (new).
- Every mutation for a given `network_id` is serialized through `pg_advisory_xact_lock(network_id)`, plus a second lock per holder (`pg_advisory_xact_lock(hashtextextended(holder, 1))`) so reconcile's "read what this holder currently holds, then diff" can never race a concurrent acquire/release/create for the same holder - this was a real gap caught in code review and fixed before merge, not present in the original design.
- **Rejected**: bare `external_key` strings in reconcile's key set (the ledger's primary key already supports one holder referencing several `network_id`s per key - a bare-string wire contract would make that unreachable); a two-call "POST then acquire" flow for the create path (collapsed to one round trip via the `reference` field); a dedicated seed script for the ledger's initial state (a holder's first reconcile push computes and applies that diff for free); non-transactional reconcile (transactional is free and removes a whole class of "which half landed" debugging).
- **Deliberately not in this PR**: a background sweep that collects rows nothing references anymore. It can't ship until the external caller (App API) has its own client work in place and has pushed at least one reconcile against production data - otherwise it risks deleting rows App API still considers live but hasn't registered a hold for yet. Follow-up work, tracked separately.

## Testing
- [x] `cargo build --workspace`, `cargo clippy --workspace --all-features --tests -- -Dwarnings`, `cargo fmt --check` all clean.
- [x] Unit tests for the reconcile add/remove diff logic (`api/src/network/ledger.rs`).
- [x] 6 new e2e tests (`e2e/tests/daemon_api.rs`): acquire idempotency, release-triggers-collect (with/without a surviving internal FK or other holder), reconcile atomicity (bad element rolls back the whole call), lock-ordering under concurrency, and the existing hard-delete endpoint's changed failure mode (now correctly errors instead of silently orphaning App API's bridge, since `network_reference`'s pre-existing `ON DELETE RESTRICT` FK now applies). These replicate the handlers' SQL directly rather than driving real HTTP requests, because this test harness has no way to mint an Auth0 token (documented constraint, not new to this PR).
- [x] Manual smoke test: real HTTP requests against the running dev API with a genuine Auth0-signed token (via `sm auth show`) confirmed `401` unauthenticated, `403` on all three new endpoints and on `POST /networks` with `reference` set for an authenticated-but-non-holder caller, and `201` unaffected for a plain `POST /networks` without `reference` (no regression to the existing create path).
- [ ] Positive path (a real App API M2M token successfully acquiring a reference) not verified in this environment - blocked by an Auth0-side `access_denied` on the dev tenant for App API's existing M2M client, unrelated to this code (that client's calls to Smith already work in prod today). Worth a quick check once App API's own client work is closer to shipping.

## Checklist
- [x] No unintended side effects on adjacent features: fully additive except one behavior change worth flagging explicitly - the pre-existing public `DELETE /networks/{id}` (unrelated code, not touched here) now fails instead of silently succeeding when called on a network with any ledger reference, because `network_reference`'s `ON DELETE RESTRICT` FK (added in an earlier migration, already on `main`) applies once rows start being inserted into that table. Covered by a new e2e test.
- [ ] Breaking change? No API contract is removed or changed; `POST /networks`'s new `reference` field is optional and additive. The `DELETE /networks/{id}` failure-mode change above is a behavior change for a caller that has no legitimate use today.
- [ ] Docs / changelog: no user-facing docs needed (new endpoints are for a machine caller - App API - not surfaced in the dashboard or CLI). New endpoints are self-documenting via existing `utoipa` OpenAPI annotations, consistent with the rest of this router.
