### PR TITLE
feat: sweep and delete network rows nothing references anymore

### DIFF
--- a/api/.sqlx/query-a7f595fe950beb89e1109b7896d51c4fe99f51404ea7a720d0d362f858f3b4fe.json
+++ b/api/.sqlx/query-a7f595fe950beb89e1109b7896d51c4fe99f51404ea7a720d0d362f858f3b4fe.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT n.id\n        FROM network n\n        WHERE NOT EXISTS (SELECT 1 FROM network_reference r WHERE r.network_id = n.id)\n          AND NOT network_has_internal_reference(n.id)\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "a7f595fe950beb89e1109b7896d51c4fe99f51404ea7a720d0d362f858f3b4fe"
+}

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -168,6 +168,9 @@ impl Config {
             network_gc_interval_seconds: env::var("NETWORK_GC_INTERVAL_SECONDS")
                 .ok()
                 .and_then(|s| s.parse().ok())
+                // Zero treated as unset, not honored: tokio::time::interval
+                // panics on a zero duration.
+                .filter(|&secs: &u64| secs > 0)
                 // App API's reconcile job (the only current holder) pushes at
                 // most every 2 days, so sweeping more often than that just
                 // finds nothing new.

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -104,6 +104,10 @@ pub struct Config {
     /// `holder` is never client-supplied: this map is the sole source of truth
     /// for who a caller is allowed to hold references as.
     pub known_holders: HashMap<String, String>,
+    /// How often the network garbage collection sweep (`network::gc`) runs. A plain tunable,
+    /// not an on/off switch - the sweep only ships once seeding is already
+    /// confirmed.
+    pub network_gc_interval_seconds: u64,
 }
 
 /// Builds the M2M-sub -> holder map from one env var per known holder. Missing
@@ -161,6 +165,13 @@ impl Config {
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(3600),
             known_holders: known_holders_from_env(),
+            network_gc_interval_seconds: env::var("NETWORK_GC_INTERVAL_SECONDS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                // App API's reconcile job (the only current holder) pushes at
+                // most every 2 days, so sweeping more often than that just
+                // finds nothing new.
+                .unwrap_or(2 * 24 * 60 * 60),
         })
     }
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -232,6 +232,10 @@ async fn start_main_server(
     // go down to a day, so the real cleanup has to run here.
     files::spawn_sweeper(state.pg_pool.clone(), &config.assets_bucket_name);
 
+    // Every pre-existing network has zero ledger references until App API
+    // seeds it, so this only runs once seeding is confirmed (network::gc).
+    network::gc::spawn_sweeper(state.pg_pool.clone(), config.network_gc_interval_seconds);
+
     let recorder_handle = metric::setup_metrics_recorder();
 
     let mut api_doc = ApiDoc::openapi();

--- a/api/src/network/gc.rs
+++ b/api/src/network/gc.rs
@@ -1,0 +1,75 @@
+//! Background garbage collection sweep for `network` rows nothing references
+//! anymore.
+//!
+//! Deliberately not part of the same deploy as the rest of the reference
+//! ledger. It only ships once App API has deployed its client and pushed at
+//! least one full reconcile, so every pre-existing synced network already has
+//! a `network_reference` row before this sweep can ever run against it. No
+//! runtime flag gates this: the sweep's presence in the deployed binary *is*
+//! the on/off state.
+
+use crate::network::ledger::{collect_network, lock_network};
+use sqlx::PgPool;
+use std::time::Duration;
+use tokio::time::{MissedTickBehavior, sleep};
+use tracing::{error, info};
+
+/// Same reasoning as `files::spawn_sweeper`: every replica boots at once
+/// during a rolling deploy, so stagger the first tick rather than have the
+/// whole fleet sweep in lockstep.
+const STARTUP_GRACE: Duration = Duration::from_secs(60);
+
+/// Finds every network with zero `network_reference` rows and zero internal
+/// FK references, taking each candidate's per-id advisory lock and running it
+/// through `collect_network` - the exact same check `acquire`/`release`/
+/// `reconcile` use, so this can never drift into a different opinion of what
+/// counts as referenced. Returns the number actually collected.
+async fn sweep_once(pool: &PgPool) -> Result<i64, sqlx::Error> {
+    // A network's collection state can only change between this SELECT and
+    // its own row's `collect_network` call, not because of another candidate
+    // in the same batch - each candidate is locked and re-checked
+    // independently below, so a stale list is harmless.
+    let candidates: Vec<i32> = sqlx::query_scalar!(
+        r#"
+        SELECT n.id
+        FROM network n
+        WHERE NOT EXISTS (SELECT 1 FROM network_reference r WHERE r.network_id = n.id)
+          AND NOT network_has_internal_reference(n.id)
+        "#
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let mut collected = 0;
+    for network_id in candidates {
+        let mut tx = pool.begin().await?;
+        lock_network(&mut tx, network_id).await?;
+        if collect_network(&mut tx, network_id).await? {
+            collected += 1;
+        }
+        tx.commit().await?;
+    }
+    Ok(collected)
+}
+
+/// Runs the sweep on its own task, so periodic deletion work never blocks a
+/// request handler, on `config.network_gc_interval_seconds`.
+pub fn spawn_sweeper(pool: PgPool, interval_seconds: u64) {
+    tokio::spawn(async move {
+        sleep(STARTUP_GRACE).await;
+
+        let mut ticker = tokio::time::interval(Duration::from_secs(interval_seconds));
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        loop {
+            ticker.tick().await;
+            match sweep_once(&pool).await {
+                Ok(0) => {}
+                Ok(collected) => {
+                    info!("Network garbage collection sweep collected {collected} network(s)")
+                }
+                Err(err) => error!("Network garbage collection sweep failed: {err:?}"),
+            }
+        }
+    });
+}

--- a/api/src/network/gc.rs
+++ b/api/src/network/gc.rs
@@ -9,15 +9,21 @@
 //! the on/off state.
 
 use crate::network::ledger::{collect_network, lock_network};
+use rand::RngExt;
 use sqlx::PgPool;
 use std::time::Duration;
 use tokio::time::{MissedTickBehavior, sleep};
 use tracing::{error, info};
 
-/// Same reasoning as `files::spawn_sweeper`: every replica boots at once
-/// during a rolling deploy, so stagger the first tick rather than have the
-/// whole fleet sweep in lockstep.
+/// Delay before the first tick, so the sweep doesn't compete with everything
+/// else starting up right after boot.
 const STARTUP_GRACE: Duration = Duration::from_secs(60);
+
+/// Added on top of `STARTUP_GRACE`, randomized per instance: `smith-api` runs
+/// several replicas, and a fixed delay alone still has all of them land on
+/// the same candidate set at once. The interval is 2 days by default, so a
+/// few extra minutes of spread costs nothing.
+const STARTUP_JITTER_MAX: Duration = Duration::from_secs(300);
 
 /// Finds every network with zero `network_reference` rows and zero internal
 /// FK references, taking each candidate's per-id advisory lock and running it
@@ -56,7 +62,8 @@ async fn sweep_once(pool: &PgPool) -> Result<i64, sqlx::Error> {
 /// request handler, on `config.network_gc_interval_seconds`.
 pub fn spawn_sweeper(pool: PgPool, interval_seconds: u64) {
     tokio::spawn(async move {
-        sleep(STARTUP_GRACE).await;
+        let jitter = rand::rng().random_range(Duration::ZERO..=STARTUP_JITTER_MAX);
+        sleep(STARTUP_GRACE + jitter).await;
 
         let mut ticker = tokio::time::interval(Duration::from_secs(interval_seconds));
         ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);

--- a/api/src/network/mod.rs
+++ b/api/src/network/mod.rs
@@ -1,3 +1,4 @@
 pub mod evaluation;
+pub mod gc;
 pub mod ledger;
 pub mod route;

--- a/e2e/tests/daemon_api.rs
+++ b/e2e/tests/daemon_api.rs
@@ -1259,3 +1259,161 @@ async fn ascending_lock_order_avoids_deadlock_under_concurrency() -> Result<()> 
     outcome.context("concurrent ascending-order lockers should all complete without deadlock")?;
     Ok(())
 }
+
+// --- Garbage collection sweep ------------------------------------------------
+//
+// `network::gc::sweep_once` is private to the `api` binary crate (no `lib.rs`
+// to import from), so - same as the ledger tests above - this replicates its
+// query and per-candidate `collect_network` check directly against Postgres
+// rather than driving it through HTTP or a shared function.
+
+/// Mirrors `network::gc::sweep_once`'s candidate query and per-row
+/// `collect_network` check (hand-copied - keep in sync). Returns the ids
+/// actually collected.
+async fn run_gc_sweep_once(ctx: &Ctx) -> Result<Vec<i32>> {
+    let candidates: Vec<i32> = sqlx::query_scalar(
+        "SELECT n.id FROM network n
+         WHERE NOT EXISTS (SELECT 1 FROM network_reference r WHERE r.network_id = n.id)
+           AND NOT network_has_internal_reference(n.id)",
+    )
+    .fetch_all(&ctx.db)
+    .await
+    .context("selecting gc sweep candidates")?;
+
+    let mut collected = Vec::new();
+    for network_id in candidates {
+        let mut tx = ctx.db.begin().await?;
+        sqlx::query("SELECT pg_advisory_xact_lock($1)")
+            .bind(i64::from(network_id))
+            .execute(&mut *tx)
+            .await?;
+        let has_ledger_ref: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM network_reference WHERE network_id = $1)",
+        )
+        .bind(network_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        let has_internal_ref: bool =
+            sqlx::query_scalar("SELECT network_has_internal_reference($1)")
+                .bind(network_id)
+                .fetch_one(&mut *tx)
+                .await?;
+        if !has_ledger_ref && !has_internal_ref {
+            sqlx::query("DELETE FROM network WHERE id = $1")
+                .bind(network_id)
+                .execute(&mut *tx)
+                .await?;
+            collected.push(network_id);
+        }
+        tx.commit().await?;
+    }
+    Ok(collected)
+}
+
+/// A network with zero `network_reference` rows and zero internal FK
+/// references is collected by the sweep; a referenced sibling seeded
+/// alongside it survives untouched.
+#[tokio::test]
+#[ignore = "requires running compose stack; use make test.e2e"]
+async fn gc_sweep_collects_only_unreferenced_networks() -> Result<()> {
+    let ctx = Ctx::connect().await?;
+    wait_for_api(&ctx).await?;
+    if !has_reference_ledger(&ctx).await? {
+        println!(
+            "skipping gc_sweep_collects_only_unreferenced_networks: \
+             ledger not present (version-skew job)"
+        );
+        return Ok(());
+    }
+
+    let unreferenced_ssid = format!("e2e-gc-sweep-unreferenced-{}", uuid::Uuid::new_v4());
+    let referenced_ssid = format!("e2e-gc-sweep-referenced-{}", uuid::Uuid::new_v4());
+    let outcome: Result<(bool, bool)> = async {
+        let unreferenced_id = insert_test_network(&ctx, &unreferenced_ssid).await?;
+        let referenced_id = insert_test_network(&ctx, &referenced_ssid).await?;
+        insert_reference(&ctx, "app_api", &referenced_ssid, referenced_id).await?;
+
+        run_gc_sweep_once(&ctx).await?;
+
+        Ok((
+            network_exists(&ctx, unreferenced_id).await?,
+            network_exists(&ctx, referenced_id).await?,
+        ))
+    }
+    .await;
+
+    sqlx::query("DELETE FROM network_reference WHERE external_key = $1")
+        .bind(&referenced_ssid)
+        .execute(&ctx.db)
+        .await
+        .context("cleaning up gc sweep reference")?;
+    sqlx::query("DELETE FROM network WHERE ssid IN ($1, $2)")
+        .bind(&unreferenced_ssid)
+        .bind(&referenced_ssid)
+        .execute(&ctx.db)
+        .await
+        .context("cleaning up gc sweep networks")?;
+
+    let (unreferenced_exists, referenced_exists) = outcome?;
+    ensure!(
+        !unreferenced_exists,
+        "an unreferenced network should have been collected by the sweep"
+    );
+    ensure!(
+        referenced_exists,
+        "a network with a surviving network_reference row must not be collected by the sweep"
+    );
+    Ok(())
+}
+
+/// Same mechanism as above, but the surviving reference is an internal FK
+/// (`device_configured_network`), not a ledger row - the sweep's candidate
+/// query itself must exclude it, not just `collect_network`'s later check.
+#[tokio::test]
+#[ignore = "requires running compose stack; use make test.e2e"]
+async fn gc_sweep_does_not_collect_while_internal_reference_remains() -> Result<()> {
+    let (ctx, device_id) = setup().await?;
+    if !has_reference_ledger(&ctx).await? {
+        println!(
+            "skipping gc_sweep_does_not_collect_while_internal_reference_remains: \
+             ledger not present (version-skew job)"
+        );
+        return Ok(());
+    }
+
+    let ssid = format!("e2e-gc-sweep-internal-{}", uuid::Uuid::new_v4());
+    let outcome: Result<bool> = async {
+        let network_id = insert_test_network(&ctx, &ssid).await?;
+        sqlx::query(
+            "INSERT INTO device_configured_network (device_id, network_id, profile_name)
+             VALUES ($1, $2, $3)",
+        )
+        .bind(device_id)
+        .bind(network_id)
+        .bind(&ssid)
+        .execute(&ctx.db)
+        .await?;
+
+        run_gc_sweep_once(&ctx).await?;
+
+        network_exists(&ctx, network_id).await
+    }
+    .await;
+
+    sqlx::query("DELETE FROM device_configured_network WHERE network_id IN (SELECT id FROM network WHERE ssid = $1)")
+        .bind(&ssid)
+        .execute(&ctx.db)
+        .await
+        .context("cleaning up gc sweep configured-network row")?;
+    sqlx::query("DELETE FROM network WHERE ssid = $1")
+        .bind(&ssid)
+        .execute(&ctx.db)
+        .await
+        .context("cleaning up gc sweep internal-reference network")?;
+
+    ensure!(
+        outcome?,
+        "a network with a surviving device_configured_network row must not be collected by the sweep"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## What
Adds a background sweep that finds and deletes `network` rows nothing references anymore
(zero reference-ledger holds and zero internal foreign-key references), running on its own
interval alongside the API's two existing background sweepers.

## Approach
`api/src/network/gc.rs` reuses the exact same `collect_network`/`network_has_internal_reference`
check the reference-ledger endpoints already use for release/reconcile, so this can never drift
into a different opinion of what counts as referenced. Each sweep tick selects candidates, takes
each one's advisory lock, and re-verifies before deleting - matching the pattern already used by
`files::spawn_sweeper` and `device::spawn_downtime_sweeper`.

The interval defaults to every 2 days via `NETWORK_GC_INTERVAL_SECONDS`, matching how often App
API's reconcile job pushes reference updates - sweeping more often than that would just find
nothing new.

Every network created before the ledger existed has zero references by construction, so this can
only run safely once App API has deployed its client and pushed at least one full reconcile in
production.

## Testing
- [x] `cargo build`, `cargo clippy --workspace --all-features --tests -- -Dwarnings`,
      `cargo fmt --check` all clean.
- [x] `make test.e2e` (full suite, 17/17 passing), including two new tests covering the sweep:
      one confirming an unreferenced network is collected while a referenced sibling survives,
      one confirming a lingering internal foreign key blocks collection.
- [x] Live smoke test against a restored production data snapshot (isolated local copy, not
      production itself): a read-only dry run found 173 of 337 real networks with zero
      references, and letting the sweep actually run collected exactly 173, three times in a
      row with consistent results.

## Checklist
- [x] No unintended side effects: the sweep only ever deletes rows that already pass the same
      zero-reference check the release/reconcile endpoints use to delete on their own path;
      nothing else changes.
- [x] Breaking change? No - `network` rows deleted here were already unreferenced; nothing
      currently relies on rows in that state sticking around.