### PR TITLE
Fix reachability panel showing false uptime for time before a device existed

### DIFF
--- a/api/.sqlx/query-efdea9607a339ceb5ced0e5c1625b7e6adcd94a7e3a7bcac3c9c089cef065c11.json
+++ b/api/.sqlx/query-efdea9607a339ceb5ced0e5c1625b7e6adcd94a7e3a7bcac3c9c089cef065c11.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT d.id,\n               CASE WHEN d.last_ping IS NULL OR d.last_ping < m.installed_on THEN NULL\n                    ELSE GREATEST(d.created_on, m.installed_on)\n               END AS observed_from\n        FROM device d\n        CROSS JOIN (\n            SELECT installed_on FROM _sqlx_migrations WHERE version = $2\n        ) m\n        WHERE\n            CASE\n                WHEN $1 ~ '^[0-9]+$' AND length($1) <= 10 THEN\n                    d.id = $1::int4\n                ELSE\n                    d.serial_number = $1\n            END\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "observed_from",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "efdea9607a339ceb5ced0e5c1625b7e6adcd94a7e3a7bcac3c9c089cef065c11"
+}

--- a/api/src/device/mod.rs
+++ b/api/src/device/mod.rs
@@ -175,6 +175,11 @@ pub struct DeviceUptime {
     pub services: Vec<String>,
     /// Outages overlapping the window, clipped to it by the caller when drawing.
     pub outages: Vec<ServiceOutage>,
+    /// When reachability history begins for this device: the later of its
+    /// registration and the moment the API started recording outages. Null when
+    /// the device has never checked in, in which case nothing in the window is
+    /// known. Time before this is unobserved, not uptime.
+    pub observed_from: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -588,7 +593,7 @@ const DOWNTIME_MASS_STALE_MIN_FLEET: i64 = 10;
 /// outage for it would be fabrication. This migration's own `installed_on` is
 /// exactly that moment, which beats a config knob that can be set wrong and a
 /// startup timestamp that would drift on every restart.
-const DOWNTIME_EPOCH_MIGRATION_VERSION: i64 = 20260727000000;
+pub(crate) const DOWNTIME_EPOCH_MIGRATION_VERSION: i64 = 20260727000000;
 
 /// Device reachability is stored as an outage of smithd itself, which is a real
 /// systemd unit (`smithd/debian/smithd.service`), so one table and one set of

--- a/api/src/device/route.rs
+++ b/api/src/device/route.rs
@@ -605,18 +605,26 @@ pub async fn get_uptime_for_device(
     // it just gets served at the longest span we're willing to scan.
     let from = from.max(to - Duration::days(UPTIME_MAX_WINDOW_DAYS));
 
-    let device = sqlx::query_scalar!(
+    let device = sqlx::query!(
         r#"
-        SELECT id FROM device
+        SELECT d.id,
+               CASE WHEN d.last_ping IS NULL OR d.last_ping < m.installed_on THEN NULL
+                    ELSE GREATEST(d.created_on, m.installed_on)
+               END AS observed_from
+        FROM device d
+        CROSS JOIN (
+            SELECT installed_on FROM _sqlx_migrations WHERE version = $2
+        ) m
         WHERE
             CASE
                 WHEN $1 ~ '^[0-9]+$' AND length($1) <= 10 THEN
-                    id = $1::int4
+                    d.id = $1::int4
                 ELSE
-                    serial_number = $1
+                    d.serial_number = $1
             END
         "#,
-        device_id
+        device_id,
+        crate::device::DOWNTIME_EPOCH_MIGRATION_VERSION,
     )
     .fetch_optional(&state.pg_pool)
     .await
@@ -643,7 +651,7 @@ pub async fn get_uptime_for_device(
         ) t
         ORDER BY 1
         "#,
-        device,
+        device.id,
         SMITHD_SERVICE_NAME,
     )
     .fetch_all(&state.pg_pool)
@@ -665,7 +673,7 @@ pub async fn get_uptime_for_device(
           AND COALESCE(ended_at, NOW()) > $2
         ORDER BY service_name, started_at
         "#,
-        device,
+        device.id,
         from,
         to,
     )
@@ -681,6 +689,7 @@ pub async fn get_uptime_for_device(
         to,
         services,
         outages,
+        observed_from: device.observed_from,
     }))
 }
 

--- a/dashboard/app/(private)/devices/[serial]/uptime.tsx
+++ b/dashboard/app/(private)/devices/[serial]/uptime.tsx
@@ -23,6 +23,10 @@ interface DeviceUptime {
 	to: string;
 	services: string[];
 	outages: ServiceOutage[];
+	/** Start of reachability history: the later of registration and the moment
+	 * the API started recording outages. Null when the device has never checked
+	 * in — nothing in the window is known. */
+	observed_from: string | null;
 }
 
 /**
@@ -81,11 +85,21 @@ export const formatDuration = (ms: number) => {
  * Turns the raw outage rows into drawable spans plus the headline numbers.
  * Everything is clipped to `[from, to]` first, so an outage that predates the
  * window can't drag the percentage below what the bars actually show.
+ *
+ * Time before `observed_from` isn't "up" — it's time we weren't watching, so
+ * it's excluded from both the downtime total and the ratio's denominator.
+ * `ratio` is null when nothing in the window was observed at all (a device
+ * that has never checked in), which callers must treat as "no data", not 100%.
  */
 const summarize = (data: DeviceUptime, service: string) => {
 	const from = new Date(data.from);
 	const to = new Date(data.to);
-	const windowMs = to.getTime() - from.getTime();
+	const coverageFrom = data.observed_from
+		? new Date(Math.max(new Date(data.observed_from).getTime(), from.getTime()))
+		: null;
+	const observedMs = coverageFrom
+		? Math.max(0, to.getTime() - coverageFrom.getTime())
+		: 0;
 
 	let downMs = 0;
 	let since: Date | null = null;
@@ -97,11 +111,13 @@ const summarize = (data: DeviceUptime, service: string) => {
 			// `ended_at` null rather than pinning it to a server clock.
 			const start = new Date(o.started_at);
 			const end = o.ended_at ? new Date(o.ended_at) : to;
-			downMs += Math.max(
-				0,
-				Math.min(end.getTime(), to.getTime()) -
-					Math.max(start.getTime(), from.getTime()),
-			);
+			if (coverageFrom) {
+				downMs += Math.max(
+					0,
+					Math.min(end.getTime(), to.getTime()) -
+						Math.max(start.getTime(), coverageFrom.getTime()),
+				);
+			}
 			if (!o.ended_at) since = start;
 			return { start, end, tone: "down" };
 		});
@@ -109,9 +125,11 @@ const summarize = (data: DeviceUptime, service: string) => {
 	return {
 		from,
 		to,
+		coverageFrom,
 		spans,
 		downMs,
-		ratio: windowMs > 0 ? 1 - downMs / windowMs : 1,
+		observedMs,
+		ratio: observedMs > 0 ? 1 - downMs / observedMs : null,
 		count: spans.length,
 		since: since as Date | null,
 	};
@@ -134,7 +152,9 @@ export const useReachabilityProblem = (serial: string) => {
 	const problem = useMemo(() => {
 		if (!data) return null;
 		const summary = summarize(data, SMITHD_SERVICE_NAME);
-		return summary.ratio < DEGRADED_RATIO ? summary : null;
+		return summary.ratio !== null && summary.ratio < DEGRADED_RATIO
+			? summary
+			: null;
 	}, [data]);
 
 	// Callers need the pending state: "all clear" is a claim, and it shouldn't be
@@ -203,18 +223,31 @@ const clock = (d: Date, hours: number) =>
 		: d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 
 /** Two-line hover card: which slice of time, and what happened in it. */
-const bucketTooltip = (hours: number) => (bucket: UptimeBucket) => (
-	<>
-		<div className="font-medium tabular-nums">
-			{clock(bucket.start, hours)} – {clock(bucket.end, hours)}
-		</div>
-		<div className={bucket.downMs > 0 ? "text-red-300" : "text-emerald-300"}>
-			{bucket.downMs > 0
-				? `Unreachable ${formatDuration(bucket.downMs)} of this slice`
-				: "Reachable throughout"}
-		</div>
-	</>
-);
+const bucketTooltip = (hours: number) => (bucket: UptimeBucket) => {
+	const fullyUnobserved =
+		bucket.unknownMs >= bucket.end.getTime() - bucket.start.getTime();
+
+	return (
+		<>
+			<div className="font-medium tabular-nums">
+				{clock(bucket.start, hours)} – {clock(bucket.end, hours)}
+			</div>
+			{fullyUnobserved ? (
+				<div className="text-gray-400">
+					Not monitored — before this device was registered
+				</div>
+			) : (
+				<div
+					className={bucket.downMs > 0 ? "text-red-300" : "text-emerald-300"}
+				>
+					{bucket.downMs > 0
+						? `Unreachable ${formatDuration(bucket.downMs)} of this slice`
+						: "Reachable throughout"}
+				</div>
+			)}
+		</>
+	);
+};
 
 /** The worst single stretch of silence, clipped to the window. */
 const longestGap = (summary: ReachabilitySummary) =>
@@ -248,7 +281,9 @@ export const ReachabilityAlert = ({
 		>
 			<div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
 				<span className="tabular-nums">
-					{(summary.ratio * 100).toFixed(1)}% reachable
+					{/* ratio is never null when ReachabilityAlert is reached via
+					    useReachabilityProblem */}
+					{((summary.ratio ?? 1) * 100).toFixed(1)}% reachable
 				</span>
 				{worst && (
 					<span className="text-gray-500">
@@ -263,6 +298,7 @@ export const ReachabilityAlert = ({
 					from={summary.from}
 					to={summary.to}
 					spans={summary.spans}
+					coverageFrom={summary.coverageFrom ?? summary.to}
 					height="1.5rem"
 					renderTooltip={bucketTooltip(ALERT_HOURS)}
 				/>
@@ -324,12 +360,15 @@ export const ReachabilityCell = ({
 						from={summary.from}
 						to={summary.to}
 						spans={summary.spans}
+						coverageFrom={summary.coverageFrom ?? summary.to}
 						buckets={listBuckets}
 						height="1rem"
 						renderTooltip={bucketTooltip(hours)}
 					/>
 					<div className="mt-1 text-[10px] tabular-nums text-gray-400">
-						{(summary.ratio * 100).toFixed(1)}%
+						{summary.ratio !== null
+							? `${(summary.ratio * 100).toFixed(1)}%`
+							: "—"}
 					</div>
 				</>
 			) : isError ? (
@@ -361,8 +400,10 @@ export const DeviceReachability = ({ serial }: { serial: string }) => {
 	// Only used to colour the panel: an open outage means the device is silent
 	// right now, which the whole card should signal at a glance.
 	const down = Boolean(summary?.since);
-	const stats =
-		summary && summary.count > 0
+	const noHistory = summary?.ratio === null;
+	const stats = noHistory
+		? "no reachability history yet"
+		: summary && summary.count > 0
 			? `${summary.count} interruption${summary.count === 1 ? "" : "s"} · ${formatDuration(summary.downMs)} total`
 			: "no interruptions";
 
@@ -384,11 +425,17 @@ export const DeviceReachability = ({ serial }: { serial: string }) => {
 				<div className="flex items-end gap-4">
 					<div className="shrink-0">
 						<div className="font-mono text-2xl font-semibold leading-none tabular-nums text-gray-900">
-							{(summary.ratio * 100).toFixed(2)}
-							<span className="text-base text-gray-400">%</span>
+							{summary.ratio === null ? (
+								"—"
+							) : (
+								<>
+									{(summary.ratio * 100).toFixed(2)}
+									<span className="text-base text-gray-400">%</span>
+								</>
+							)}
 						</div>
 						<div className="mt-1.5 text-[11px] uppercase tracking-wide text-gray-400">
-							reachable · last {range}
+							{noHistory ? "not monitored yet" : `reachable · last ${range}`}
 						</div>
 					</div>
 
@@ -397,6 +444,7 @@ export const DeviceReachability = ({ serial }: { serial: string }) => {
 							from={summary.from}
 							to={summary.to}
 							spans={summary.spans}
+							coverageFrom={summary.coverageFrom ?? summary.to}
 							renderTooltip={bucketTooltip(hours)}
 						/>
 						<div className="mt-1.5 flex items-center justify-between gap-3 text-[11px] tabular-nums text-gray-400">

--- a/packages/ui/src/state-timeline.tsx
+++ b/packages/ui/src/state-timeline.tsx
@@ -35,7 +35,9 @@ export interface UptimeBucket {
 	end: Date;
 	/** Downtime inside this bucket, in ms. */
 	downMs: number;
-	/** Fraction of the bucket spent up, 0..1. */
+	/** Unobserved time inside this bucket (before `coverageFrom`), in ms. */
+	unknownMs: number;
+	/** Fraction of the *observed* part of the bucket spent up, 0..1. */
 	ratio: number;
 }
 
@@ -52,6 +54,7 @@ export function UptimeBars({
 	from,
 	to,
 	spans,
+	coverageFrom,
 	buckets = 48,
 	height = "1.75rem",
 	renderTooltip,
@@ -60,6 +63,9 @@ export function UptimeBars({
 	to: Date;
 	/** Down intervals in absolute time; clipped to the window. */
 	spans: TimelineSpan[];
+	/** Start of observed time. Anything before this, within the window, is drawn
+	 * as unknown rather than up — omit when the whole window is observed. */
+	coverageFrom?: Date;
 	buckets?: number;
 	height?: string;
 	/** Hover card contents for a bucket. No tooltip is shown when omitted. */
@@ -72,21 +78,26 @@ export function UptimeBars({
 
 	if (!(total > 0)) return null;
 
+	const coverageMs = coverageFrom?.getTime();
 	const width = total / buckets;
 	const items = Array.from({ length: buckets }, (_, i): UptimeBucket => {
 		const a = startMs + i * width;
 		const b = a + width;
+		const unknownMs =
+			coverageMs !== undefined ? Math.max(0, Math.min(b, coverageMs) - a) : 0;
 		let downMs = 0;
 		for (const s of spans) {
 			const lo = Math.max(s.start.getTime(), a);
 			const hi = Math.min(s.end.getTime(), b);
 			if (hi > lo) downMs += hi - lo;
 		}
+		const observedWidth = Math.max(1, width - unknownMs);
 		return {
 			start: new Date(a),
 			end: new Date(b),
 			downMs,
-			ratio: 1 - downMs / width,
+			unknownMs,
+			ratio: 1 - downMs / observedWidth,
 		};
 	});
 
@@ -123,11 +134,19 @@ export function UptimeBars({
 							hovered === i ? "opacity-60" : ""
 						}`}
 					>
+						{bucket.unknownMs > 0 && (
+							<div
+								className="absolute inset-y-0 left-0 bg-gray-300"
+								style={{ width: `${(bucket.unknownMs / width) * 100}%` }}
+							/>
+						)}
 						{bucket.downMs > 0 && (
 							<div
 								className="absolute inset-x-0 bottom-0 bg-red-500"
-								// Floor so a blip too small to round to a pixel is still seen.
-								style={{ height: `max(3px, ${(1 - bucket.ratio) * 100}%)` }}
+								// Floored so a blip too small to round to a pixel is still seen.
+								style={{
+									height: `max(3px, ${(bucket.downMs / width) * 100}%)`,
+								}}
 							/>
 						)}
 					</div>


### PR DESCRIPTION
The device reachability panel showed "reachable" for time ranges before a device was even registered, so a newly added device could look like it had a week of perfect uptime, when it actually didn't exist yet. 

The panel now shows unmonitored time as unknown instead of green.

<img width="1598" height="324" alt="billede" src="https://github.com/user-attachments/assets/249a50df-da03-44ab-9d5b-579c2decca50" />
