### PR TITLE
feat: bundle id, recipe picker, and label filter keyboard nav

### DIFF
--- a/dashboard/app/(private)/commands/page.tsx
+++ b/dashboard/app/(private)/commands/page.tsx
@@ -19,6 +19,7 @@ import { useClientMutator } from "@/app/api-client-mutator";
 import { RelativeTime } from "@/app/components/RelativeTime";
 import {
 	CodeBlock,
+	CopyableText,
 	getCommandStatus,
 	getTxLabel,
 	renderRxDetail,
@@ -278,6 +279,12 @@ const BundleDetail = ({ bundle }: { bundle: BundleWithCommands }) => {
 								>
 									Triggered by: {bundle.user_email ?? "System"}
 								</p>
+							</div>
+							<div className="flex items-center gap-1.5 mt-1">
+								<span className="text-xs leading-none text-gray-400 shrink-0">
+									Bundle ID:
+								</span>
+								<CopyableText text={bundle.uuid} />
 							</div>
 						</div>
 						<div className="flex-1 overflow-y-auto overflow-x-hidden">

--- a/dashboard/app/(private)/commands/shared.tsx
+++ b/dashboard/app/(private)/commands/shared.tsx
@@ -682,9 +682,15 @@ const CopyButton = ({ text }: { text: string }) => {
 	const [copied, setCopied] = useState(false);
 
 	const handleCopy = () => {
-		navigator.clipboard.writeText(text);
-		setCopied(true);
-		setTimeout(() => setCopied(false), 2000);
+		navigator.clipboard
+			.writeText(text)
+			.then(() => {
+				setCopied(true);
+				setTimeout(() => setCopied(false), 2000);
+			})
+			.catch((err) => {
+				console.error("Failed to copy to clipboard:", err);
+			});
 	};
 
 	return (

--- a/dashboard/app/(private)/commands/shared.tsx
+++ b/dashboard/app/(private)/commands/shared.tsx
@@ -676,6 +676,52 @@ export const getStatusColor = (status: string) => {
 // UI primitives
 // ---------------------------------------------------------------------------
 
+// Copy-to-clipboard icon button, shared by CodeBlock and CopyableText so
+// there's one "copied" flash implementation instead of several.
+const CopyButton = ({ text }: { text: string }) => {
+	const [copied, setCopied] = useState(false);
+
+	const handleCopy = () => {
+		navigator.clipboard.writeText(text);
+		setCopied(true);
+		setTimeout(() => setCopied(false), 2000);
+	};
+
+	return (
+		<button
+			onClick={handleCopy}
+			className="text-gray-400 hover:text-gray-600 cursor-pointer p-1 rounded shrink-0 self-center"
+			title={copied ? "Copied!" : "Copy"}
+		>
+			{copied ? (
+				<Check className="w-3 h-3 text-green-500" />
+			) : (
+				<Copy className="w-3 h-3" />
+			)}
+		</button>
+	);
+};
+
+// Inline monospace value (e.g. an id) with a copy button. Truncates via CSS
+// so the full value stays in the DOM/title, not sliced in JS.
+export const CopyableText = ({
+	text,
+	className,
+}: {
+	text: string;
+	className?: string;
+}) => (
+	<div className={`flex items-center gap-1 min-w-0 ${className ?? ""}`}>
+		<span
+			className="text-xs font-mono leading-none text-gray-500 truncate min-w-0"
+			title={text}
+		>
+			{text}
+		</span>
+		<CopyButton text={text} />
+	</div>
+);
+
 export const CodeBlock = ({
 	label,
 	content,
@@ -687,50 +733,30 @@ export const CodeBlock = ({
 	labelClassName?: string;
 	/** Optional muted text shown left-aligned next to the label. */
 	meta?: ReactNode;
-}) => {
-	const [copied, setCopied] = useState(false);
-
-	const handleCopy = () => {
-		navigator.clipboard.writeText(content);
-		setCopied(true);
-		setTimeout(() => setCopied(false), 2000);
-	};
-
-	return (
-		<div>
-			<div className="flex items-center justify-between mb-1">
-				<span
-					className={`text-xs font-medium uppercase tracking-wide ${labelClassName ?? "text-gray-400"}`}
-				>
-					{label}
-					{meta && (
-						<span className="ml-2 font-normal normal-case text-gray-400">
-							{meta}
-						</span>
-					)}
-				</span>
-				<button
-					onClick={handleCopy}
-					className="text-gray-400 hover:text-gray-600 cursor-pointer p-1 rounded"
-					title={copied ? "Copied!" : "Copy"}
-				>
-					{copied ? (
-						<Check className="w-3 h-3 text-green-500" />
-					) : (
-						<Copy className="w-3 h-3" />
-					)}
-				</button>
-			</div>
-			<pre className="text-xs font-mono bg-gray-900 text-gray-100 p-3 rounded overflow-x-auto whitespace-pre-wrap break-words min-h-[2.5rem]">
-				{content.trim() === "" ? (
-					<span className="text-gray-500 italic">(no output)</span>
-				) : (
-					content
+}) => (
+	<div>
+		<div className="flex items-center justify-between mb-1">
+			<span
+				className={`text-xs font-medium uppercase tracking-wide ${labelClassName ?? "text-gray-400"}`}
+			>
+				{label}
+				{meta && (
+					<span className="ml-2 font-normal normal-case text-gray-400">
+						{meta}
+					</span>
 				)}
-			</pre>
+			</span>
+			<CopyButton text={content} />
 		</div>
-	);
-};
+		<pre className="text-xs font-mono bg-gray-900 text-gray-100 p-3 rounded overflow-x-auto whitespace-pre-wrap break-words min-h-[2.5rem]">
+			{content.trim() === "" ? (
+				<span className="text-gray-500 italic">(no output)</span>
+			) : (
+				content
+			)}
+		</pre>
+	</div>
+);
 
 export const KVTable = ({
 	rows,

--- a/dashboard/app/(private)/devices/page.tsx
+++ b/dashboard/app/(private)/devices/page.tsx
@@ -43,6 +43,7 @@ import {
 	useApproveDevice,
 	useDeleteDevice,
 	useGetDistributionRollouts,
+	useGetRecipes,
 	useGetReleases,
 	useIssueCommandsToDevices,
 	useUpdateDevicesTargetRelease,
@@ -275,6 +276,21 @@ const DevicesPage = () => {
 		setError: setBulkCommandError,
 		reset: resetBulkCommand,
 	} = useCommandForm("Ping");
+	const [bulkCommandMode, setBulkCommandMode] = useState<"custom" | "recipe">(
+		"custom",
+	);
+	const [selectedRecipeId, setSelectedRecipeId] = useState<number | null>(null);
+	const resetBulkCommandForm = () => {
+		resetBulkCommand();
+		setBulkCommandMode("custom");
+		setSelectedRecipeId(null);
+	};
+	const {
+		data: recipes = [],
+		isLoading: isLoadingRecipes,
+		isError: isRecipesError,
+	} = useGetRecipes();
+	const selectedRecipe = recipes.find((r) => r.id === selectedRecipeId) ?? null;
 
 	// Approval state
 	const [approveModalDevice, setApproveModalDevice] = useState<Device | null>(
@@ -580,7 +596,7 @@ const DevicesPage = () => {
 				onSuccess: () => {
 					setShowBulkCommandModal(false);
 					setSelectedDeviceIds(new Set());
-					resetBulkCommand();
+					resetBulkCommandForm();
 					navigate("/commands");
 				},
 				onError: (error) => {
@@ -592,10 +608,30 @@ const DevicesPage = () => {
 			},
 		});
 
+	// Recipe mode has no single command variant, so errors use the generic
+	// getCommandErrorMessage branch rather than a per-variant one (e.g. FreeForm's).
+	const isBulkCommandValid =
+		bulkCommandMode === "recipe"
+			? selectedRecipe != null && !isLoadingRecipes && !isRecipesError
+			: commandIsValid(bulkCommand);
+
 	const handleBulkCommand = () => {
-		if (!commandIsValid(bulkCommand) || isIssuingCommands) return;
+		if (!isBulkCommandValid || isIssuingCommands) return;
 
 		setBulkCommandError(null);
+
+		if (bulkCommandMode === "recipe") {
+			if (!selectedRecipe) return;
+			submittedBulkVariantRef.current = "Recipe";
+			issueCommands({
+				data: {
+					devices: Array.from(selectedDeviceIds),
+					commands: selectedRecipe.commands,
+				},
+			});
+			return;
+		}
+
 		submittedBulkVariantRef.current = bulkCommand.variant;
 		issueCommands({
 			data: {
@@ -1892,7 +1928,7 @@ const DevicesPage = () => {
 					// Escape/backdrop/X bypass the Cancel button's isIssuingCommands
 					// guard: don't reset while a dispatch is in flight, or the
 					// eventual onError lands its banner on an already-reset form.
-					if (!isIssuingCommands) resetBulkCommand();
+					if (!isIssuingCommands) resetBulkCommandForm();
 				}}
 				title="Run Command on Selected Devices"
 				footer={
@@ -1903,7 +1939,7 @@ const DevicesPage = () => {
 							disabled={isIssuingCommands}
 							onClick={() => {
 								setShowBulkCommandModal(false);
-								resetBulkCommand();
+								resetBulkCommandForm();
 							}}
 						>
 							Cancel
@@ -1912,7 +1948,7 @@ const DevicesPage = () => {
 							variant="solid"
 							tone="purple"
 							loading={isIssuingCommands}
-							disabled={!commandIsValid(bulkCommand)}
+							disabled={!isBulkCommandValid}
 							onClick={handleBulkCommand}
 						>
 							{isIssuingCommands ? "Sending..." : "Run Command"}
@@ -1943,21 +1979,75 @@ const DevicesPage = () => {
 					</div>
 				)}
 
-				{/* Command */}
-				<div>
-					<label className="block text-sm font-medium text-gray-700 mb-2">
-						Command
-					</label>
-					<CommandFields
-						command={bulkCommand}
-						options={BULK_COMMAND_OPTIONS}
-						onChange={setBulkCommand}
-						onSubmit={handleBulkCommand}
-					/>
-					<p className="mt-1 text-xs text-gray-500">
-						Runs on all selected devices
-					</p>
+				{/* Mode toggle */}
+				<div className="flex items-center gap-1 mb-4 bg-gray-100 rounded-lg p-1 w-fit">
+					{(["custom", "recipe"] as const).map((mode) => (
+						<button
+							key={mode}
+							type="button"
+							onClick={() => setBulkCommandMode(mode)}
+							className={`px-3 py-1.5 text-sm font-medium rounded-md cursor-pointer transition-colors ${
+								bulkCommandMode === mode
+									? "bg-white text-gray-900 shadow-sm"
+									: "text-gray-500 hover:text-gray-700"
+							}`}
+						>
+							{mode === "custom" ? "Custom command" : "Recipe"}
+						</button>
+					))}
 				</div>
+
+				{bulkCommandMode === "custom" ? (
+					<div>
+						<label className="block text-sm font-medium text-gray-700 mb-2">
+							Command
+						</label>
+						<CommandFields
+							command={bulkCommand}
+							options={BULK_COMMAND_OPTIONS}
+							onChange={setBulkCommand}
+							onSubmit={handleBulkCommand}
+						/>
+						<p className="mt-1 text-xs text-gray-500">
+							Runs on all selected devices
+						</p>
+					</div>
+				) : (
+					<div>
+						<label
+							htmlFor="bulk-command-recipe"
+							className="block text-sm font-medium text-gray-700 mb-2"
+						>
+							Recipe
+						</label>
+						{isLoadingRecipes ? (
+							<p className="text-sm text-gray-500">Loading recipes…</p>
+						) : isRecipesError ? (
+							<p className="text-sm text-red-600">Failed to load recipes</p>
+						) : recipes.length === 0 ? (
+							<p className="text-sm text-gray-500">No recipes saved yet</p>
+						) : (
+							<Select
+								id="bulk-command-recipe"
+								value={selectedRecipeId != null ? String(selectedRecipeId) : ""}
+								onChange={(value) =>
+									setSelectedRecipeId(value ? Number(value) : null)
+								}
+								className="w-full"
+							>
+								<option value="">Select a recipe…</option>
+								{recipes.map((recipe) => (
+									<option key={recipe.id} value={recipe.id}>
+										{recipe.name}
+									</option>
+								))}
+							</Select>
+						)}
+						<p className="mt-1 text-xs text-gray-500">
+							Runs the recipe's commands on all selected devices
+						</p>
+					</div>
+				)}
 			</Modal>
 
 			{/* Approve & Assign Distribution Modal */}

--- a/dashboard/app/components/LabelAutocomplete.tsx
+++ b/dashboard/app/components/LabelAutocomplete.tsx
@@ -21,10 +21,24 @@ export default function LabelAutocomplete({
 		mode: "key",
 		search: "",
 	});
+	const [highlightedIndex, setHighlightedIndex] = useState<number | null>(null);
 	const inputRef = useRef<HTMLInputElement>(null);
 	const dropdownRef = useRef<HTMLDivElement>(null);
+	const rowRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
 	const { data: labels } = useGetLabels();
+
+	// A stale highlight can outlive the list it was computed against, so reset
+	// it whenever the filter text, key/value mode, or `labels` data changes.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: reset highlight whenever the list-defining inputs change
+	useEffect(() => {
+		setHighlightedIndex(null);
+	}, [state.mode, state.search, labels]);
+
+	useEffect(() => {
+		if (highlightedIndex == null) return;
+		rowRefs.current[highlightedIndex]?.scrollIntoView({ block: "nearest" });
+	}, [highlightedIndex]);
 
 	useEffect(() => {
 		const handleClickOutside = (event: MouseEvent) => {
@@ -110,8 +124,38 @@ export default function LabelAutocomplete({
 		}
 	};
 
+	const filteredKeys = getFilteredKeys();
+	const filteredValues =
+		state.mode === "value" ? getFilteredValues(state.key) : [];
+
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		const list: LabelWithValues[] | string[] =
+			state.mode === "key" ? filteredKeys : filteredValues;
+
+		if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+			if (!isOpen || list.length === 0) return;
+			e.preventDefault();
+			setHighlightedIndex((prev) => {
+				const next = prev == null ? 0 : prev + (e.key === "ArrowDown" ? 1 : -1);
+				return Math.max(0, Math.min(next, list.length - 1));
+			});
+			return;
+		}
+
 		if (e.key === "Enter") {
+			if (
+				isOpen &&
+				highlightedIndex != null &&
+				highlightedIndex < list.length
+			) {
+				if (state.mode === "key") {
+					handleKeySelect((list[highlightedIndex] as LabelWithValues).key);
+				} else {
+					handleValueSelect(list[highlightedIndex] as string);
+				}
+				return;
+			}
+
 			const value = e.currentTarget.value;
 			if (value.includes("=")) {
 				const [key, val] = value.split("=");
@@ -144,10 +188,6 @@ export default function LabelAutocomplete({
 		return state.search;
 	};
 
-	const filteredKeys = getFilteredKeys();
-	const filteredValues =
-		state.mode === "value" ? getFilteredValues(state.key) : [];
-
 	return (
 		<div className="relative">
 			<input
@@ -172,11 +212,19 @@ export default function LabelAutocomplete({
 								<div className="px-3 py-1.5 text-xs text-gray-500 bg-gray-50 border-b border-gray-100">
 									Select a label key
 								</div>
-								{filteredKeys.map((label) => (
+								{filteredKeys.map((label, i) => (
 									<button
 										key={label.key}
+										ref={(el) => {
+											rowRefs.current[i] = el;
+										}}
 										type="button"
-										className="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700 cursor-pointer"
+										className={`w-full px-3 py-2 text-left text-sm cursor-pointer ${
+											i === highlightedIndex
+												? "bg-blue-50 text-blue-700"
+												: "text-gray-700"
+										}`}
+										onMouseEnter={() => setHighlightedIndex(i)}
 										onClick={() => handleKeySelect(label.key)}
 									>
 										<span className="font-medium">{label.key}</span>
@@ -212,20 +260,26 @@ export default function LabelAutocomplete({
 								</button>
 							</div>
 							{filteredValues.length > 0 ? (
-								filteredValues.map((value) => {
+								filteredValues.map((value, i) => {
 									const isAlreadySelected = existingFilters.includes(
 										`${state.key}=${value}`,
 									);
 									return (
 										<button
 											key={value}
+											ref={(el) => {
+												rowRefs.current[i] = el;
+											}}
 											type="button"
 											disabled={isAlreadySelected}
 											className={`w-full px-3 py-2 text-left text-sm cursor-pointer ${
 												isAlreadySelected
 													? "text-gray-400 bg-gray-50"
-													: "text-gray-700 hover:bg-blue-50 hover:text-blue-700"
+													: i === highlightedIndex
+														? "bg-blue-50 text-blue-700"
+														: "text-gray-700"
 											}`}
+											onMouseEnter={() => setHighlightedIndex(i)}
 											onClick={() => handleValueSelect(value)}
 										>
 											{value}

--- a/dashboard/app/components/LabelAutocomplete.tsx
+++ b/dashboard/app/components/LabelAutocomplete.tsx
@@ -151,7 +151,12 @@ export default function LabelAutocomplete({
 				if (state.mode === "key") {
 					handleKeySelect((list[highlightedIndex] as LabelWithValues).key);
 				} else {
-					handleValueSelect(list[highlightedIndex] as string);
+					const value = list[highlightedIndex] as string;
+					// Mirror the disabled button: an already-selected value can't be
+					// activated by mouse, so Enter shouldn't activate it either.
+					if (!existingFilters.includes(`${state.key}=${value}`)) {
+						handleValueSelect(value);
+					}
 				}
 				return;
 			}


### PR DESCRIPTION
## What
Three dashboard UI changes: show the bundle id on /commands, let the bulk Run Command modal dispatch a saved recipe, and add keyboard navigation to the /devices label filter.

## Why
- The bundle uuid existed on `BundleWithCommands` but was never shown, only used internally as a React key — operators had no way to reference a specific bundle (e.g. when reporting an issue).
- The bulk Run Command modal could only build one ad-hoc command; recipes already existed as reusable command sets but could only be triggered from /recipes, which meant re-selecting devices in a second picker instead of reusing the already-selected set on /devices.
- The label filter's suggestion dropdown was mouse-only; there was no way to select a key or value without leaving the keyboard.

## Approach
Three independent, additive changes, each in-place in its existing file rather than a new abstraction (none of the three pieces of logic are reused elsewhere yet):

- **Bundle id**: extracted a shared `CopyableText` copy-button helper in `commands/shared.tsx` out of `CodeBlock`'s existing copy logic (one "copied" flash implementation instead of two), and used it in `BundleDetail`'s header on /commands, on its own line below the serial/"Triggered by" row so it doesn't fight that row's truncation.
- **Recipe picker**: added a Custom/Recipe toggle to the existing bulk Run Command modal on /devices. Recipe mode dispatches `recipe.commands` through the same `useIssueCommandsToDevices` call the /recipes page's `TriggerModal` already uses (`{ devices, commands: recipe.commands }`), so a recipe run from either place produces an identical bundle. Rejected reusing `TriggerModal` directly, since it has its own device picker and would mean re-selecting devices already selected on /devices.
- **Label filter keyboard nav**: added `highlightedIndex` state to `LabelAutocomplete`, with Up/Down clamped (no wrap) against the current key/value list, Enter activating the highlighted row (falling back to the existing free-text `key=value` parse when nothing is highlighted), and mouse hover kept in sync with the keyboard highlight. Rejected pulling in a combobox library (e.g. downshift) as overkill for this scope.

## Testing
- [x] Lint: `npm run lint` (Biome) clean across all 86 dashboard files
- [x] Typecheck: `tsc --noEmit` shows no new errors (2 pre-existing errors in an untouched file, confirmed present on `main` too)
- [x] Manual smoke test (local dev env, real device data): bundle id visible and copyable in the /commands detail header; toggled to Recipe mode on /devices, selected a real recipe, ran it against a selected device — resulting bundle on /commands shows the recipe's exact commands, correctly attributed; on /devices, arrow-keyed through label keys, Enter drilled into values, arrow-keyed a value, Enter applied the filter (`?labels=environment=development`)

## Checklist
- [x] No unintended side effects on adjacent features — `CodeBlock`'s existing copy buttons (used throughout /commands' TX/RX detail views) were manually re-verified after the `CopyableText` extraction
- [x] Breaking change? No
- [ ] Docs / changelog updated if user-facing — not applicable, no user-facing docs/changelog exist for this dashboard in this repo