### PR TITLE
chore: remove public DELETE /networks/{id} endpoint

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -257,10 +257,7 @@ async fn start_main_server(
             network::route::get_networks,
             network::route::create_network
         ))
-        .routes(routes!(
-            network::route::get_network_by_id,
-            network::route::delete_network_by_id
-        ))
+        .routes(routes!(network::route::get_network_by_id))
         .routes(routes!(
             network::ledger::acquire_reference,
             network::ledger::release_reference

--- a/api/src/network/route.rs
+++ b/api/src/network/route.rs
@@ -143,36 +143,6 @@ pub async fn get_network_by_id(
     Ok(Json(network))
 }
 
-#[utoipa::path(
-    delete,
-    path = "/networks/{network_id}",
-    params(
-        ("network_id" = i32, Path),
-    ),
-    responses(
-        (status = StatusCode::NO_CONTENT, description = "Successfully deleted the network"),
-        (status = StatusCode::INTERNAL_SERVER_ERROR, description = "Failed to delete network", body = String),
-    ),
-    security(
-        ("auth_token" = [])
-    ),
-    tag = NETWORKS_TAG
-)]
-pub async fn delete_network_by_id(
-    Path(network_id): Path<i32>,
-    Extension(state): Extension<State>,
-) -> Result<StatusCode, StatusCode> {
-    sqlx::query!(r#"DELETE FROM network WHERE id = $1"#, network_id)
-        .execute(&state.pg_pool)
-        .await
-        .map_err(|err| {
-            error!("Failed to delete network {err}");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-
-    Ok(StatusCode::NO_CONTENT)
-}
-
 /// The one construction of the content-addressing `credentials` envelope.
 ///
 /// Both the lock key and the identity match project `->>'psk'`, so a row must be

--- a/e2e/tests/daemon_api.rs
+++ b/e2e/tests/daemon_api.rs
@@ -1143,9 +1143,8 @@ async fn reconcile_rolls_back_entirely_on_invalid_element() -> Result<()> {
     Ok(())
 }
 
-/// `network_reference`'s `ON DELETE RESTRICT` FK means the existing public
-/// `DELETE /networks/{id}` can no longer silently orphan a held network now
-/// that the ledger exists: it must fail instead.
+/// `network_reference`'s `ON DELETE RESTRICT` FK means a raw `DELETE FROM
+/// network` can't silently orphan a held network: it must fail instead.
 #[tokio::test]
 #[ignore = "requires running compose stack; use make test.e2e"]
 async fn hard_delete_fails_on_a_held_network() -> Result<()> {


### PR DESCRIPTION
## What
Removes the public `DELETE /networks/{network_id}` endpoint from the `api` service.

## Why
This endpoint predates the `network_reference` ledger and bypassed it entirely: it ran a bare `DELETE FROM network WHERE id = $1` with no check on whether anything still held that network row, and could silently orphan a network still in use by a device or device group. A code search across Smith (dashboard, CLI, e2e tests) and App API found zero callers of this endpoint, and manual operator deletion is done via direct DB access, not through this API, so there's no legitimate remaining caller to preserve.

## Approach
Deleted the route registration and its handler outright, no replacement, no internal-only variant, no feature flag:
- `api/src/main.rs`: removed `network::route::delete_network_by_id` from the `routes!()` registration (this also drops it from the generated OpenAPI doc, since utoipa derives docs from what's registered here, there's no separate spec file to regenerate).
- `api/src/network/route.rs`: deleted the `delete_network_by_id` handler and its `#[utoipa::path(delete, ...)]` annotation.
- `e2e/tests/daemon_api.rs`: updated a stale doc comment on `hard_delete_fails_on_a_held_network` that referenced the now-removed endpoint; the test itself was already exercising the DB-level `ON DELETE RESTRICT` FK directly and needed no logic change.

The only remaining path to delete a `network` row is `collect_network()` (in `api/src/network/ledger.rs`), reached via `release_reference`/`reconcile_references`, which only deletes once both the ledger's reference count and internal FK count are zero. Direct DB access remains available to operators and is still protected by the `ON DELETE RESTRICT` FK on `network_reference`.

**Rejected alternatives:**
- Internalize behind a second listener/scope: Smith binds a single `TcpListener` on `0.0.0.0:8080` for everything; building a second port/router for an endpoint with zero confirmed callers wasn't worth it.
- Tighter auth (reusing the `Holder` M2M-token concept): still leaves a network-reachable endpoint that bypasses the ledger's reference-count check, for a caller that doesn't exist.
- Deprecation window: skipped, the code-search investigation across Smith, App API, and the CLI was treated as sufficient evidence of zero callers.

## Testing
- [x] Tests pass: `SQLX_OFFLINE=true cargo test -p api --bins` → 53 passed, 0 failed, 1 ignored
- [x] `cargo fmt --check` clean, `cargo clippy --all-features -- -Dwarnings` clean on `api` and `smith-e2e`
- [x] Manual smoke test: confirmed via static review that no custom 404 fallback is registered in `main.rs`, so a request to the removed path now gets axum's default 404 (previously 204/500)

## Checklist
- [x] No unintended side effects on adjacent features: `GET /networks/{id}` and all ledger endpoints (`POST /networks/{id}/reference`, `.../reference/release`, `POST /networks/reconcile`) are untouched
- [x] Breaking change? Yes in principle (removes a public endpoint), but no in practice: zero confirmed callers found in Smith, App API, or the CLI. No migration path needed.
- [ ] Docs / changelog updated if user-facing: not done, this repo doesn't appear to have a user-facing changelog entry convention checked for this kind of internal API removal (flagging for your call)