### PR TITLE
fix: Add rust-analyzer to Rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.91.0"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
Prevents VS Code compatibility warnings.

In case you ever got this:

<img width="287" height="386" alt="billede" src="https://github.com/user-attachments/assets/c0ffa273-05bd-42b4-9f80-787d9612bc7f" />
