### PR TITLE
fix: Print update notice to stderr

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -165,7 +165,7 @@ fn maybe_show_update_notice() {
     };
     let current = self_update::cargo_crate_version!();
     if latest != current {
-        println!(
+        eprintln!(
             "A new version {} is available! Run 'sm update' to update.",
             latest
         );


### PR DESCRIPTION
It broke my command when using `sm get d --json | jq ...`