### PR TITLE
feat: bring device-detail Run Command modal to parity with bulk modal

### DIFF
--- a/dashboard/app/(private)/commands/shared.tsx
+++ b/dashboard/app/(private)/commands/shared.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import { Badge } from "@teton/smith-ui";
+import { isAxiosError } from "axios";
 import { Check, ChevronDown, ChevronRight, Copy, X } from "lucide-react";
-import { Fragment, type ReactNode, useMemo, useState } from "react";
+import {
+	Fragment,
+	type ReactNode,
+	useCallback,
+	useMemo,
+	useState,
+} from "react";
 import type { DeviceCommandResponse } from "@/app/api-client";
 import { Tooltip } from "@/app/components/tooltip";
 import { deriveBand, groupScanResults, SignalBar } from "@/app/utils/wifiScan";
@@ -298,6 +305,37 @@ export function commandIsValid(ec: EditableCommand): boolean {
 	}
 }
 
+// The state a Run Command modal needs: the editable command plus its
+// dispatch-error banner, with a single `reset` back to a fresh command of
+// `variant` covering every open/cancel/success reset site. Used by both the
+// devices bulk-command modal and the device-detail Run modal.
+export function useCommandForm(variant = "Ping") {
+	const [command, setCommand] = useState<EditableCommand>(() =>
+		emptyCommand(variant),
+	);
+	const [error, setError] = useState<string | null>(null);
+	const reset = useCallback(() => {
+		setCommand(emptyCommand(variant));
+		setError(null);
+	}, [variant]);
+	return { command, setCommand, error, setError, reset };
+}
+
+// Turn a failed command-dispatch mutation into a user-facing message. FreeForm
+// is the only BULK_COMMAND_OPTIONS variant gated behind the admin-only
+// `freeform` permission, so a 403 on it gets a specific message.
+export function getCommandErrorMessage(
+	error: unknown,
+	variant: string,
+): string {
+	if (isAxiosError(error) && error.response?.status === 403) {
+		return variant === "FreeForm"
+			? "You don't have permission to run FreeForm commands"
+			: "You don't have permission to run this command";
+	}
+	return "Failed to dispatch command";
+}
+
 const fieldClass =
 	"w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900 placeholder-gray-400 text-sm";
 
@@ -308,16 +346,32 @@ export function CommandFields({
 	command,
 	options,
 	onChange,
+	onSubmit,
+	showContinueOnError = true,
 }: {
 	command: EditableCommand;
 	options: readonly string[];
 	onChange: (next: EditableCommand) => void;
+	/** Enter-to-submit, matching a plain text input's native behavior. */
+	onSubmit?: () => void;
+	/** Hide where only one command is ever dispatched (e.g. the device-detail
+	 * Run modal): "continue if this fails" implies a next command in the same
+	 * bundle, which doesn't exist there. */
+	showContinueOnError?: boolean;
 }) {
 	const set = (patch: Partial<EditableCommand>) =>
 		onChange({ ...command, ...patch });
 
 	return (
-		<div className="space-y-3">
+		<div
+			className="space-y-3"
+			onKeyDown={(e) => {
+				if (e.key === "Enter" && onSubmit) {
+					e.preventDefault();
+					onSubmit();
+				}
+			}}
+		>
 			<select
 				value={command.variant}
 				onChange={(e) => set({ variant: e.target.value })}
@@ -437,14 +491,16 @@ export function CommandFields({
 				</div>
 			)}
 
-			<label className="flex items-center gap-2 text-xs text-gray-600">
-				<input
-					type="checkbox"
-					checked={command.continue_on_error}
-					onChange={(e) => set({ continue_on_error: e.target.checked })}
-				/>
-				Continue running the bundle if this command fails
-			</label>
+			{showContinueOnError && (
+				<label className="flex items-center gap-2 text-xs text-gray-600">
+					<input
+						type="checkbox"
+						checked={command.continue_on_error}
+						onChange={(e) => set({ continue_on_error: e.target.checked })}
+					/>
+					Continue running the bundle if this command fails
+				</label>
+			)}
 		</div>
 	);
 }

--- a/dashboard/app/(private)/devices/[serial]/DeviceHeader.tsx
+++ b/dashboard/app/(private)/devices/[serial]/DeviceHeader.tsx
@@ -204,6 +204,11 @@ const DeviceHeader: React.FC<DeviceHeaderProps> = ({ device, serial }) => {
 		);
 	};
 
+	// The variant actually dispatched, captured at submit time: `onError` fires
+	// after the form may have been edited (or reset by closing the modal), so
+	// reading `runCommandState.variant` there could name the wrong command.
+	const submittedVariantRef = useRef(runCommandState.variant);
+
 	const { mutate: issueCommands, isPending: isIssuingCommands } =
 		useIssueCommandsToDevices({
 			mutation: {
@@ -215,7 +220,7 @@ const DeviceHeader: React.FC<DeviceHeaderProps> = ({ device, serial }) => {
 				onError: (error) => {
 					console.error("Failed to issue command:", error);
 					setRunCommandError(
-						getCommandErrorMessage(error, runCommandState.variant),
+						getCommandErrorMessage(error, submittedVariantRef.current),
 					);
 				},
 			},
@@ -237,6 +242,7 @@ const DeviceHeader: React.FC<DeviceHeaderProps> = ({ device, serial }) => {
 		if (!commandIsValid(runCommandState) || !device?.id || isIssuingCommands)
 			return;
 		setRunCommandError(null);
+		submittedVariantRef.current = runCommandState.variant;
 		issueCommands({
 			data: {
 				devices: [device.id],
@@ -492,7 +498,10 @@ const DeviceHeader: React.FC<DeviceHeaderProps> = ({ device, serial }) => {
 				open={showRunModal}
 				onClose={() => {
 					setShowRunModal(false);
-					resetRunCommand();
+					// Escape/backdrop/X bypass the Cancel button's isIssuingCommands
+					// guard: don't reset while a dispatch is in flight, or the
+					// eventual onError lands its banner on an already-reset form.
+					if (!isIssuingCommands) resetRunCommand();
 				}}
 				title="Run Command"
 				footer={

--- a/dashboard/app/(private)/devices/[serial]/DeviceHeader.tsx
+++ b/dashboard/app/(private)/devices/[serial]/DeviceHeader.tsx
@@ -15,7 +15,15 @@ import {
 	Terminal,
 } from "lucide-react";
 import { useRef, useState } from "react";
-import { Link } from "react-router";
+import { Link, useNavigate } from "react-router";
+import {
+	BULK_COMMAND_OPTIONS,
+	buildCommand,
+	CommandFields,
+	commandIsValid,
+	getCommandErrorMessage,
+	useCommandForm,
+} from "@/app/(private)/commands/shared";
 import {
 	type CommandRecipe,
 	type Device,
@@ -152,8 +160,15 @@ const DeviceHeader: React.FC<DeviceHeaderProps> = ({ device, serial }) => {
 	const [selectedRecipeId, setSelectedRecipeId] = useState<number | null>(null);
 	const [recipeTriggered, setRecipeTriggered] = useState(false);
 	const [recipeError, setRecipeError] = useState<string | null>(null);
-	const [runCommand, setRunCommand] = useState("");
+	const {
+		command: runCommandState,
+		setCommand: setRunCommandState,
+		error: runCommandError,
+		setError: setRunCommandError,
+		reset: resetRunCommand,
+	} = useCommandForm("Ping");
 	const { config } = useConfig();
+	const navigate = useNavigate();
 
 	const { data: recipesData, isLoading: isLoadingRecipes } = useGetRecipes();
 	const recipes: CommandRecipe[] = Array.isArray(recipesData)
@@ -194,10 +209,14 @@ const DeviceHeader: React.FC<DeviceHeaderProps> = ({ device, serial }) => {
 			mutation: {
 				onSuccess: () => {
 					setShowRunModal(false);
-					setRunCommand("");
+					resetRunCommand();
+					navigate(`/devices/${serial}/commands`);
 				},
 				onError: (error) => {
 					console.error("Failed to issue command:", error);
+					setRunCommandError(
+						getCommandErrorMessage(error, runCommandState.variant),
+					);
 				},
 			},
 		});
@@ -215,15 +234,16 @@ const DeviceHeader: React.FC<DeviceHeaderProps> = ({ device, serial }) => {
 		});
 
 	const handleRunCommand = () => {
-		if (!runCommand.trim() || !device?.id) return;
+		if (!commandIsValid(runCommandState) || !device?.id) return;
+		setRunCommandError(null);
 		issueCommands({
 			data: {
 				devices: [device.id],
 				commands: [
 					{
 						id: -1,
-						command: { FreeForm: { cmd: runCommand } },
-						continue_on_error: false,
+						command: buildCommand(runCommandState),
+						continue_on_error: runCommandState.continue_on_error,
 					},
 				],
 			},
@@ -471,7 +491,7 @@ const DeviceHeader: React.FC<DeviceHeaderProps> = ({ device, serial }) => {
 				open={showRunModal}
 				onClose={() => {
 					setShowRunModal(false);
-					setRunCommand("");
+					resetRunCommand();
 				}}
 				title="Run Command"
 				footer={
@@ -482,7 +502,7 @@ const DeviceHeader: React.FC<DeviceHeaderProps> = ({ device, serial }) => {
 							disabled={isIssuingCommands}
 							onClick={() => {
 								setShowRunModal(false);
-								setRunCommand("");
+								resetRunCommand();
 							}}
 						>
 							Cancel
@@ -491,7 +511,7 @@ const DeviceHeader: React.FC<DeviceHeaderProps> = ({ device, serial }) => {
 							variant="solid"
 							tone="purple"
 							loading={isIssuingCommands}
-							disabled={!runCommand.trim()}
+							disabled={!commandIsValid(runCommandState)}
 							onClick={handleRunCommand}
 						>
 							{isIssuingCommands ? "Sending..." : "Run Command"}
@@ -514,25 +534,23 @@ const DeviceHeader: React.FC<DeviceHeaderProps> = ({ device, serial }) => {
 					</div>
 				</div>
 
+				{runCommandError && (
+					<div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg p-3 mb-4">
+						{runCommandError}
+					</div>
+				)}
+
 				<div>
 					<label className="block text-sm font-medium text-gray-700 mb-2">
 						Command
 					</label>
-					<input
-						type="text"
-						value={runCommand}
-						onChange={(e) => setRunCommand(e.target.value)}
-						onKeyDown={(e) => {
-							if (e.key === "Enter" && runCommand.trim()) {
-								handleRunCommand();
-							}
-						}}
-						placeholder="e.g., ls -la /var/log"
-						className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-purple-500 focus:border-purple-500 text-gray-900 placeholder-gray-400"
+					<CommandFields
+						command={runCommandState}
+						options={BULK_COMMAND_OPTIONS}
+						onChange={setRunCommandState}
+						onSubmit={handleRunCommand}
+						showContinueOnError={false}
 					/>
-					<p className="mt-1 text-xs text-gray-500">
-						Enter a shell command to execute on this device
-					</p>
 				</div>
 			</Modal>
 

--- a/dashboard/app/(private)/devices/[serial]/DeviceHeader.tsx
+++ b/dashboard/app/(private)/devices/[serial]/DeviceHeader.tsx
@@ -234,7 +234,8 @@ const DeviceHeader: React.FC<DeviceHeaderProps> = ({ device, serial }) => {
 		});
 
 	const handleRunCommand = () => {
-		if (!commandIsValid(runCommandState) || !device?.id) return;
+		if (!commandIsValid(runCommandState) || !device?.id || isIssuingCommands)
+			return;
 		setRunCommandError(null);
 		issueCommands({
 			data: {

--- a/dashboard/app/(private)/devices/page.tsx
+++ b/dashboard/app/(private)/devices/page.tsx
@@ -590,7 +590,7 @@ const DevicesPage = () => {
 		});
 
 	const handleBulkCommand = () => {
-		if (!commandIsValid(bulkCommand)) return;
+		if (!commandIsValid(bulkCommand) || isIssuingCommands) return;
 
 		setBulkCommandError(null);
 		issueCommands({

--- a/dashboard/app/(private)/devices/page.tsx
+++ b/dashboard/app/(private)/devices/page.tsx
@@ -568,6 +568,11 @@ const DevicesPage = () => {
 		});
 	};
 
+	// The variant actually dispatched, captured at submit time: `onError` fires
+	// after the form may have been edited (or reset by closing the modal), so
+	// reading `bulkCommand.variant` there could name the wrong command.
+	const submittedBulkVariantRef = useRef(bulkCommand.variant);
+
 	// Bulk command mutation
 	const { mutate: issueCommands, isPending: isIssuingCommands } =
 		useIssueCommandsToDevices({
@@ -580,10 +585,8 @@ const DevicesPage = () => {
 				},
 				onError: (error) => {
 					console.error("Failed to issue commands:", error);
-					// The bulk modal only ever dispatches one command, so the variant
-					// still held in state is the one that got rejected.
 					setBulkCommandError(
-						getCommandErrorMessage(error, bulkCommand.variant),
+						getCommandErrorMessage(error, submittedBulkVariantRef.current),
 					);
 				},
 			},
@@ -593,6 +596,7 @@ const DevicesPage = () => {
 		if (!commandIsValid(bulkCommand) || isIssuingCommands) return;
 
 		setBulkCommandError(null);
+		submittedBulkVariantRef.current = bulkCommand.variant;
 		issueCommands({
 			data: {
 				devices: Array.from(selectedDeviceIds),
@@ -1860,7 +1864,10 @@ const DevicesPage = () => {
 				open={showBulkCommandModal}
 				onClose={() => {
 					setShowBulkCommandModal(false);
-					resetBulkCommand();
+					// Escape/backdrop/X bypass the Cancel button's isIssuingCommands
+					// guard: don't reset while a dispatch is in flight, or the
+					// eventual onError lands its banner on an already-reset form.
+					if (!isIssuingCommands) resetBulkCommand();
 				}}
 				title="Run Command on Selected Devices"
 				footer={

--- a/dashboard/app/(private)/devices/page.tsx
+++ b/dashboard/app/(private)/devices/page.tsx
@@ -1632,7 +1632,10 @@ const DevicesPage = () => {
 									tone="purple"
 									icon={<Terminal className="w-4 h-4" />}
 									onClick={() => {
-										resetBulkCommand();
+										// Reopening while a previous dispatch is still pending (e.g.
+										// closed via Escape/backdrop mid-request) must not wipe the
+										// form the eventual onError still needs to correlate with.
+										if (!isIssuingCommands) resetBulkCommand();
 										setShowBulkCommandModal(true);
 									}}
 								>

--- a/dashboard/app/(private)/devices/page.tsx
+++ b/dashboard/app/(private)/devices/page.tsx
@@ -1,7 +1,6 @@
 import { useAuth0 } from "@auth0/auth0-react";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { Button, LabelChip, Select, Toast } from "@teton/smith-ui";
-import { isAxiosError } from "axios";
 import {
 	AlertTriangle,
 	Calendar,
@@ -27,8 +26,8 @@ import {
 	buildCommand,
 	CommandFields,
 	commandIsValid,
-	type EditableCommand,
-	emptyCommand,
+	getCommandErrorMessage,
+	useCommandForm,
 } from "@/app/(private)/commands/shared";
 import LabelAutocomplete from "@/app/components/LabelAutocomplete";
 import { Modal } from "@/app/components/modal";
@@ -269,10 +268,13 @@ const DevicesPage = () => {
 	const [bulkDeployReleaseSearch, setBulkDeployReleaseSearch] = useState("");
 	// Bulk command state
 	const [showBulkCommandModal, setShowBulkCommandModal] = useState(false);
-	const [bulkCommand, setBulkCommand] = useState<EditableCommand>(() =>
-		emptyCommand("Ping"),
-	);
-	const [bulkCommandError, setBulkCommandError] = useState<string | null>(null);
+	const {
+		command: bulkCommand,
+		setCommand: setBulkCommand,
+		error: bulkCommandError,
+		setError: setBulkCommandError,
+		reset: resetBulkCommand,
+	} = useCommandForm("Ping");
 
 	// Approval state
 	const [approveModalDevice, setApproveModalDevice] = useState<Device | null>(
@@ -573,25 +575,16 @@ const DevicesPage = () => {
 				onSuccess: () => {
 					setShowBulkCommandModal(false);
 					setSelectedDeviceIds(new Set());
-					setBulkCommand(emptyCommand("Ping"));
-					setBulkCommandError(null);
+					resetBulkCommand();
 					navigate("/commands");
 				},
 				onError: (error) => {
 					console.error("Failed to issue commands:", error);
-					if (isAxiosError(error) && error.response?.status === 403) {
-						// The bulk modal only ever dispatches one command, so the variant
-						// still held in state is the one that got rejected. FreeForm is
-						// the only variant in BULK_COMMAND_OPTIONS gated behind the
-						// admin-only `freeform` permission, so it gets a specific message.
-						setBulkCommandError(
-							bulkCommand.variant === "FreeForm"
-								? "You don't have permission to run FreeForm commands"
-								: "You don't have permission to run this command",
-						);
-					} else {
-						setBulkCommandError("Failed to dispatch command");
-					}
+					// The bulk modal only ever dispatches one command, so the variant
+					// still held in state is the one that got rejected.
+					setBulkCommandError(
+						getCommandErrorMessage(error, bulkCommand.variant),
+					);
 				},
 			},
 		});
@@ -1635,8 +1628,7 @@ const DevicesPage = () => {
 									tone="purple"
 									icon={<Terminal className="w-4 h-4" />}
 									onClick={() => {
-										setBulkCommand(emptyCommand("Ping"));
-										setBulkCommandError(null);
+										resetBulkCommand();
 										setShowBulkCommandModal(true);
 									}}
 								>
@@ -1868,8 +1860,7 @@ const DevicesPage = () => {
 				open={showBulkCommandModal}
 				onClose={() => {
 					setShowBulkCommandModal(false);
-					setBulkCommand(emptyCommand("Ping"));
-					setBulkCommandError(null);
+					resetBulkCommand();
 				}}
 				title="Run Command on Selected Devices"
 				footer={
@@ -1880,8 +1871,7 @@ const DevicesPage = () => {
 							disabled={isIssuingCommands}
 							onClick={() => {
 								setShowBulkCommandModal(false);
-								setBulkCommand(emptyCommand("Ping"));
-								setBulkCommandError(null);
+								resetBulkCommand();
 							}}
 						>
 							Cancel
@@ -1930,6 +1920,7 @@ const DevicesPage = () => {
 						command={bulkCommand}
 						options={BULK_COMMAND_OPTIONS}
 						onChange={setBulkCommand}
+						onSubmit={handleBulkCommand}
 					/>
 					<p className="mt-1 text-xs text-gray-500">
 						Runs on all selected devices

--- a/dashboard/app/(private)/devices/page.tsx
+++ b/dashboard/app/(private)/devices/page.tsx
@@ -1631,13 +1631,7 @@ const DevicesPage = () => {
 									variant="solid"
 									tone="purple"
 									icon={<Terminal className="w-4 h-4" />}
-									onClick={() => {
-										// Reopening while a previous dispatch is still pending (e.g.
-										// closed via Escape/backdrop mid-request) must not wipe the
-										// form the eventual onError still needs to correlate with.
-										if (!isIssuingCommands) resetBulkCommand();
-										setShowBulkCommandModal(true);
-									}}
+									onClick={() => setShowBulkCommandModal(true)}
 								>
 									Run Command
 								</Button>


### PR DESCRIPTION
## What
Brings the `/devices/{id}` "Run" command modal to full parity with the `/devices` bulk "Run Command" modal, replacing its FreeForm-only text input with the same variant picker, validation, and error handling.

## Why
The device-detail page's Run modal was limited to a single free-text input hardcoded to `FreeForm`, with no visible error handling. The bulk devices-list modal already had the complete implementation (8 command variants via a shared `CommandFields` component, proper validation, and a visible 403/permission-aware error message). Fleet operators running a single-device command had access to only a fraction of what bulk-selection users could already do.

Closes #

## Approach
Pure consumer-side refactor, no schema or API changes, both modals already hit the same `useIssueCommandsToDevices` endpoint with the same wire shape.

- `DeviceHeader.tsx`'s Run modal now renders the shared `CommandFields` component (`commands/shared.tsx`) instead of a raw `<input>`, offering the same `BULK_COMMAND_OPTIONS` variant list (WifiScan, Ping, TestNetwork, ExtendedNetworkTest, RunAudit, ReportNMProfiles, GetLogs, FreeForm) with the same per-variant parameter fields, gated by the same `commandIsValid`/`buildCommand` helpers the bulk modal already used.
- On success it now navigates to `/devices/{serial}/commands` (that device's own Commands tab) instead of just closing the modal, the single-device analogue of the bulk modal's `navigate("/commands")`.
- On error it now shows a visible banner distinguishing a FreeForm-specific 403 ("You don't have permission to run FreeForm commands") from a generic 403 or dispatch failure, instead of only logging to console.
- Extracted `getCommandErrorMessage(error, variant)` into `commands/shared.tsx` so this 403-branching logic exists in exactly one place, used by both modals, rather than being duplicated.
- Extracted `useCommandForm(variant)` into `commands/shared.tsx`, bundling the editable-command state, its error state, and a single `reset()` that covers every open/cancel/success reset site. Both modals now use it, eliminating four near-duplicate `setCommand(emptyCommand(...)); setError(null);` pairs.
- `CommandFields` gained two new optional props, adopted by both modals: `onSubmit` (Enter-to-submit, restoring a convenience the old device-detail input had and extending it to the bulk modal too) and `showContinueOnError` (hides the "continue running the bundle" checkbox on the device-detail modal, where it's always exactly one command against one device, so "continue to the next command" doesn't apply; the bulk modal keeps it).

**Considered and dropped**: a `disabled` prop that would freeze the form while a dispatch is in flight, to close a theoretical race where changing the variant mid-request could mislabel the eventual 403 error. On reflection the reachable case is narrow enough (only FreeForm without the `freeform` permission can 403 among these options today) that it wasn't worth the added surface, so it was left out.

**Rejected alternatives**:
- Duplicating the 403-message branching locally in `DeviceHeader.tsx` instead of extracting it, rejected to satisfy the explicit reuse requirement.
- A full `useCommandDispatch` hook wrapping `useIssueCommandsToDevices` for both callers, rejected as a bigger refactor than needed: the two call sites still differ in target device(s), navigation target, and reset side-effects.
- Keeping the device-detail modal's success navigation on the global `/commands` page, rejected in favor of the device's own `/devices/{serial}/commands` tab.

## Testing
- [x] `npm run lint` (Biome) clean, `npm run build` passes
- [x] Manual smoke test against the local dev stack (Docker dashboard + API, device `1234`):
  - Variant picker shows all 8 `BULK_COMMAND_OPTIONS`
  - `Ping` submit closes the modal and navigates to `/devices/1234/commands`, command appears there
  - FreeForm validation gates the submit button until non-empty; Enter-to-submit works from the FreeForm field
  - FreeForm submit with permission dispatches and navigates correctly
  - FreeForm submit **without** permission (verified by temporarily downgrading the test user's role in the dev DB from `admin` to `default`, which lacks the `commands:freeform` permission, then restoring it) shows the exact expected banner: "You don't have permission to run FreeForm commands"
  - The "continue running the bundle" checkbox is confirmed hidden on the device-detail modal and still present on the bulk modal
  - Confirmed no regression on the recipes page's `CommandRow` (doesn't pass the new `onSubmit` prop, so it's unaffected: Enter is a no-op there)

## Checklist
- [x] No unintended side effects on adjacent features (Reboot modal, Recipe modal, SSH/Grafana actions, and the recipes page's command list all untouched and verified unaffected)
- [x] Breaking change? No, purely additive UI change; wire format to the API is unchanged
- [ ] Docs / changelog updated if user-facing — no user-facing docs/changelog exist for this dashboard feature in this repo; none needed