### PR TITLE
fix: return 404 from GET /networks/{id} for a missing network

### DIFF
--- a/api/src/network/route.rs
+++ b/api/src/network/route.rs
@@ -103,6 +103,7 @@ pub async fn get_networks(
     ),
     responses(
         (status = 200, description = "Return found network"),
+        (status = 404, description = "Network does not exist"),
         (status = 500, description = "Failed to retrieve network", body = String),
     ),
     security(
@@ -132,12 +133,17 @@ pub async fn get_network_by_id(
     )
     .fetch_one(&state.pg_pool)
     .await
-    .map_err(|err| {
-        error!(
-            "error: failed to get network for id {}: {:?}",
-            network_id, err
-        );
-        StatusCode::INTERNAL_SERVER_ERROR
+    .map_err(|err| match err {
+        // A missing row is a normal, expected outcome here (e.g. a network
+        // the ledger has since collected), not a failure worth logging as one.
+        sqlx::Error::RowNotFound => StatusCode::NOT_FOUND,
+        err => {
+            error!(
+                "error: failed to get network for id {}: {:?}",
+                network_id, err
+            );
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
     })?;
 
     Ok(Json(network))


### PR DESCRIPTION
## What
`GET /networks/{id}` now returns 404, not 500, when the network doesn't exist.

## Why
Found while testing a deletion flow locally: fetching a network id that had genuinely been
deleted came back as a 500. `get_network_by_id` mapped every error from the lookup query,
including a simple missing row, to a generic internal error - so "not found" and "the
database is broken" were indistinguishable to a caller.

## Approach
`RowNotFound` is now matched explicitly and mapped to 404; every other error still goes
through the existing `error!` log line and 500, unchanged. Added the 404 response to the
endpoint's OpenAPI annotation.

## Testing
- [x] `cargo build`, `cargo clippy --workspace --all-features --tests -- -Dwarnings`,
      `cargo fmt --check` all clean.
- [x] Manually verified against a running local instance with a real auth token:
      `GET /networks/<a deleted id>` returns 404 (previously 500); an existing network still
      returns 200.

## Checklist
- [x] No unintended side effects: touches only the not-found branch of one handler; the
      200 path and the 500 path for genuine errors are unchanged.
- [x] Breaking change? No - 500 for a missing row was a bug, not a contract anything should
      have depended on.