### PR TITLE
Recover closed device tunnels and retry transient setup failures

### DIFF
--- a/smithd/src/tunnel/actor.rs
+++ b/smithd/src/tunnel/actor.rs
@@ -109,7 +109,15 @@ impl Actor {
                     } else {
                         Some(secret.as_str())
                     };
-                    let client = Client::new("localhost", local, &server, 0, secret_opt).await;
+                    let mut client = Client::new("localhost", local, &server, 0, secret_opt).await;
+                    for attempt in 1..3 {
+                        if client.is_ok() {
+                            break;
+                        }
+                        tracing::warn!(attempt, "Retrying tunnel connection");
+                        time::sleep(Duration::from_secs(1)).await;
+                        client = Client::new("localhost", local, &server, 0, secret_opt).await;
+                    }
 
                     match client {
                         Ok(client) => {

--- a/smithd/src/tunnel/actor.rs
+++ b/smithd/src/tunnel/actor.rs
@@ -74,6 +74,7 @@ impl Actor {
                 remote_login,
                 remote,
             } => {
+                self.timeout_old_tunnels().await;
                 let created_at = Instant::now();
 
                 // check if there is already a ForwardConnection for this port
@@ -172,13 +173,13 @@ impl Actor {
         let timeout_duration = Duration::from_secs(60 * 30);
 
         for (port, conn) in &self.ports {
-            if now.duration_since(conn.created_at) > timeout_duration {
+            if conn.task.is_finished() || now.duration_since(conn.created_at) > timeout_duration {
                 to_remove.push(*port);
             }
         }
 
         for port in to_remove {
-            info!("Closing port {} due to timeout", port);
+            info!("Closing inactive tunnel on port {}", port);
             if let Some(conn) = self.ports.remove(&port) {
                 conn.remove().await;
             }
@@ -209,5 +210,37 @@ impl Actor {
         }
 
         info!("Tunnel task shutting down");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shutdown::ShutdownHandler;
+
+    #[tokio::test]
+    async fn closed_tunnel_is_removed_before_reuse() -> anyhow::Result<()> {
+        let shutdown = ShutdownHandler::new();
+        let magic = MagicHandle::new(shutdown.signals());
+        let (_sender, receiver) = mpsc::channel(1);
+        let mut actor = Actor::new(shutdown.signals(), receiver, magic);
+        let task = tokio::spawn(async {});
+        while !task.is_finished() {
+            tokio::task::yield_now().await;
+        }
+        actor.ports.insert(
+            22,
+            ForwardConnection {
+                created_at: Instant::now(),
+                tag: "test".into(),
+                remote_login: None,
+                remote: 12345,
+                task,
+            },
+        );
+        actor.timeout_old_tunnels().await;
+        assert!(actor.ports.is_empty());
+        shutdown.signals().token.cancel();
+        Ok(())
     }
 }

--- a/smithd/src/tunnel/tests.rs
+++ b/smithd/src/tunnel/tests.rs
@@ -1,5 +1,5 @@
 #[tokio::test]
-async fn secret_from_magic_toml() {
+async fn tunnel_retries_until_server_is_ready_and_uses_secret() {
     use crate::magic::MagicHandle;
     use crate::shutdown::ShutdownHandler;
     use bore_cli::server::Server;
@@ -44,8 +44,12 @@ secret = "{random_secret}"
         .expect("Failed to convert path to string")
         .into();
 
-    tokio::spawn(Server::new(1024..=65535, Some(&random_secret)).listen());
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    let server = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        Server::new(1024..=65535, Some(&random_secret))
+            .listen()
+            .await
+    });
 
     let listener = TcpListener::bind("localhost:0")
         .await
@@ -63,4 +67,5 @@ secret = "{random_secret}"
     let resp = tunnel.start_tunnel(Some(local_port), None, None).await;
 
     assert_ne!(resp, 0);
+    server.abort();
 }


### PR DESCRIPTION
A closed device tunnel can remain in the port map and be returned by a later tunnel request. Remove finished tunnel tasks before reusing a port, and retry transient tunnel setup failures twice with a one-second delay.
